### PR TITLE
fix(terminal): use Windows cmd.exe compatible shell escaping for Claude invocation

### DIFF
--- a/apps/frontend/src/main/terminal/__tests__/claude-integration-handler.test.ts
+++ b/apps/frontend/src/main/terminal/__tests__/claude-integration-handler.test.ts
@@ -474,7 +474,7 @@ describe('claude-integration-handler - Helper Functions', () => {
         "cd '/tmp/project' && ",
         "PATH='/opt/bin' ",
         "'/opt/bin/claude'",
-        { method: 'config-dir', escapedConfigDir: "'/home/user/.claude-work'" }
+        { method: 'config-dir', escapedConfigDir: "'/home/user/.claude-work'", rawConfigDir: '/home/user/.claude-work' }
       );
 
       expect(result).toContain('clear && ');

--- a/apps/frontend/src/main/terminal/claude-integration-handler.ts
+++ b/apps/frontend/src/main/terminal/claude-integration-handler.ts
@@ -13,7 +13,7 @@ import { getClaudeProfileManager, initializeClaudeProfileManager } from '../clau
 import * as OutputParser from './output-parser';
 import * as SessionHandler from './session-handler';
 import { debugLog, debugError } from '../../shared/utils/debug-logger';
-import { escapeShellArg, escapeShellArgWindows, buildCdCommand } from '../../shared/utils/shell-escape';
+import { escapeShellArg, escapeShellArgWindows, escapeForWindowsSet, buildCdCommand } from '../../shared/utils/shell-escape';
 import { getClaudeCliInvocation, getClaudeCliInvocationAsync } from '../claude-cli-utils';
 import type {
   TerminalProcess,
@@ -110,8 +110,8 @@ export function buildClaudeShellCommand(
 
       case 'config-dir':
         // On Windows, use 'set "VAR=value"' syntax to handle paths with spaces correctly
-        // The quotes go around the entire assignment, not around the value
-        return `cls && ${cwdCommand}set "CLAUDE_CONFIG_DIR=${escapeShellArgWindows(config.rawConfigDir)}" && ${fullCmd}\r`;
+        // The quotes protect special characters, so we use escapeForWindowsSet (not escapeShellArgWindows)
+        return `cls && ${cwdCommand}set "CLAUDE_CONFIG_DIR=${escapeForWindowsSet(config.rawConfigDir)}" && ${fullCmd}\r`;
 
       default:
         // On Windows, don't use PATH= prefix syntax - the PTY already has correct PATH
@@ -488,7 +488,7 @@ export function invokeClaude(
 
       // Write platform-appropriate content
       const tempFileContent = isWindows
-        ? `@echo off\r\nset "CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArgWindows(token)}"\r\n`  // Windows batch file
+        ? `@echo off\r\nset "CLAUDE_CODE_OAUTH_TOKEN=${escapeForWindowsSet(token)}"\r\n`  // Windows batch file
         : `export CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArg(token)}\n`;  // Unix shell script
 
       fs.writeFileSync(tempFile, tempFileContent, { mode: 0o600 });
@@ -671,7 +671,7 @@ export async function invokeClaudeAsync(
 
       // Write platform-appropriate content
       const tempFileContent = isWindows
-        ? `@echo off\r\nset "CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArgWindows(token)}"\r\n`  // Windows batch file
+        ? `@echo off\r\nset "CLAUDE_CODE_OAUTH_TOKEN=${escapeForWindowsSet(token)}"\r\n`  // Windows batch file
         : `export CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArg(token)}\n`;  // Unix shell script
 
       await fsPromises.writeFile(tempFile, tempFileContent, { mode: 0o600 });

--- a/apps/frontend/src/main/terminal/claude-integration-handler.ts
+++ b/apps/frontend/src/main/terminal/claude-integration-handler.ts
@@ -488,7 +488,7 @@ export function invokeClaude(
 
       // Write platform-appropriate content
       const tempFileContent = isWindows
-        ? `@echo off\r\nset CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArgWindows(token)}\r\n`  // Windows batch file
+        ? `@echo off\r\nset "CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArgWindows(token)}"\r\n`  // Windows batch file
         : `export CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArg(token)}\n`;  // Unix shell script
 
       fs.writeFileSync(tempFile, tempFileContent, { mode: 0o600 });
@@ -671,7 +671,7 @@ export async function invokeClaudeAsync(
 
       // Write platform-appropriate content
       const tempFileContent = isWindows
-        ? `@echo off\r\nset CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArgWindows(token)}\r\n`  // Windows batch file
+        ? `@echo off\r\nset "CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArgWindows(token)}"\r\n`  // Windows batch file
         : `export CLAUDE_CODE_OAUTH_TOKEN=${escapeShellArg(token)}\n`;  // Unix shell script
 
       await fsPromises.writeFile(tempFile, tempFileContent, { mode: 0o600 });

--- a/apps/frontend/src/main/terminal/claude-integration-handler.ts
+++ b/apps/frontend/src/main/terminal/claude-integration-handler.ts
@@ -105,7 +105,8 @@ export function buildClaudeShellCommand(
     switch (config.method) {
       case 'temp-file':
         // On Windows, use 'call' to execute the batch file that sets env var, then run claude
-        return `cls && ${cwdCommand}call ${config.escapedTempFile} && del ${config.escapedTempFile} && ${fullCmd}\r`;
+        // Use del /Q for quiet (no confirmation prompt) deletion
+        return `cls && ${cwdCommand}call ${config.escapedTempFile} && del /Q ${config.escapedTempFile} && ${fullCmd}\r`;
 
       case 'config-dir':
         // On Windows, use 'set "VAR=value"' syntax to handle paths with spaces correctly

--- a/apps/frontend/src/shared/utils/shell-escape.ts
+++ b/apps/frontend/src/shared/utils/shell-escape.ts
@@ -89,6 +89,25 @@ export function escapeShellArgWindows(arg: string): string {
 }
 
 /**
+ * Escape a value for use inside Windows `set "VAR=VALUE"` command.
+ *
+ * IMPORTANT: This is different from escapeShellArgWindows!
+ * Inside `set "VAR=VALUE"`, the double quotes already protect special characters
+ * like &, |, <, >, so we DON'T add caret escapes (they would become literal).
+ *
+ * Only % needs escaping (as %%) because variable expansion still occurs inside quotes.
+ * Double quotes cannot appear in the value (would break the set syntax).
+ *
+ * @param value - The value to escape
+ * @returns The escaped value safe for use in set "VAR=VALUE"
+ */
+export function escapeForWindowsSet(value: string): string {
+  return value
+    .replace(/%/g, '%%')      // Escape percent (variable expansion still works in quotes)
+    .replace(/"/g, '');       // Remove double quotes (would break set "..." syntax)
+}
+
+/**
  * Validate that a path doesn't contain obviously malicious patterns.
  * This is a defense-in-depth measure - escaping should handle all cases,
  * but this can catch obvious attack attempts early.


### PR DESCRIPTION
## Summary
- Fixed Claude button click failing immediately on Windows terminals
- The terminal uses cmd.exe which doesn't understand bash syntax (single quotes, `PATH=value command`)
- Added platform-specific escaping and command building for Windows

## Problem
On Windows, clicking the "Claude" button in the Agent Terminal caused:
- Terminal to exit immediately (exit code 0)
- Log showing: `Generating terminal name for command: laude...` (first char stripped)

**Root cause**: The code was using bash/Unix syntax for all platforms:
```bash
# Generated command (broken on Windows):
cd "D:\..." && PATH='C:\...' 'C:\Users\...\claude.exe'
```

Windows cmd.exe treats single quotes as literal characters, not string delimiters.

## Solution
Added Windows-specific handling:

1. **`escapeForPlatform()`** - Uses double quotes on Windows, single quotes on Unix
2. **`isWindows`** constant - Platform detection helper
3. **`buildClaudeShellCommand()`** - Windows branches:
   - Default: Skip `PATH=` prefix (PTY has correct PATH)
   - Temp-file: Use `call`/`del` instead of `source`/`rm`
   - Config-dir: Use `set` instead of bash inline env syntax
4. **Temp file handling** - `.bat` extension and batch syntax on Windows

**After fix:**
```cmd
cd "D:\..." && "C:\Users\...\claude.exe"
```

## Test plan
- [ ] Test on Windows: Click Claude button in Agent Terminal
- [ ] Verify Claude CLI launches successfully
- [ ] Test profile switching (temp-file method)
- [ ] Test on Mac/Linux to ensure no regression

## Changes
- `apps/frontend/src/main/terminal/claude-integration-handler.ts` (+68/-22 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cross-platform support for Claude invocation with OS-aware escaping, Windows batch vs Unix shell handling, and platform-appropriate temp-file behavior.

* **Bug Fixes**
  * Fixed shell escaping and PATH handling so commands run reliably on Windows and Unix-like shells.

* **Tests**
  * Updated tests for Windows-specific command syntax and the config-dir flow.

* **Documentation**
  * Added clarifying notes on Windows vs Unix behavior.

* **Chores**
  * Config-dir option now includes the raw config path; added a Windows-specific escaping utility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->