### PR TITLE
fix(windows): initialize known_marketplaces.json to prevent CLI crashes

### DIFF
--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -2,7 +2,7 @@
 import { config } from 'dotenv';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { existsSync, mkdirSync } from 'fs';
+import { existsSync } from 'fs';
 import { homedir } from 'os';
 
 // ESM-compatible __dirname
@@ -28,7 +28,7 @@ for (const envPath of possibleEnvPaths) {
 
 import { app, BrowserWindow, shell, nativeImage, session, screen } from 'electron';
 import { join } from 'path';
-import { accessSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { accessSync, readFileSync, writeFileSync, rmSync, mkdirSync } from 'fs';
 import { electronApp, optimizer, is } from '@electron-toolkit/utils';
 import { setupIpcHandlers } from './ipc-setup';
 import { AgentManager } from './agent';
@@ -120,15 +120,12 @@ function fixKnownMarketplacesJson(): void {
   const pluginsDir = join(homedir(), '.claude', 'plugins');
   const marketplacesPath = join(pluginsDir, 'known_marketplaces.json');
 
-  // Ensure plugins directory exists
-  if (!existsSync(pluginsDir)) {
-    try {
-      mkdirSync(pluginsDir, { recursive: true });
-      console.log('[main] Created Claude plugins directory:', pluginsDir);
-    } catch (e) {
-      console.warn('[main] Failed to create plugins directory:', e);
-      return;
-    }
+  // Ensure plugins directory exists (mkdirSync with recursive is idempotent)
+  try {
+    mkdirSync(pluginsDir, { recursive: true });
+  } catch (e) {
+    console.warn('[main] Failed to create plugins directory:', e);
+    return;
   }
 
   // Check if file needs fixing by trying to read it directly

--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -158,6 +158,9 @@ function fixKnownMarketplacesJson(): void {
 
   if (needsFix) {
     try {
+      // Note: There's a theoretical TOCTOU race between reading (line 137) and writing here,
+      // but it's benign: if another process fixed the file in between, we just overwrite
+      // valid JSON with `{}` which is also valid JSON. The write is idempotent.
       writeFileSync(marketplacesPath, '{}', 'utf-8');
       console.log('[main] Fixed known_marketplaces.json with empty object');
     } catch (e) {

--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -43,6 +43,7 @@ import { setupErrorLogging } from './app-logger';
 import { initSentryMain } from './sentry';
 import { preWarmToolCache } from './cli-tool-manager';
 import { initializeClaudeProfileManager } from './claude-profile-manager';
+import { isWindows } from './platform';
 import type { AppSettings } from '../shared/types';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -112,7 +113,7 @@ function cleanupStaleUpdateMetadata(): void {
  * This fix runs before any Claude CLI calls to prevent crashes.
  */
 function fixKnownMarketplacesJson(): void {
-  if (process.platform !== 'win32') {
+  if (!isWindows()) {
     return;
   }
 

--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -43,7 +43,7 @@ import { setupErrorLogging } from './app-logger';
 import { initSentryMain } from './sentry';
 import { preWarmToolCache } from './cli-tool-manager';
 import { initializeClaudeProfileManager } from './claude-profile-manager';
-import { isWindows } from './platform';
+import { isWindows, isMacOS } from './platform';
 import type { AppSettings } from '../shared/types';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -176,10 +176,10 @@ function getIconPath(): string {
     : join(process.resourcesPath);
 
   let iconName: string;
-  if (process.platform === 'darwin') {
+  if (isMacOS()) {
     // Use PNG in dev mode (works better), ICNS in production
     iconName = is.dev ? 'icon-256.png' : 'icon.icns';
-  } else if (process.platform === 'win32') {
+  } else if (isWindows()) {
     iconName = 'icon.ico';
   } else {
     iconName = 'icon.png';
@@ -300,13 +300,13 @@ function createWindow(): void {
 
 // Set app name before ready (for dock tooltip on macOS in dev mode)
 app.setName('Auto Claude');
-if (process.platform === 'darwin') {
+if (isMacOS()) {
   // Force the name to appear in dock on macOS
   app.name = 'Auto Claude';
 }
 
 // Fix Windows GPU cache permission errors (0x5 Access Denied)
-if (process.platform === 'win32') {
+if (isWindows()) {
   app.commandLine.appendSwitch('disable-gpu-shader-disk-cache');
   app.commandLine.appendSwitch('disable-gpu-program-cache');
   console.log('[main] Applied Windows GPU cache fixes');
@@ -318,7 +318,7 @@ app.whenReady().then(() => {
   electronApp.setAppUserModelId('com.autoclaude.ui');
 
   // Clear cache on Windows to prevent permission errors from stale cache
-  if (process.platform === 'win32') {
+  if (isWindows()) {
     session.defaultSession.clearCache()
       .then(() => console.log('[main] Cleared cache on startup'))
       .catch((err) => console.warn('[main] Failed to clear cache:', err));
@@ -333,7 +333,7 @@ app.whenReady().then(() => {
   cleanupStaleUpdateMetadata();
 
   // Set dock icon on macOS
-  if (process.platform === 'darwin') {
+  if (isMacOS()) {
     const iconPath = getIconPath();
     try {
       const icon = nativeImage.createFromPath(iconPath);
@@ -517,7 +517,7 @@ app.whenReady().then(() => {
 
 // Quit when all windows are closed (except on macOS)
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+  if (!isMacOS()) {
     app.quit();
   }
 });


### PR DESCRIPTION
## Summary
On Windows, an empty or corrupted `known_marketplaces.json` in the Claude CLI config causes crashes. This fix runs at app startup and ensures the file contains valid JSON.

## Changes
- Creates the plugins directory if missing
- Writes `{}` to the file if it's missing, empty, or contains `[]`
- Handles malformed JSON by rewriting with `{}`

## Fixes
Closes #1095

## Test Plan
- [x] Tested on Windows 11
- [x] Start Auto-Claude with missing `~/.claude/plugins/known_marketplaces.json`
- [x] Start Auto-Claude with empty file
- [x] Start Auto-Claude with `[]` in file
- [x] Verify file contains `{}` after startup
- [x] Verify Claude CLI operations work

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows startup crash caused by a corrupted or empty CLI configuration file; the app now auto-detects and repairs invalid configuration and writes a safe default.
  * Ensures required plugin directories are created and validated during startup so the CLI works reliably without user intervention.
  * Improved cross‑platform startup handling so app/CLI behavior is more consistent on Windows and macOS.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->