### PR TITLE
feat(task): add delete and retry functionality for stuck/failed tasks

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from 
 import { projectStore } from '../../project-store';
 import { titleGenerator } from '../../title-generator';
 import { AgentManager } from '../../agent';
-import { findTaskAndProject } from './shared';
+import { findTaskAndProject, generateSpecId } from './shared';
 
 /**
  * Register task CRUD (Create, Read, Update, Delete) handlers
@@ -90,12 +90,7 @@ export function registerTaskCRUDHandlers(agentManager: AgentManager): void {
       }
 
       // Create spec ID with zero-padded number and slugified title
-      const slugifiedTitle = finalTitle
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '')
-        .substring(0, 50);
-      const specId = `${String(specNumber).padStart(3, '0')}-${slugifiedTitle}`;
+      const specId = generateSpecId(specNumber, finalTitle);
 
       // Create spec directory
       const specDir = path.join(specsDir, specId);

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1182,7 +1182,7 @@ export function registerTaskExecutionHandlers(
   // Delete and retry a stuck/failed task - cleans up worktree and spec, optionally recreates
   ipcMain.handle(
     IPC_CHANNELS.TASK_DELETE_AND_RETRY,
-    async (_, taskId: string, options?: { recreate?: boolean }): Promise<IPCResult<{ deleted: boolean; recreatedTask?: import('../../../shared/types').Task; cleanedUpWorktree?: boolean }>> => {
+    async (_, taskId: string, options?: { recreate?: boolean }): Promise<IPCResult<{ deleted: boolean; recreatedTask?: import('../../../shared/types').Task; cleanedUpWorktree?: boolean; recreationSkipped?: string }>> => {
       const { rm } = await import('fs/promises');
 
       const { task, project } = findTaskAndProject(taskId);
@@ -1270,24 +1270,39 @@ export function registerTaskExecutionHandlers(
       }
 
       // Optionally recreate the task for retry
-      if (options?.recreate && taskTitle && taskDescription) {
+      if (options?.recreate) {
+        // Check for required data to recreate - use explicit null/undefined checks
+        // to allow empty strings if they were intentionally provided
+        if (taskTitle == null || taskDescription == null) {
+          projectStore.invalidateTasksCache(project.id);
+          return {
+            success: true,
+            data: {
+              deleted: true,
+              cleanedUpWorktree,
+              recreationSkipped: 'Missing title or description'
+            }
+          };
+        }
+
         try {
           const { mkdir, writeFile } = await import('fs/promises');
           const specsDir = path.join(project.path, getSpecsDir(project.autoBuildPath));
 
           // Use spec number lock to prevent race conditions when calculating next spec number
-          // This ensures concurrent recreate operations get unique spec numbers
+          // The mkdir is inside the lock to ensure the directory is created atomically
+          // before another concurrent operation can get the same spec number
           const { newSpecId, newSpecDir } = await withSpecNumberLock(
             project.path,
-            (lock) => {
+            async (lock) => {
               const specNum = lock.getNextSpecNumber(project.autoBuildPath);
               const newSpecId = generateSpecId(specNum, taskTitle);
               const newSpecDir = path.join(specsDir, newSpecId);
+              // Create directory inside lock to prevent race condition
+              await mkdir(newSpecDir, { recursive: true });
               return { newSpecId, newSpecDir };
             }
           );
-
-          await mkdir(newSpecDir, { recursive: true });
 
           // Write basic files
           const now = new Date().toISOString();

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -7,7 +7,7 @@ import { spawnSync, execFileSync } from 'child_process';
 import { getToolPath } from '../../cli-tool-manager';
 import { AgentManager } from '../../agent';
 import { fileWatcher } from '../../file-watcher';
-import { findTaskAndProject } from './shared';
+import { findTaskAndProject, generateSpecId } from './shared';
 import { checkGitStatus } from '../../project-initializer';
 import { initializeClaudeProfileManager, type ClaudeProfileManager } from '../../claude-profile-manager';
 import {
@@ -1224,7 +1224,10 @@ export function registerTaskExecutionHandlers(
             timeout: 30000
           });
 
-          // Delete the associated branch
+          // Worktree is successfully removed at this point
+          cleanedUpWorktree = true;
+
+          // Delete the associated branch (best-effort)
           try {
             execFileSync(getToolPath('git'), ['branch', '-D', branch], {
               cwd: project.path,
@@ -1236,16 +1239,18 @@ export function registerTaskExecutionHandlers(
             console.warn(`[TASK_DELETE_AND_RETRY] Could not delete branch '${branch}'. It may not exist or be the current branch.`, error);
           }
 
-          // Prune dangling worktrees
-          execFileSync(getToolPath('git'), ['worktree', 'prune'], {
-            cwd: project.path,
-            encoding: 'utf-8',
-            timeout: 30000
-          });
-
-          cleanedUpWorktree = true;
-        } catch (e) {
-          console.error('[TASK_DELETE_AND_RETRY] Worktree cleanup error:', e);
+          // Prune dangling worktrees (best-effort)
+          try {
+            execFileSync(getToolPath('git'), ['worktree', 'prune'], {
+              cwd: project.path,
+              encoding: 'utf-8',
+              timeout: 30000
+            });
+          } catch (error) {
+            console.warn('[TASK_DELETE_AND_RETRY] Worktree prune failed:', error);
+          }
+        } catch (error) {
+          console.error('[TASK_DELETE_AND_RETRY] Worktree cleanup error:', error);
         }
       }
 
@@ -1289,11 +1294,7 @@ export function registerTaskExecutionHandlers(
           }
 
           // Create new spec directory
-          const slug = taskTitle.toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-')
-            .replace(/^-|-$/g, '')
-            .substring(0, 50);
-          const newSpecId = `${String(specNum).padStart(3, '0')}-${slug}`;
+          const newSpecId = generateSpecId(specNum, taskTitle);
           const newSpecDir = path.join(specsDir, newSpecId);
 
           await mkdir(newSpecDir, { recursive: true });

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1199,7 +1199,8 @@ export function registerTaskExecutionHandlers(
       const { title: taskTitle, description: taskDescription, metadata: taskMetadata, projectId } = task;
       let cleanedUpWorktree = false;
 
-      // Clean up git worktree if it exists
+      // Clean up git worktree if it exists (best-effort - cleanup failure shouldn't block task deletion)
+      // The cleanedUpWorktree flag in the response indicates whether cleanup succeeded
       const worktreePath = findTaskWorktree(project.path, task.specId);
       if (worktreePath) {
         try {
@@ -1258,9 +1259,6 @@ export function registerTaskExecutionHandlers(
           error: `Failed to delete task files: ${error instanceof Error ? error.message : String(error)}`
         };
       }
-
-      // Invalidate the task cache
-      projectStore.invalidateTasksCache(project.id);
 
       // Optionally recreate the task for retry
       if (options?.recreate && taskTitle && taskDescription) {
@@ -1344,10 +1342,13 @@ export function registerTaskExecutionHandlers(
         } catch (error) {
           console.error('[TASK_DELETE_AND_RETRY] Task recreation failed:', error);
           // If recreation fails, still report successful deletion
+          projectStore.invalidateTasksCache(project.id);
           return { success: true, data: { deleted: true, cleanedUpWorktree } };
         }
       }
 
+      // Invalidate cache after successful deletion (without recreation)
+      projectStore.invalidateTasksCache(project.id);
       return { success: true, data: { deleted: true, cleanedUpWorktree } };
     }
   );

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1183,7 +1183,6 @@ export function registerTaskExecutionHandlers(
     IPC_CHANNELS.TASK_DELETE_AND_RETRY,
     async (_, taskId: string, options?: { recreate?: boolean }): Promise<IPCResult<{ deleted: boolean; recreatedTask?: import('../../../shared/types').Task; cleanedUpWorktree?: boolean }>> => {
       const { rm } = await import('fs/promises');
-      const { readdirSync } = await import('fs');
 
       const { task, project } = findTaskAndProject(taskId);
       if (!task || !project) {
@@ -1249,12 +1248,10 @@ export function registerTaskExecutionHandlers(
         }
       }
 
-      // Delete the spec directory
+      // Delete the spec directory (rm with force:true handles non-existent paths)
       const specDir = task.specsPath || path.join(project.path, getSpecsDir(project.autoBuildPath), task.specId);
       try {
-        if (existsSync(specDir)) {
-          await rm(specDir, { recursive: true, force: true });
-        }
+        await rm(specDir, { recursive: true, force: true });
       } catch (error) {
         return {
           success: false,
@@ -1272,8 +1269,8 @@ export function registerTaskExecutionHandlers(
           const specsDir = path.join(project.path, getSpecsDir(project.autoBuildPath));
           let specNum = 1;
 
-          // Find next spec number
-          if (existsSync(specsDir)) {
+          // Find next spec number (readdir throws if dir doesn't exist)
+          try {
             const dirents = await readdir(specsDir, { withFileTypes: true });
             const nums = dirents
               .filter(d => d.isDirectory())
@@ -1286,6 +1283,8 @@ export function registerTaskExecutionHandlers(
             if (nums.length > 0) {
               specNum = Math.max(...nums) + 1;
             }
+          } catch {
+            // Directory doesn't exist yet, use default specNum = 1
           }
 
           // Create new spec directory

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1177,4 +1177,174 @@ export function registerTaskExecutionHandlers(
       }
     }
   );
+
+  // Delete and retry a stuck/failed task - cleans up worktree and spec, optionally recreates
+  ipcMain.handle(
+    IPC_CHANNELS.TASK_DELETE_AND_RETRY,
+    async (_, taskId: string, options?: { recreate?: boolean }): Promise<IPCResult<{ deleted: boolean; recreatedTask?: import('../../../shared/types').Task; cleanedUpWorktree?: boolean }>> => {
+      const { rm } = await import('fs/promises');
+      const { readdirSync } = await import('fs');
+
+      const { task, project } = findTaskAndProject(taskId);
+      if (!task || !project) {
+        return { success: false, error: 'Task or project not found' };
+      }
+
+      // Stop any running process for this task
+      if (agentManager.isRunning(taskId)) {
+        agentManager.killTask(taskId);
+        fileWatcher.unwatch(taskId);
+      }
+
+      // Save task info for potential recreation
+      const { title: taskTitle, description: taskDescription, metadata: taskMetadata, projectId } = task;
+      let cleanedUpWorktree = false;
+
+      // Clean up git worktree if it exists
+      const worktreePath = findTaskWorktree(project.path, task.specId);
+      if (worktreePath) {
+        try {
+          // Get the branch name before removing worktree
+          let branch = `auto-claude/${task.specId}`;
+          try {
+            branch = execFileSync(getToolPath('git'), ['rev-parse', '--abbrev-ref', 'HEAD'], {
+              cwd: worktreePath,
+              encoding: 'utf-8',
+              timeout: 30000
+            }).trim();
+          } catch {
+            // Use default branch name if rev-parse fails
+          }
+
+          // Remove the worktree forcefully
+          execFileSync(getToolPath('git'), ['worktree', 'remove', '--force', worktreePath], {
+            cwd: project.path,
+            encoding: 'utf-8',
+            timeout: 30000
+          });
+
+          // Delete the associated branch
+          try {
+            execFileSync(getToolPath('git'), ['branch', '-D', branch], {
+              cwd: project.path,
+              encoding: 'utf-8',
+              timeout: 30000
+            });
+          } catch {
+            // Branch may not exist or be the current branch
+          }
+
+          // Prune dangling worktrees
+          execFileSync(getToolPath('git'), ['worktree', 'prune'], {
+            cwd: project.path,
+            encoding: 'utf-8',
+            timeout: 30000
+          });
+
+          cleanedUpWorktree = true;
+        } catch (e) {
+          console.error('[TASK_DELETE_AND_RETRY] Worktree cleanup error:', e);
+        }
+      }
+
+      // Delete the spec directory
+      const specDir = task.specsPath || path.join(project.path, getSpecsDir(project.autoBuildPath), task.specId);
+      try {
+        if (existsSync(specDir)) {
+          await rm(specDir, { recursive: true, force: true });
+        }
+      } catch (error) {
+        return {
+          success: false,
+          error: `Failed to delete task files: ${error instanceof Error ? error.message : String(error)}`
+        };
+      }
+
+      // Invalidate the task cache
+      projectStore.invalidateTasksCache(project.id);
+
+      // Optionally recreate the task for retry
+      if (options?.recreate && taskTitle && taskDescription) {
+        try {
+          const specsDir = path.join(project.path, getSpecsDir(project.autoBuildPath));
+          let specNum = 1;
+
+          // Find next spec number
+          if (existsSync(specsDir)) {
+            const nums = readdirSync(specsDir, { withFileTypes: true })
+              .filter(d => d.isDirectory())
+              .map(d => {
+                const m = d.name.match(/^(\d+)/);
+                return m ? parseInt(m[1], 10) : 0;
+              })
+              .filter(n => n > 0);
+
+            if (nums.length > 0) {
+              specNum = Math.max(...nums) + 1;
+            }
+          }
+
+          // Create new spec directory
+          const slug = taskTitle.toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-|-$/g, '')
+            .substring(0, 50);
+          const newSpecId = `${String(specNum).padStart(3, '0')}-${slug}`;
+          const newSpecDir = path.join(specsDir, newSpecId);
+
+          mkdirSync(newSpecDir, { recursive: true });
+
+          // Write basic files
+          const now = new Date().toISOString();
+          writeFileSync(
+            path.join(newSpecDir, AUTO_BUILD_PATHS.IMPLEMENTATION_PLAN),
+            JSON.stringify({
+              feature: taskTitle,
+              description: taskDescription,
+              created_at: now,
+              updated_at: now,
+              status: 'pending',
+              phases: []
+            }, null, 2)
+          );
+
+          const newMeta = {
+            ...taskMetadata,
+            sourceType: taskMetadata?.sourceType || 'manual',
+            retriedFrom: task.specId
+          };
+          writeFileSync(path.join(newSpecDir, 'task_metadata.json'), JSON.stringify(newMeta, null, 2));
+          writeFileSync(
+            path.join(newSpecDir, AUTO_BUILD_PATHS.REQUIREMENTS),
+            JSON.stringify({
+              task_description: taskDescription,
+              workflow_type: newMeta.category || 'feature'
+            }, null, 2)
+          );
+
+          const newTask: import('../../../shared/types').Task = {
+            id: newSpecId,
+            specId: newSpecId,
+            projectId,
+            title: taskTitle,
+            description: taskDescription,
+            status: 'backlog',
+            subtasks: [],
+            logs: [],
+            metadata: newMeta,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          };
+
+          projectStore.invalidateTasksCache(project.id);
+          return { success: true, data: { deleted: true, recreatedTask: newTask, cleanedUpWorktree } };
+        } catch {
+          // If recreation fails, still report successful deletion
+          return { success: true, data: { deleted: true, cleanedUpWorktree } };
+        }
+      }
+
+      return { success: true, data: { deleted: true, cleanedUpWorktree } };
+    }
+  );
 }

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -18,6 +18,7 @@ import {
 import { findTaskWorktree } from '../../worktree-paths';
 import { projectStore } from '../../project-store';
 import { getIsolatedGitEnv } from '../../utils/git-isolation';
+import { withSpecNumberLock } from '../../utils/spec-number-lock';
 
 /**
  * Atomic file write to prevent TOCTOU race conditions.
@@ -1271,31 +1272,20 @@ export function registerTaskExecutionHandlers(
       // Optionally recreate the task for retry
       if (options?.recreate && taskTitle && taskDescription) {
         try {
-          const { readdir, mkdir, writeFile } = await import('fs/promises');
+          const { mkdir, writeFile } = await import('fs/promises');
           const specsDir = path.join(project.path, getSpecsDir(project.autoBuildPath));
-          let specNum = 1;
 
-          // Find next spec number (readdir throws if dir doesn't exist)
-          try {
-            const dirents = await readdir(specsDir, { withFileTypes: true });
-            const nums = dirents
-              .filter(d => d.isDirectory())
-              .map(d => {
-                const m = d.name.match(/^(\d+)/);
-                return m ? parseInt(m[1], 10) : 0;
-              })
-              .filter(n => n > 0);
-
-            if (nums.length > 0) {
-              specNum = Math.max(...nums) + 1;
+          // Use spec number lock to prevent race conditions when calculating next spec number
+          // This ensures concurrent recreate operations get unique spec numbers
+          const { newSpecId, newSpecDir } = await withSpecNumberLock(
+            project.path,
+            (lock) => {
+              const specNum = lock.getNextSpecNumber(project.autoBuildPath);
+              const newSpecId = generateSpecId(specNum, taskTitle);
+              const newSpecDir = path.join(specsDir, newSpecId);
+              return { newSpecId, newSpecDir };
             }
-          } catch {
-            // Directory doesn't exist yet, use default specNum = 1
-          }
-
-          // Create new spec directory
-          const newSpecId = generateSpecId(specNum, taskTitle);
-          const newSpecDir = path.join(specsDir, newSpecId);
+          );
 
           await mkdir(newSpecDir, { recursive: true });
 

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1254,6 +1254,9 @@ export function registerTaskExecutionHandlers(
       try {
         await rm(specDir, { recursive: true, force: true });
       } catch (error) {
+        // Invalidate cache even on failure - worktree may have been cleaned up
+        // and we don't want stale data in the UI
+        projectStore.invalidateTasksCache(project.id);
         return {
           success: false,
           error: `Failed to delete task files: ${error instanceof Error ? error.message : String(error)}`

--- a/apps/frontend/src/main/ipc-handlers/task/shared.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/shared.ts
@@ -2,6 +2,24 @@ import type { Task, Project } from '../../../shared/types';
 import { projectStore } from '../../project-store';
 
 /**
+ * Generate a spec ID from a spec number and title.
+ * Creates a slug by lowercasing, replacing non-alphanumeric chars with dashes,
+ * trimming leading/trailing dashes, and limiting to 50 chars.
+ *
+ * @param specNumber - The numeric spec number (will be zero-padded to 3 digits)
+ * @param title - The task title to slugify
+ * @returns Spec ID in format "NNN-slug" (e.g., "001-fix-login-bug")
+ */
+export function generateSpecId(specNumber: number, title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 50);
+  return `${String(specNumber).padStart(3, '0')}-${slug}`;
+}
+
+/**
  * Helper function to find task and project by taskId
  */
 export const findTaskAndProject = (taskId: string): { task: Task | undefined; project: Project | undefined } => {

--- a/apps/frontend/src/preload/api/task-api.ts
+++ b/apps/frontend/src/preload/api/task-api.ts
@@ -49,6 +49,10 @@ export interface TaskAPI {
     options?: import('../../shared/types').TaskRecoveryOptions
   ) => Promise<IPCResult<TaskRecoveryResult>>;
   checkTaskRunning: (taskId: string) => Promise<IPCResult<boolean>>;
+  deleteAndRetryTask: (
+    taskId: string,
+    options?: { recreate?: boolean }
+  ) => Promise<IPCResult<{ deleted: boolean; recreatedTask?: Task; cleanedUpWorktree?: boolean }>>;
 
   // Workspace Management (for human review)
   getWorktreeStatus: (taskId: string) => Promise<IPCResult<import('../../shared/types').WorktreeStatus>>;
@@ -134,6 +138,12 @@ export const createTaskAPI = (): TaskAPI => ({
 
   checkTaskRunning: (taskId: string): Promise<IPCResult<boolean>> =>
     ipcRenderer.invoke(IPC_CHANNELS.TASK_CHECK_RUNNING, taskId),
+
+  deleteAndRetryTask: (
+    taskId: string,
+    options?: { recreate?: boolean }
+  ): Promise<IPCResult<{ deleted: boolean; recreatedTask?: Task; cleanedUpWorktree?: boolean }>> =>
+    ipcRenderer.invoke(IPC_CHANNELS.TASK_DELETE_AND_RETRY, taskId, options),
 
   // Workspace Management
   getWorktreeStatus: (taskId: string): Promise<IPCResult<import('../../shared/types').WorktreeStatus>> =>

--- a/apps/frontend/src/preload/api/task-api.ts
+++ b/apps/frontend/src/preload/api/task-api.ts
@@ -142,7 +142,7 @@ export const createTaskAPI = (): TaskAPI => ({
   deleteAndRetryTask: (
     taskId: string,
     options?: { recreate?: boolean }
-  ): Promise<IPCResult<{ deleted: boolean; recreatedTask?: Task; cleanedUpWorktree?: boolean }>> =>
+  ): Promise<IPCResult<{ deleted: boolean; recreatedTask?: Task; cleanedUpWorktree?: boolean; recreationSkipped?: string }>> =>
     ipcRenderer.invoke(IPC_CHANNELS.TASK_DELETE_AND_RETRY, taskId, options),
 
   // Workspace Management

--- a/apps/frontend/src/renderer/lib/mocks/task-mock.ts
+++ b/apps/frontend/src/renderer/lib/mocks/task-mock.ts
@@ -74,6 +74,11 @@ export const taskMock = {
 
   checkTaskRunning: async () => ({ success: true, data: false }),
 
+  deleteAndRetryTask: async () => ({
+    success: true,
+    data: { deleted: true, cleanedUpWorktree: false }
+  }),
+
   // Task logs operations
   getTaskLogs: async () => ({
     success: true,

--- a/apps/frontend/src/renderer/lib/mocks/task-mock.ts
+++ b/apps/frontend/src/renderer/lib/mocks/task-mock.ts
@@ -74,9 +74,28 @@ export const taskMock = {
 
   checkTaskRunning: async () => ({ success: true, data: false }),
 
-  deleteAndRetryTask: async () => ({
+  deleteAndRetryTask: async (_taskId: string, options?: { recreate?: boolean }) => ({
     success: true,
-    data: { deleted: true, cleanedUpWorktree: false }
+    data: {
+      deleted: true,
+      cleanedUpWorktree: false,
+      // Include recreatedTask when recreate option is true
+      ...(options?.recreate && {
+        recreatedTask: {
+          id: 'mock-retry-001',
+          specId: 'mock-retry-001',
+          projectId: 'mock-project',
+          title: 'Retried Task',
+          description: 'Mock retried task',
+          status: 'backlog' as const,
+          subtasks: [],
+          logs: [],
+          metadata: { retriedFrom: _taskId },
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
+      })
+    }
   }),
 
   // Task logs operations

--- a/apps/frontend/src/shared/constants/ipc.ts
+++ b/apps/frontend/src/shared/constants/ipc.ts
@@ -27,6 +27,7 @@ export const IPC_CHANNELS = {
   TASK_UPDATE_STATUS: 'task:updateStatus',
   TASK_RECOVER_STUCK: 'task:recoverStuck',
   TASK_CHECK_RUNNING: 'task:checkRunning',
+  TASK_DELETE_AND_RETRY: 'task:deleteAndRetry',
 
   // Workspace management (for human review)
   // Per-spec architecture: Each spec has its own worktree at .worktrees/{spec-name}/

--- a/apps/frontend/src/shared/types/ipc.ts
+++ b/apps/frontend/src/shared/types/ipc.ts
@@ -164,7 +164,7 @@ export interface ElectronAPI {
   updateTaskStatus: (taskId: string, status: TaskStatus, options?: { forceCleanup?: boolean }) => Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }>;
   recoverStuckTask: (taskId: string, options?: TaskRecoveryOptions) => Promise<IPCResult<TaskRecoveryResult>>;
   checkTaskRunning: (taskId: string) => Promise<IPCResult<boolean>>;
-  deleteAndRetryTask: (taskId: string, options?: { recreate?: boolean }) => Promise<IPCResult<{ deleted: boolean; recreatedTask?: Task; cleanedUpWorktree?: boolean }>>;
+  deleteAndRetryTask: (taskId: string, options?: { recreate?: boolean }) => Promise<IPCResult<{ deleted: boolean; recreatedTask?: Task; cleanedUpWorktree?: boolean; recreationSkipped?: string }>>;
 
   // Workspace management (for human review)
   // Per-spec architecture: Each spec has its own worktree at .worktrees/{spec-name}/

--- a/apps/frontend/src/shared/types/ipc.ts
+++ b/apps/frontend/src/shared/types/ipc.ts
@@ -164,6 +164,7 @@ export interface ElectronAPI {
   updateTaskStatus: (taskId: string, status: TaskStatus, options?: { forceCleanup?: boolean }) => Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }>;
   recoverStuckTask: (taskId: string, options?: TaskRecoveryOptions) => Promise<IPCResult<TaskRecoveryResult>>;
   checkTaskRunning: (taskId: string) => Promise<IPCResult<boolean>>;
+  deleteAndRetryTask: (taskId: string, options?: { recreate?: boolean }) => Promise<IPCResult<{ deleted: boolean; recreatedTask?: Task; cleanedUpWorktree?: boolean }>>;
 
   // Workspace management (for human review)
   // Per-spec architecture: Each spec has its own worktree at .worktrees/{spec-name}/

--- a/apps/frontend/src/shared/types/task.ts
+++ b/apps/frontend/src/shared/types/task.ts
@@ -180,6 +180,7 @@ export interface TaskMetadata {
   sourceType?: 'ideation' | 'manual' | 'imported' | 'insights' | 'roadmap' | 'linear' | 'github' | 'gitlab';
   ideationType?: string;  // e.g., 'code_improvements', 'security_hardening'
   ideaId?: string;  // Reference to original idea if converted
+  retriedFrom?: string;  // Original task specId if this task was created from a retry
   featureId?: string;  // Reference to roadmap feature if from roadmap
   linearIssueId?: string;  // Reference to Linear issue if from Linear
   linearIdentifier?: string;  // Linear issue identifier (e.g., 'ABC-123')


### PR DESCRIPTION
## Summary

- Add `TASK_DELETE_AND_RETRY` IPC handler for cleaning up stuck/failed tasks
- Stops running task process if active
- Cleans up git worktree with `git worktree remove --force`
- Deletes associated branch and prunes dangling worktrees
- Removes spec directory from `.auto-claude/specs/`
- Optionally recreates task with `retriedFrom` metadata for retry tracking

Fixes #1103

## Test plan

- [x] Delete a failed task - verify worktree is cleaned up
- [x] Delete and retry - verify new spec has retriedFrom metadata
- [x] Verify running task is stopped before deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Delete and Retry" for tasks: delete a task, optionally recreate it as a new task, and get back whether worktree cleanup occurred and the recreated task for automatic UI updates.
  * Recreated tasks include metadata linking them to the original task (retriedFrom).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->