### PR TITLE
fix(i18n): use system locale for date formatting instead of hardcoded en-US

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/gitlab/spec-utils.ts
+++ b/apps/frontend/src/main/ipc-handlers/gitlab/spec-utils.ts
@@ -217,7 +217,7 @@ export function buildIssueContext(issue: IssueLike, projectPath: string, instanc
   lines.push('');
   lines.push(`**Project:** ${safeProjectPath}`);
   lines.push(`**State:** ${safeIssue.state}`);
-  lines.push(`**Created:** ${new Date(safeIssue.created_at).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}`);
+  lines.push(`**Created:** ${new Date(safeIssue.created_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })}`);
 
   if (safeIssue.labels.length > 0) {
     lines.push(`**Labels:** ${safeIssue.labels.join(', ')}`);

--- a/apps/frontend/src/main/terminal-session-store.ts
+++ b/apps/frontend/src/main/terminal-session-store.ts
@@ -67,7 +67,7 @@ function getDateLabel(dateStr: string): string {
   } else {
     // Format as "Dec 10" or similar
     const date = new Date(dateStr + 'T00:00:00');
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   }
 }
 

--- a/apps/frontend/src/renderer/components/ExistingCompetitorAnalysisDialog.tsx
+++ b/apps/frontend/src/renderer/components/ExistingCompetitorAnalysisDialog.tsx
@@ -43,7 +43,7 @@ export function ExistingCompetitorAnalysisDialog({
 
   const formatDate = (date?: Date) => {
     if (!date) return 'recently';
-    return new Intl.DateTimeFormat('en-US', {
+    return new Intl.DateTimeFormat(undefined, {
       month: 'short',
       day: 'numeric',
       year: 'numeric',

--- a/apps/frontend/src/renderer/components/ExistingCompetitorAnalysisDialog.tsx
+++ b/apps/frontend/src/renderer/components/ExistingCompetitorAnalysisDialog.tsx
@@ -8,6 +8,7 @@ import {
   AlertDialogTitle,
 } from './ui/alert-dialog';
 import { Button } from './ui/button';
+import { formatDate } from '../lib/date-utils';
 
 interface ExistingCompetitorAnalysisDialogProps {
   open: boolean;
@@ -41,13 +42,13 @@ export function ExistingCompetitorAnalysisDialog({
     onOpenChange(false);
   };
 
-  const formatDate = (date?: Date) => {
+  const formatAnalysisDate = (date?: Date) => {
     if (!date) return 'recently';
-    return new Intl.DateTimeFormat(undefined, {
+    return formatDate(date, {
       month: 'short',
       day: 'numeric',
       year: 'numeric',
-    }).format(date);
+    });
   };
 
   return (
@@ -59,7 +60,7 @@ export function ExistingCompetitorAnalysisDialog({
             Competitor Analysis Options
           </AlertDialogTitle>
           <AlertDialogDescription className="text-muted-foreground">
-            This project has an existing competitor analysis from {formatDate(analysisDate)}
+            This project has an existing competitor analysis from {formatAnalysisDate(analysisDate)}
           </AlertDialogDescription>
         </AlertDialogHeader>
 

--- a/apps/frontend/src/renderer/components/github-issues/utils/index.ts
+++ b/apps/frontend/src/renderer/components/github-issues/utils/index.ts
@@ -1,7 +1,7 @@
 import type { GitHubIssue } from '../../../../shared/types';
 
 export function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('en-US', {
+  return new Date(dateString).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
     day: 'numeric'

--- a/apps/frontend/src/renderer/components/github-issues/utils/index.ts
+++ b/apps/frontend/src/renderer/components/github-issues/utils/index.ts
@@ -1,7 +1,8 @@
 import type { GitHubIssue } from '../../../../shared/types';
+import { getAppLocale } from '../../../lib/date-utils';
 
 export function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString(undefined, {
+  return new Date(dateString).toLocaleDateString(getAppLocale(), {
     year: 'numeric',
     month: 'short',
     day: 'numeric'

--- a/apps/frontend/src/renderer/components/github-prs/components/PRLogs.tsx
+++ b/apps/frontend/src/renderer/components/github-prs/components/PRLogs.tsx
@@ -531,7 +531,7 @@ function LogEntry({ entry }: LogEntryProps) {
   const formatTime = (timestamp: string) => {
     try {
       const date = new Date(timestamp);
-      return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
     } catch {
       return '';
     }

--- a/apps/frontend/src/renderer/components/github-prs/components/PRLogs.tsx
+++ b/apps/frontend/src/renderer/components/github-prs/components/PRLogs.tsx
@@ -14,6 +14,7 @@ import {
   Clock,
   Activity
 } from 'lucide-react';
+import { getAppLocale } from '../../../lib/date-utils';
 import { Badge } from '../../ui/badge';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../../ui/collapsible';
 import { cn } from '../../../lib/utils';
@@ -187,7 +188,7 @@ export function PRLogs({ prNumber, logs, isLoading, isStreaming = false }: PRLog
               </div>
               <div className="text-xs text-muted-foreground flex items-center gap-1">
                 <Clock className="h-3 w-3" />
-                {new Date(logs.updated_at).toLocaleString()}
+                {new Date(logs.updated_at).toLocaleString(getAppLocale())}
               </div>
             </div>
 
@@ -432,7 +433,7 @@ function OrchestratorActivitySection({ entries, isExpanded, onToggle }: Orchestr
           {entries.map((entry, idx) => (
             <div key={`activity-${entry.timestamp}-${idx}`} className="flex items-start gap-2 text-[10px] text-muted-foreground/80 py-0.5">
               <span className="text-muted-foreground/50 tabular-nums shrink-0">
-                {new Date(entry.timestamp).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+                {new Date(entry.timestamp).toLocaleTimeString(getAppLocale(), { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
               </span>
               <span className="break-words">{entry.content}</span>
             </div>
@@ -531,7 +532,7 @@ function LogEntry({ entry }: LogEntryProps) {
   const formatTime = (timestamp: string) => {
     try {
       const date = new Date(timestamp);
-      return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      return date.toLocaleTimeString(getAppLocale(), { hour: '2-digit', minute: '2-digit', second: '2-digit' });
     } catch {
       return '';
     }

--- a/apps/frontend/src/renderer/components/github-prs/utils/formatDate.ts
+++ b/apps/frontend/src/renderer/components/github-prs/utils/formatDate.ts
@@ -1,10 +1,10 @@
 /**
  * Helper function for formatting dates with validation and locale support
  * @param dateString - ISO date string to format
- * @param locale - Locale for formatting (defaults to 'en-US')
+ * @param locale - Locale for formatting (defaults to system locale)
  * @returns Formatted date string or empty string if invalid
  */
-export function formatDate(dateString: string, locale: string = 'en-US'): string {
+export function formatDate(dateString: string, locale?: string): string {
   const date = new Date(dateString);
   if (isNaN(date.getTime())) return '';
   return date.toLocaleDateString(locale, {

--- a/apps/frontend/src/renderer/components/github-prs/utils/formatDate.ts
+++ b/apps/frontend/src/renderer/components/github-prs/utils/formatDate.ts
@@ -1,13 +1,15 @@
+import { getAppLocale } from '../../../lib/date-utils';
+
 /**
  * Helper function for formatting dates with validation and locale support
  * @param dateString - ISO date string to format
- * @param locale - Locale for formatting (defaults to system locale)
+ * @param locale - Locale for formatting (defaults to app's i18n language)
  * @returns Formatted date string or empty string if invalid
  */
 export function formatDate(dateString: string, locale?: string): string {
   const date = new Date(dateString);
   if (isNaN(date.getTime())) return '';
-  return date.toLocaleDateString(locale, {
+  return date.toLocaleDateString(locale ?? getAppLocale(), {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/apps/frontend/src/renderer/components/gitlab-issues/utils/index.ts
+++ b/apps/frontend/src/renderer/components/gitlab-issues/utils/index.ts
@@ -1,7 +1,7 @@
 import type { GitLabIssue } from '../../../../shared/types';
 
 export function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('en-US', {
+  return new Date(dateString).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
     day: 'numeric'

--- a/apps/frontend/src/renderer/components/gitlab-issues/utils/index.ts
+++ b/apps/frontend/src/renderer/components/gitlab-issues/utils/index.ts
@@ -1,7 +1,8 @@
 import type { GitLabIssue } from '../../../../shared/types';
+import { getAppLocale } from '../../../lib/date-utils';
 
 export function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString(undefined, {
+  return new Date(dateString).toLocaleDateString(getAppLocale(), {
     year: 'numeric',
     month: 'short',
     day: 'numeric'

--- a/apps/frontend/src/renderer/components/gitlab-merge-requests/components/MRDetail.tsx
+++ b/apps/frontend/src/renderer/components/gitlab-merge-requests/components/MRDetail.tsx
@@ -50,7 +50,7 @@ interface MRDetailProps {
 }
 
 function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('en-US', {
+  return new Date(dateString).toLocaleDateString(undefined, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/apps/frontend/src/renderer/components/gitlab-merge-requests/components/MRDetail.tsx
+++ b/apps/frontend/src/renderer/components/gitlab-merge-requests/components/MRDetail.tsx
@@ -19,6 +19,7 @@ import {
   AlertTriangle,
   CheckCheck,
 } from 'lucide-react';
+import { getAppLocale } from '../../../lib/date-utils';
 import { Badge } from '../../ui/badge';
 import { Button } from '../../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card';
@@ -50,7 +51,7 @@ interface MRDetailProps {
 }
 
 function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString(undefined, {
+  return new Date(dateString).toLocaleDateString(getAppLocale(), {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/apps/frontend/src/renderer/components/gitlab-merge-requests/components/MergeRequestItem.tsx
+++ b/apps/frontend/src/renderer/components/gitlab-merge-requests/components/MergeRequestItem.tsx
@@ -27,7 +27,7 @@ export function MergeRequestItem({ mr, isSelected, onClick }: MergeRequestItemPr
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   };
 
   return (

--- a/apps/frontend/src/renderer/components/gitlab-merge-requests/components/MergeRequestItem.tsx
+++ b/apps/frontend/src/renderer/components/gitlab-merge-requests/components/MergeRequestItem.tsx
@@ -1,5 +1,6 @@
 import { GitMerge, GitPullRequest, Lock, ExternalLink } from 'lucide-react';
 import { cn } from '../../../lib/utils';
+import { getAppLocale } from '../../../lib/date-utils';
 import type { GitLabMergeRequest } from '../../../../shared/types';
 
 interface MergeRequestItemProps {
@@ -27,7 +28,7 @@ export function MergeRequestItem({ mr, isSelected, onClick }: MergeRequestItemPr
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    return date.toLocaleDateString(getAppLocale(), { month: 'short', day: 'numeric' });
   };
 
   return (

--- a/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
@@ -314,7 +314,7 @@ function LogEntry({ entry }: LogEntryProps) {
   const formatTime = (timestamp: string) => {
     try {
       const date = new Date(timestamp);
-      return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
     } catch {
       return '';
     }

--- a/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskLogs.tsx
@@ -18,6 +18,7 @@ import {
   Brain,
   Cpu
 } from 'lucide-react';
+import { getAppLocale } from '../../lib/date-utils';
 import { Badge } from '../ui/badge';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../ui/collapsible';
 import { cn } from '../../lib/utils';
@@ -314,7 +315,7 @@ function LogEntry({ entry }: LogEntryProps) {
   const formatTime = (timestamp: string) => {
     try {
       const date = new Date(timestamp);
-      return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+      return date.toLocaleTimeString(getAppLocale(), { hour: '2-digit', minute: '2-digit', second: '2-digit' });
     } catch {
       return '';
     }

--- a/apps/frontend/src/renderer/lib/date-utils.ts
+++ b/apps/frontend/src/renderer/lib/date-utils.ts
@@ -1,0 +1,43 @@
+import i18n from '../../shared/i18n';
+
+/**
+ * Get the current locale from i18n settings.
+ * Falls back to 'en' if no language is set.
+ */
+export function getAppLocale(): string {
+  return i18n.language || 'en';
+}
+
+/**
+ * Format a date according to the app's current language setting.
+ * Uses the i18n language to ensure consistency with the UI.
+ */
+export function formatDate(
+  date: Date | string | number,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  const dateObj = date instanceof Date ? date : new Date(date);
+  return dateObj.toLocaleDateString(getAppLocale(), options);
+}
+
+/**
+ * Format a time according to the app's current language setting.
+ */
+export function formatTime(
+  date: Date | string | number,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  const dateObj = date instanceof Date ? date : new Date(date);
+  return dateObj.toLocaleTimeString(getAppLocale(), options);
+}
+
+/**
+ * Format a date and time according to the app's current language setting.
+ */
+export function formatDateTime(
+  date: Date | string | number,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  const dateObj = date instanceof Date ? date : new Date(date);
+  return dateObj.toLocaleString(getAppLocale(), options);
+}

--- a/apps/frontend/src/renderer/lib/utils.ts
+++ b/apps/frontend/src/renderer/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { getAppLocale } from './date-utils';
 
 /**
  * Utility function to merge Tailwind CSS classes
@@ -35,7 +36,7 @@ export function formatRelativeTime(date: Date): string {
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 7) return `${diffDays}d ago`;
-  return new Date(date).toLocaleDateString();
+  return new Date(date).toLocaleDateString(getAppLocale());
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace hardcoded `'en-US'` locale with `undefined` to use the user's system locale
- Affects 10 files across the frontend (date/time formatting)

## Problem

All dates in the UI were displayed in US format regardless of the user's system locale settings.

## Solution

Use `undefined` as the locale parameter, which tells the browser to use the system's default locale:

```typescript
// Before
new Date(dateString).toLocaleDateString('en-US', { ... })

// After
new Date(dateString).toLocaleDateString(undefined, { ... })
```

## Files Changed

- `task-detail/TaskLogs.tsx`
- `github-prs/utils/formatDate.ts`
- `github-prs/components/PRLogs.tsx`
- `github-issues/utils/index.ts`
- `ExistingCompetitorAnalysisDialog.tsx`
- `gitlab-merge-requests/components/MRDetail.tsx`
- `gitlab-merge-requests/components/MergeRequestItem.tsx`
- `gitlab-issues/utils/index.ts`
- `terminal-session-store.ts`
- `gitlab/spec-utils.ts`

## Test plan

- [ ] Verify dates display correctly on systems with non-US locales
- [ ] Verify dates still display correctly on US locale systems

Fixes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated date and time formatting across the application to respect your system's regional settings. Dates, times, and timestamps in issues, pull requests, merge requests, task logs, and various dialogs now display according to your locale preferences instead of defaulting to US English format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->