### PR TITLE
fix: persist GitHub integration enabled state

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/env-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/env-handlers.ts
@@ -426,12 +426,10 @@ ${existingVars['GRAPHITI_DB_PATH'] ? `GRAPHITI_DB_PATH=${existingVars['GRAPHITI_
       }
 
       // GitHub config - check GITHUB_ENABLED explicitly, fallback to GITHUB_TOKEN presence
-      if (vars['GITHUB_ENABLED']?.toLowerCase() === 'true') {
-        config.githubEnabled = true;
-      } else if (vars['GITHUB_ENABLED']?.toLowerCase() === 'false') {
-        config.githubEnabled = false;
+      const githubEnabledValue = vars['GITHUB_ENABLED']?.toLowerCase();
+      if (githubEnabledValue === 'true' || githubEnabledValue === 'false') {
+        config.githubEnabled = githubEnabledValue === 'true';
       } else if (vars['GITHUB_TOKEN']) {
-        // Legacy fallback: enabled if token exists
         config.githubEnabled = true;
       }
       if (vars['GITHUB_TOKEN']) {

--- a/apps/frontend/src/main/ipc-handlers/env-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/env-handlers.ts
@@ -118,6 +118,10 @@ export function registerEnvHandlers(
     if (config.githubAutoSync !== undefined) {
       existingVars['GITHUB_AUTO_SYNC'] = config.githubAutoSync ? 'true' : 'false';
     }
+    // Store githubEnabled explicitly so it persists independently of GITHUB_TOKEN
+    if (config.githubEnabled !== undefined) {
+      existingVars['GITHUB_ENABLED'] = config.githubEnabled ? 'true' : 'false';
+    }
     // GitLab Integration
     if (config.gitlabEnabled !== undefined) {
       existingVars[GITLAB_ENV_KEYS.ENABLED] = config.gitlabEnabled ? 'true' : 'false';
@@ -248,6 +252,8 @@ ${existingVars['LINEAR_REALTIME_SYNC'] !== undefined ? `LINEAR_REALTIME_SYNC=${e
 # =============================================================================
 # GITHUB INTEGRATION (OPTIONAL)
 # =============================================================================
+# Enable GitHub integration (default: true if GITHUB_TOKEN is set)
+${existingVars['GITHUB_ENABLED'] !== undefined ? `GITHUB_ENABLED=${existingVars['GITHUB_ENABLED']}` : '# GITHUB_ENABLED=true'}
 ${existingVars['GITHUB_TOKEN'] ? `GITHUB_TOKEN=${existingVars['GITHUB_TOKEN']}` : '# GITHUB_TOKEN='}
 ${existingVars['GITHUB_REPO'] ? `GITHUB_REPO=${existingVars['GITHUB_REPO']}` : '# GITHUB_REPO=owner/repo'}
 ${existingVars['GITHUB_AUTO_SYNC'] !== undefined ? `GITHUB_AUTO_SYNC=${existingVars['GITHUB_AUTO_SYNC']}` : '# GITHUB_AUTO_SYNC=false'}
@@ -419,9 +425,16 @@ ${existingVars['GRAPHITI_DB_PATH'] ? `GRAPHITI_DB_PATH=${existingVars['GRAPHITI_
         config.linearRealtimeSync = true;
       }
 
-      // GitHub config
-      if (vars['GITHUB_TOKEN']) {
+      // GitHub config - check GITHUB_ENABLED explicitly, fallback to GITHUB_TOKEN presence
+      if (vars['GITHUB_ENABLED']?.toLowerCase() === 'true') {
         config.githubEnabled = true;
+      } else if (vars['GITHUB_ENABLED']?.toLowerCase() === 'false') {
+        config.githubEnabled = false;
+      } else if (vars['GITHUB_TOKEN']) {
+        // Legacy fallback: enabled if token exists
+        config.githubEnabled = true;
+      }
+      if (vars['GITHUB_TOKEN']) {
         config.githubToken = vars['GITHUB_TOKEN'];
       }
       if (vars['GITHUB_REPO']) {


### PR DESCRIPTION
## Summary

Previously, the "Enable GitHub Issues" toggle in Project Settings would not persist after saving. The githubEnabled state was inferred from GITHUB_TOKEN presence rather than being explicitly stored.

## Changes

This fix adds explicit persistence for the GitHub integration enabled state:

1. Saves githubEnabled to .env file as GITHUB_ENABLED environment variable
2. Reads GITHUB_ENABLED explicitly when loading project settings
3. Maintains backward compatibility - existing configurations without GITHUB_ENABLED will fallback to inferring from GITHUB_TOKEN presence

## Files Changed

- apps/frontend/src/main/ipc-handlers/env-handlers.ts

## Testing

1. Open Project Settings for a project
2. Toggle "Enable GitHub Issues" off
3. Click Save Settings
4. Reopen Project Settings - the toggle should remain off

Bug: GitHub Integration toggle does not persist after save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub integration can be explicitly enabled or disabled via configuration, independent of the authentication token.
  * Generated environment output now includes an explicit GitHub enabled/disabled entry.

* **Improvements**
  * Persistence and detection of the GitHub-enabled setting are more consistent.
  * Configuration reading prioritizes an explicit enable/disable flag before falling back to token presence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->