### PR TITLE
fix(task): ensure roadmap/ideation tasks go through planning flow

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/ideation/task-converter.ts
+++ b/apps/frontend/src/main/ipc-handlers/ideation/task-converter.ts
@@ -158,21 +158,20 @@ function createSpecFiles(
     JSON.stringify(initialPlan, null, 2)
   );
 
-  // Create initial spec.md
-  const specContent = `# ${idea.title}
-
-## Overview
-
-${idea.description}
-
-## Rationale
-
-${idea.rationale}
-
----
-*This spec was created from ideation and is pending detailed specification.*
-`;
-  writeFileSync(path.join(specDir, AUTO_BUILD_PATHS.SPEC_FILE), specContent);
+  // Create requirements.json instead of spec.md
+  // This ensures the task goes through the full planning flow:
+  // 1. User starts task -> spec_runner.py reads requirements.json
+  // 2. spec_runner.py creates AI-generated spec.md with proper structure
+  // 3. spec_runner.py chains to run.py for implementation planning
+  // Creating spec.md here would cause run.py to be called directly, skipping spec creation
+  const requirements = {
+    task_description: `# ${idea.title}\n\n## Overview\n\n${idea.description}\n\n## Rationale\n\n${idea.rationale}`,
+    workflow_type: 'development'
+  };
+  writeFileSync(
+    path.join(specDir, AUTO_BUILD_PATHS.REQUIREMENTS),
+    JSON.stringify(requirements, null, 2)
+  );
 }
 
 /**

--- a/apps/frontend/src/main/ipc-handlers/ideation/task-converter.ts
+++ b/apps/frontend/src/main/ipc-handlers/ideation/task-converter.ts
@@ -166,7 +166,8 @@ function createSpecFiles(
   // Creating spec.md here would cause run.py to be called directly, skipping spec creation
   const requirements = {
     task_description: `# ${idea.title}\n\n## Overview\n\n${idea.description}\n\n## Rationale\n\n${idea.rationale}`,
-    workflow_type: 'development'
+    // Valid workflow types: feature, refactor, investigation, migration, simple, bugfix, bug_fix
+    workflow_type: 'feature'
   };
   writeFileSync(
     path.join(specDir, AUTO_BUILD_PATHS.REQUIREMENTS),

--- a/apps/frontend/src/main/ipc-handlers/ideation/task-converter.ts
+++ b/apps/frontend/src/main/ipc-handlers/ideation/task-converter.ts
@@ -148,7 +148,7 @@ function createSpecFiles(
     status: 'backlog',
     planStatus: 'pending',
     phases: [],
-    workflow_type: 'development',
+    workflow_type: 'feature',
     services_involved: [],
     final_acceptance: [],
     spec_file: 'spec.md'

--- a/apps/frontend/src/main/ipc-handlers/roadmap-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/roadmap-handlers.ts
@@ -565,6 +565,11 @@ ${(feature.acceptance_criteria || []).map((c: string) => `- [ ] ${c}`).join("\n"
         );
 
         // Create requirements.json
+        // NOTE: We do NOT create spec.md here - let spec_runner.py create it properly
+        // This ensures the task goes through the full planning flow:
+        // 1. User starts task -> spec_runner.py reads requirements.json
+        // 2. spec_runner.py creates AI-generated spec.md with proper structure
+        // 3. spec_runner.py chains to run.py for implementation planning
         const requirements = {
           task_description: taskDescription,
           workflow_type: "feature",
@@ -573,9 +578,6 @@ ${(feature.acceptance_criteria || []).map((c: string) => `- [ ] ${c}`).join("\n"
           path.join(specDir, AUTO_BUILD_PATHS.REQUIREMENTS),
           JSON.stringify(requirements, null, 2)
         );
-
-        // Create spec.md (required by backend spec creation process)
-        writeFileSync(path.join(specDir, AUTO_BUILD_PATHS.SPEC_FILE), taskDescription);
 
         // Build metadata
         const metadata: TaskMetadata = {

--- a/apps/frontend/src/renderer/components/Worktrees.tsx
+++ b/apps/frontend/src/renderer/components/Worktrees.tsx
@@ -58,7 +58,7 @@ interface WorktreesProps {
 }
 
 export function Worktrees({ projectId }: WorktreesProps) {
-  const { t } = useTranslation(['common', 'dialogs']);
+  const { t } = useTranslation(['common', 'dialogs', 'errors']);
   const projects = useProjectStore((state) => state.projects);
   const selectedProject = projects.find((p) => p.id === projectId);
   const tasks = useTaskStore((state) => state.tasks);

--- a/apps/frontend/src/shared/i18n/locales/en/errors.json
+++ b/apps/frontend/src/shared/i18n/locales/en/errors.json
@@ -5,5 +5,13 @@
       "titleSuffix": "(JSON Error)",
       "description": "⚠️ JSON Parse Error: {{error}}\n\nThe implementation_plan.json file is malformed. Run the backend auto-fix or manually repair the file."
     }
+  },
+  "merge": {
+    "success": "Merge Successful",
+    "failed": "Merge Failed",
+    "timeout": "Merge process timed out.",
+    "timeoutWithOutput": "Merge process timed out. Some output was received - please run `git status` in your project directory to check if the merge completed partially.",
+    "timeoutNoOutput": "Merge process timed out. No output received - the merge may not have started.",
+    "timeoutLastError": "Last error: {{lastError}}"
   }
 }

--- a/apps/frontend/src/shared/i18n/locales/fr/errors.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/errors.json
@@ -5,5 +5,13 @@
       "titleSuffix": "(Erreur JSON)",
       "description": "⚠️ Erreur d'analyse JSON : {{error}}\n\nLe fichier implementation_plan.json est malformé. Exécutez la correction automatique du backend ou réparez le fichier manuellement."
     }
+  },
+  "merge": {
+    "success": "Fusion réussie",
+    "failed": "Échec de la fusion",
+    "timeout": "Le processus de fusion a expiré.",
+    "timeoutWithOutput": "Le processus de fusion a expiré. Une sortie a été reçue - veuillez exécuter `git status` dans le répertoire de votre projet pour vérifier si la fusion s'est partiellement terminée.",
+    "timeoutNoOutput": "Le processus de fusion a expiré. Aucune sortie reçue - la fusion n'a peut-être pas démarré.",
+    "timeoutLastError": "Dernière erreur : {{lastError}}"
   }
 }


### PR DESCRIPTION
## Summary

- **task-converter.ts**: Create `requirements.json` instead of `spec.md` for ideation tasks
  - This ensures `spec_runner.py` creates proper AI-generated specs
  - Previously, creating spec.md directly caused tasks to skip the planning phase
  
- **roadmap-handlers.ts**: Remove `spec.md` creation, let `spec_runner.py` handle it
  - Same fix as task-converter.ts for roadmap-generated tasks
  
- **agent-events-handlers.ts**: Set failed tasks without subtasks to `backlog` (not `human_review`)
  - Allows users to retry tasks that failed during planning
  - Only moves to `human_review` if actual work (subtasks) was created

Fixes #1102

## Test plan

- [ ] Create task from ideation - should go through spec_runner.py planning
- [ ] Create task from roadmap - should go through spec_runner.py planning  
- [ ] Task that fails during planning - should return to backlog for retry
- [ ] Task that fails after subtasks created - should go to human_review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks without subtasks now route to backlog upon failure, enabling automatic retry capabilities instead of blocking on human review.

* **Refactor**
  * Specification generation workflow updated to defer spec.md creation, initially generating requirements.json during planning instead. Full specification generation now occurs as part of an external planning process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->