### PR TITLE
fix(startup): proactive Python environment initialization at startup

### DIFF
--- a/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
+++ b/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
@@ -194,7 +194,7 @@ describe('Terminal copy/paste integration', () => {
 
       // Verify integration: clipboard.writeText() called with selection
       expect(mockClipboard.writeText).toHaveBeenCalledWith('selected terminal text');
-    });
+    }, 15000);  // Increase timeout for CI
 
     it('should not call getSelection when hasSelection returns false', async () => {
       const { useXterm } = await import('../../renderer/components/terminal/useXterm');
@@ -267,7 +267,7 @@ describe('Terminal copy/paste integration', () => {
 
       // Verify clipboard was NOT written to
       expect(mockClipboard.writeText).not.toHaveBeenCalled();
-    });
+    }, 15000);  // Increase timeout for CI
   });
 
   describe('clipboard read with xterm paste integration', () => {
@@ -363,7 +363,7 @@ describe('Terminal copy/paste integration', () => {
 
       // Verify integration: xterm.paste() called with clipboard content
       expect(mockPaste).toHaveBeenCalledWith('pasted text');
-    });
+    }, 15000);  // Increase timeout for CI
 
     it('should not paste when clipboard is empty', async () => {
       const { useXterm } = await import('../../renderer/components/terminal/useXterm');
@@ -443,7 +443,7 @@ describe('Terminal copy/paste integration', () => {
 
       // Verify paste was NOT called for empty clipboard
       expect(mockPaste).not.toHaveBeenCalled();
-    });
+    }, 15000);  // Increase timeout for CI
   });
 
   describe('keyboard event propagation', () => {
@@ -548,7 +548,7 @@ describe('Terminal copy/paste integration', () => {
         // The input() should not be called directly
         expect(eventCallOrder).toHaveLength(0);
       });
-    });
+    }, 15000);  // Increase timeout for CI
 
     it('should maintain correct handler ordering for existing shortcuts', async () => {
       const { useXterm } = await import('../../renderer/components/terminal/useXterm');
@@ -635,7 +635,7 @@ describe('Terminal copy/paste integration', () => {
         // Should return true (let ^C pass through to terminal for interrupt signal)
         expect(handlerResults[0].handled).toBe(true);
       });
-    });
+    }, 15000);  // Increase timeout for CI
   });
 
   describe('clipboard error handling without breaking terminal', () => {
@@ -744,6 +744,6 @@ describe('Terminal copy/paste integration', () => {
       expect(mockSendTerminalInput).toHaveBeenCalledWith('test-terminal', 'test command');
 
       consoleErrorSpy.mockRestore();
-    });
+    }, 15000);  // Increase timeout for CI
   });
 });

--- a/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
+++ b/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
@@ -66,7 +66,6 @@ describe('Terminal copy/paste integration', () => {
   };
 
   beforeEach(() => {
-    vi.useFakeTimers();
     vi.clearAllMocks();
 
     // Mock ResizeObserver
@@ -105,8 +104,6 @@ describe('Terminal copy/paste integration', () => {
   });
 
   afterEach(() => {
-    vi.runOnlyPendingTimers();
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -173,7 +170,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(event);
           // Wait for clipboard write
-          await vi.runAllTimersAsync();
+          await new Promise(resolve => setTimeout(resolve, 0));
         }
       });
 
@@ -345,7 +342,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(event);
           // Wait for clipboard read and paste
-          await vi.runAllTimersAsync();
+          await new Promise(resolve => setTimeout(resolve, 0));
         }
       });
 
@@ -425,7 +422,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(event);
           // Wait for clipboard read
-          await vi.runAllTimersAsync();
+          await new Promise(resolve => setTimeout(resolve, 0));
         }
       });
 
@@ -517,7 +514,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(copyEvent);
           // Wait for clipboard write
-          await vi.runAllTimersAsync();
+          await new Promise(resolve => setTimeout(resolve, 0));
         }
 
         // Copy should not send input to terminal
@@ -532,7 +529,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(pasteEvent);
           // Wait for clipboard read
-          await vi.runAllTimersAsync();
+          await new Promise(resolve => setTimeout(resolve, 0));
         }
 
         // Paste should use xterm.paste(), not xterm.input()
@@ -717,7 +714,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(pasteEvent);
           // Wait for clipboard error
-          await vi.runAllTimersAsync();
+          await new Promise(resolve => setTimeout(resolve, 0));
         }
       });
 

--- a/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
+++ b/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
@@ -173,7 +173,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(event);
           // Wait for clipboard write
-          await new Promise(resolve => setTimeout(resolve, 0));
+          await vi.runAllTimersAsync();
         }
       });
 
@@ -345,7 +345,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(event);
           // Wait for clipboard read and paste
-          await new Promise(resolve => setTimeout(resolve, 0));
+          await vi.runAllTimersAsync();
         }
       });
 
@@ -425,7 +425,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(event);
           // Wait for clipboard read
-          await new Promise(resolve => setTimeout(resolve, 0));
+          await vi.runAllTimersAsync();
         }
       });
 
@@ -517,7 +517,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(copyEvent);
           // Wait for clipboard write
-          await new Promise(resolve => setTimeout(resolve, 0));
+          await vi.runAllTimersAsync();
         }
 
         // Copy should not send input to terminal
@@ -532,7 +532,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(pasteEvent);
           // Wait for clipboard read
-          await new Promise(resolve => setTimeout(resolve, 0));
+          await vi.runAllTimersAsync();
         }
 
         // Paste should use xterm.paste(), not xterm.input()
@@ -717,7 +717,7 @@ describe('Terminal copy/paste integration', () => {
         if (keyEventHandler) {
           keyEventHandler(pasteEvent);
           // Wait for clipboard error
-          await new Promise(resolve => setTimeout(resolve, 0));
+          await vi.runAllTimersAsync();
         }
       });
 

--- a/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
+++ b/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
@@ -66,7 +66,18 @@ describe('Terminal copy/paste integration', () => {
   };
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
+
+    // Mock requestAnimationFrame to prevent async operations after test teardown
+    // Using setTimeout with fake timers instead of callback.call(window, 0) which
+    // fails when jsdom window is destroyed after test completion
+    global.requestAnimationFrame = vi.fn((callback) => {
+      return setTimeout(callback, 0) as unknown as number;
+    });
+    global.cancelAnimationFrame = vi.fn((id) => {
+      clearTimeout(id);
+    });
 
     // Mock ResizeObserver
     global.ResizeObserver = vi.fn().mockImplementation(function() {
@@ -103,6 +114,8 @@ describe('Terminal copy/paste integration', () => {
   });
 
   afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 

--- a/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
+++ b/apps/frontend/src/__tests__/integration/terminal-copy-paste.test.ts
@@ -69,16 +69,6 @@ describe('Terminal copy/paste integration', () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
 
-    // Mock requestAnimationFrame to prevent async operations after test teardown
-    // Using setTimeout with fake timers instead of callback.call(window, 0) which
-    // fails when jsdom window is destroyed after test completion
-    global.requestAnimationFrame = vi.fn((callback) => {
-      return setTimeout(callback, 0) as unknown as number;
-    });
-    global.cancelAnimationFrame = vi.fn((id) => {
-      clearTimeout(id);
-    });
-
     // Mock ResizeObserver
     global.ResizeObserver = vi.fn().mockImplementation(function() {
       return {
@@ -89,12 +79,13 @@ describe('Terminal copy/paste integration', () => {
     });
 
     // Mock requestAnimationFrame for xterm.js integration tests
+    // Synchronously execute the callback to avoid timing issues in tests
+    // Just pass timestamp directly - this context isn't used by RAF callbacks
     global.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
-      // Synchronously execute the callback to avoid timing issues in tests
-      // Just pass timestamp directly - this context isn't used by RAF callbacks
       callback(0);
       return 0;
     }) as unknown as Mock;
+    global.cancelAnimationFrame = vi.fn();
 
     // Mock navigator.clipboard
     mockClipboard = {

--- a/apps/frontend/src/main/ipc-handlers/settings-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/settings-handlers.ts
@@ -796,7 +796,7 @@ export function registerSettingsHandlers(
 
         let autoBuildPath = settings.autoBuildPath;
         if (!autoBuildPath) {
-          autoBuildPath = detectAutoBuildSourcePath();
+          autoBuildPath = detectAutoBuildSourcePath() ?? undefined;
         }
 
         if (!autoBuildPath) {

--- a/apps/frontend/src/main/ipc-handlers/settings-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/settings-handlers.ts
@@ -780,7 +780,7 @@ export function registerSettingsHandlers(
         console.error('[PYTHON_ENV_STATUS] Error:', error);
         return {
           success: false,
-          error: error instanceof Error ? error.message : 'Failed to get Python environment status'
+          error: error instanceof Error ? error.message : 'errors:pythonEnv.statusFailed'
         };
       }
     }
@@ -802,7 +802,7 @@ export function registerSettingsHandlers(
         if (!autoBuildPath) {
           return {
             success: false,
-            error: 'Auto-build source path not configured. Please set it in Settings.'
+            error: 'errors:pythonEnv.autoBuildPathMissing'
           };
         }
 
@@ -812,7 +812,7 @@ export function registerSettingsHandlers(
         if (!status.ready) {
           return {
             success: false,
-            error: status.error || 'Failed to initialize Python environment'
+            error: status.error || 'errors:pythonEnv.initializeFailed'
           };
         }
 
@@ -821,7 +821,7 @@ export function registerSettingsHandlers(
         console.error('[PYTHON_ENV_INITIALIZE] Error:', error);
         return {
           success: false,
-          error: error instanceof Error ? error.message : 'Failed to initialize Python environment'
+          error: error instanceof Error ? error.message : 'errors:pythonEnv.initializeFailed'
         };
       }
     }

--- a/apps/frontend/src/main/python-env-manager.ts
+++ b/apps/frontend/src/main/python-env-manager.ts
@@ -6,16 +6,10 @@ import { app } from 'electron';
 import { findPythonCommand, getBundledPythonPath } from './python-detector';
 import { isLinux, isWindows, getPathDelimiter } from './platform';
 import { getIsolatedGitEnv } from './utils/git-isolation';
+import type { PythonEnvStatus } from '../shared/types/settings';
 
-export interface PythonEnvStatus {
-  ready: boolean;
-  pythonPath: string | null;
-  sitePackagesPath: string | null;
-  venvExists: boolean;
-  depsInstalled: boolean;
-  usingBundledPackages: boolean;
-  error?: string;
-}
+// Re-export for backwards compatibility
+export type { PythonEnvStatus };
 
 /**
  * Manages the Python environment for the auto-claude backend.

--- a/apps/frontend/src/main/settings-utils.ts
+++ b/apps/frontend/src/main/settings-utils.ts
@@ -74,16 +74,16 @@ export async function readSettingsFileAsync(): Promise<Record<string, unknown> |
   const settingsPath = getSettingsPath();
 
   try {
-    await fsPromises.access(settingsPath);
-  } catch {
-    return undefined;
-  }
-
-  try {
+    // Read file directly without checking existence first to avoid TOCTOU race condition
     const content = await fsPromises.readFile(settingsPath, 'utf-8');
     return JSON.parse(content);
-  } catch {
-    // Return undefined on parse error - caller will use defaults
+  } catch (e) {
+    // Return undefined if file doesn't exist or on parse error - caller will use defaults
+    // ENOENT means file doesn't exist, which is expected on first run
+    if (e && typeof e === 'object' && 'code' in e && e.code !== 'ENOENT') {
+      // Log unexpected errors (but not missing file, which is normal)
+      console.warn('[settings-utils] Failed to read settings file:', e);
+    }
     return undefined;
   }
 }

--- a/apps/frontend/src/main/settings-utils.ts
+++ b/apps/frontend/src/main/settings-utils.ts
@@ -79,7 +79,7 @@ export async function readSettingsFileAsync(): Promise<Record<string, unknown> |
   } catch (e) {
     // Return undefined if file doesn't exist or on parse error - caller will use defaults
     // ENOENT means file doesn't exist, which is expected on first run
-    if (e && typeof e === 'object' && 'code' in e && e.code !== 'ENOENT') {
+    if (e && typeof e === 'object' && 'code' in e && (e as NodeJS.ErrnoException).code !== 'ENOENT') {
       // Log unexpected errors (but not missing file, which is normal)
       console.warn('[settings-utils] Failed to read settings file:', e);
     }

--- a/apps/frontend/src/main/settings-utils.ts
+++ b/apps/frontend/src/main/settings-utils.ts
@@ -9,7 +9,7 @@
  */
 
 import { app } from 'electron';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { promises as fsPromises } from 'fs';
 import path from 'path';
 
@@ -30,15 +30,16 @@ export function getSettingsPath(): string {
 export function readSettingsFile(): Record<string, unknown> | undefined {
   const settingsPath = getSettingsPath();
 
-  if (!existsSync(settingsPath)) {
-    return undefined;
-  }
-
   try {
+    // Read file directly without checking existence first to avoid TOCTOU race condition
     const content = readFileSync(settingsPath, 'utf-8');
     return JSON.parse(content);
-  } catch {
-    // Return undefined on parse error - caller will use defaults
+  } catch (e) {
+    // Return undefined if file doesn't exist or on parse error - caller will use defaults
+    // ENOENT means file doesn't exist, which is expected on first run
+    if (e && typeof e === 'object' && 'code' in e && (e as NodeJS.ErrnoException).code !== 'ENOENT') {
+      console.warn('[settings-utils] Failed to read settings file:', e);
+    }
     return undefined;
   }
 }
@@ -51,11 +52,9 @@ export function readSettingsFile(): Record<string, unknown> | undefined {
 export function writeSettingsFile(settings: Record<string, unknown>): void {
   const settingsPath = getSettingsPath();
 
-  // Ensure the directory exists
+  // Ensure the directory exists (mkdirSync with recursive:true is idempotent, avoids TOCTOU)
   const dir = path.dirname(settingsPath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
+  mkdirSync(dir, { recursive: true });
 
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
 }

--- a/apps/frontend/src/renderer/components/Worktrees.tsx
+++ b/apps/frontend/src/renderer/components/Worktrees.tsx
@@ -58,7 +58,7 @@ interface WorktreesProps {
 }
 
 export function Worktrees({ projectId }: WorktreesProps) {
-  const { t } = useTranslation(['common', 'dialogs']);
+  const { t } = useTranslation(['common', 'dialogs', 'errors']);
   const projects = useProjectStore((state) => state.projects);
   const selectedProject = projects.find((p) => p.id === projectId);
   const tasks = useTaskStore((state) => state.tasks);
@@ -813,7 +813,7 @@ export function Worktrees({ projectId }: WorktreesProps) {
                   )}
                   <div>
                     <p className={`font-medium ${mergeResult.success ? 'text-success' : 'text-destructive'}`}>
-                      {mergeResult.success ? 'Merge Successful' : 'Merge Failed'}
+                      {mergeResult.success ? t('errors:merge.success') : t('errors:merge.failed')}
                     </p>
                     <p className="text-muted-foreground mt-1">{mergeResult.message}</p>
                     {mergeResult.conflictFiles && mergeResult.conflictFiles.length > 0 && (

--- a/apps/frontend/src/shared/constants/ipc.ts
+++ b/apps/frontend/src/shared/constants/ipc.ts
@@ -128,6 +128,10 @@ export const IPC_CHANNELS = {
   SETTINGS_SAVE: 'settings:save',
   SETTINGS_GET_CLI_TOOLS_INFO: 'settings:getCliToolsInfo',
 
+  // Python environment management
+  PYTHON_ENV_STATUS: 'python:envStatus',
+  PYTHON_ENV_INITIALIZE: 'python:envInitialize',
+
   // API Profile management (custom Anthropic-compatible endpoints)
   PROFILES_GET: 'profiles:get',
   PROFILES_SAVE: 'profiles:save',

--- a/apps/frontend/src/shared/i18n/locales/en/errors.json
+++ b/apps/frontend/src/shared/i18n/locales/en/errors.json
@@ -5,5 +5,18 @@
       "titleSuffix": "(JSON Error)",
       "description": "⚠️ JSON Parse Error: {{error}}\n\nThe implementation_plan.json file is malformed. Run the backend auto-fix or manually repair the file."
     }
+  },
+  "merge": {
+    "success": "Merge successful",
+    "failed": "Merge failed",
+    "timeout": "Merge process timed out.",
+    "timeoutWithOutput": "Merge process timed out. Some output was received - please run `git status` in your project directory to check if the merge partially completed.",
+    "timeoutNoOutput": "Merge process timed out. No output received - the merge may not have started.",
+    "timeoutLastError": "Last error: {{lastError}}"
+  },
+  "pythonEnv": {
+    "autoBuildPathMissing": "Auto-build source path not configured. Please set it in Settings.",
+    "initializeFailed": "Failed to initialize Python environment",
+    "statusFailed": "Failed to get Python environment status"
   }
 }

--- a/apps/frontend/src/shared/i18n/locales/fr/errors.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/errors.json
@@ -13,5 +13,10 @@
     "timeoutWithOutput": "Le processus de fusion a expiré. Une sortie a été reçue - veuillez exécuter `git status` dans le répertoire de votre projet pour vérifier si la fusion s'est partiellement terminée.",
     "timeoutNoOutput": "Le processus de fusion a expiré. Aucune sortie reçue - la fusion n'a peut-être pas démarré.",
     "timeoutLastError": "Dernière erreur : {{lastError}}"
+  },
+  "pythonEnv": {
+    "autoBuildPathMissing": "Le chemin source auto-build n'est pas configuré. Veuillez le définir dans les Paramètres.",
+    "initializeFailed": "Échec de l'initialisation de l'environnement Python",
+    "statusFailed": "Échec de la récupération du statut de l'environnement Python"
   }
 }

--- a/apps/frontend/src/shared/i18n/locales/fr/errors.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/errors.json
@@ -5,5 +5,13 @@
       "titleSuffix": "(Erreur JSON)",
       "description": "⚠️ Erreur d'analyse JSON : {{error}}\n\nLe fichier implementation_plan.json est malformé. Exécutez la correction automatique du backend ou réparez le fichier manuellement."
     }
+  },
+  "merge": {
+    "success": "Fusion réussie",
+    "failed": "Échec de la fusion",
+    "timeout": "Le processus de fusion a expiré.",
+    "timeoutWithOutput": "Le processus de fusion a expiré. Une sortie a été reçue - veuillez exécuter `git status` dans le répertoire de votre projet pour vérifier si la fusion s'est partiellement terminée.",
+    "timeoutNoOutput": "Le processus de fusion a expiré. Aucune sortie reçue - la fusion n'a peut-être pas démarré.",
+    "timeoutLastError": "Dernière erreur : {{lastError}}"
   }
 }

--- a/apps/frontend/src/shared/types/settings.ts
+++ b/apps/frontend/src/shared/types/settings.ts
@@ -301,3 +301,17 @@ export interface SourceEnvCheckResult {
   sourcePath?: string;
   error?: string;
 }
+
+/**
+ * Python environment status information
+ * FIX (#1106): Exported for UI to show Python setup status
+ */
+export interface PythonEnvStatus {
+  ready: boolean;
+  pythonPath: string | null;
+  sitePackagesPath: string | null;
+  venvExists: boolean;
+  depsInstalled: boolean;
+  usingBundledPackages: boolean;
+  error?: string;
+}

--- a/guides/CLI-USAGE.md
+++ b/guides/CLI-USAGE.md
@@ -220,7 +220,8 @@ See `.env.example` for complete configuration options including provider-specifi
 ### API Error: 404 Model Not Found
 
 If you see an error like:
-```
+
+```text
 API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-5-20241022"}}
 ```
 
@@ -229,26 +230,23 @@ This means a stale/invalid model ID is being used. The issue is typically caused
 **Solution:**
 
 1. Check your project's `.auto-claude/.env` file for `AUTO_BUILD_MODEL`:
+
    ```bash
    cat <your-project>/.auto-claude/.env | grep AUTO_BUILD_MODEL
    ```
 
 2. If it contains an outdated model ID (e.g., `claude-sonnet-4-5-20241022`), either:
-   - **Comment it out** to use the default from `phase_config.py`:
+   - **Comment it out** to use the default from `apps/backend/phase_config.py`:
+
      ```bash
      # AUTO_BUILD_MODEL=claude-sonnet-4-5-20241022
      ```
-   - **Update it** to the correct model ID:
-     ```bash
-     AUTO_BUILD_MODEL=claude-sonnet-4-5-20250929
-     ```
 
-**Recommendation:** Let `phase_config.py` be the single source of truth for model IDs. Only use `AUTO_BUILD_MODEL` in your project's `.auto-claude/.env` for special testing scenarios.
+   - **Update it** to the correct model ID (see official docs below)
 
-**Valid Model IDs (as of January 2026):**
-- `claude-opus-4-5-20251101`
-- `claude-sonnet-4-5-20250929`
-- `claude-haiku-4-5-20251001`
+**Recommendation:** Let `apps/backend/phase_config.py` be the single source of truth for model IDs. Only use `AUTO_BUILD_MODEL` in your project's `.auto-claude/.env` for special testing scenarios.
+
+**Valid Model IDs:** Model IDs change frequently. See the [official Anthropic documentation](https://docs.anthropic.com/en/docs/about-claude/models) for current model IDs.
 
 ### Windows: Stale Process Issues
 

--- a/guides/CLI-USAGE.md
+++ b/guides/CLI-USAGE.md
@@ -214,3 +214,48 @@ cp .env.example .env
 | `GRAPHITI_EMBEDDER_PROVIDER` | No | Embedder: openai, voyage, ollama, google, openrouter |
 
 See `.env.example` for complete configuration options including provider-specific settings.
+
+## Troubleshooting
+
+### API Error: 404 Model Not Found
+
+If you see an error like:
+```
+API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-5-20241022"}}
+```
+
+This means a stale/invalid model ID is being used. The issue is typically caused by a per-project `.env` file overriding the correct model ID.
+
+**Solution:**
+
+1. Check your project's `.auto-claude/.env` file for `AUTO_BUILD_MODEL`:
+   ```bash
+   cat <your-project>/.auto-claude/.env | grep AUTO_BUILD_MODEL
+   ```
+
+2. If it contains an outdated model ID (e.g., `claude-sonnet-4-5-20241022`), either:
+   - **Comment it out** to use the default from `phase_config.py`:
+     ```bash
+     # AUTO_BUILD_MODEL=claude-sonnet-4-5-20241022
+     ```
+   - **Update it** to the correct model ID:
+     ```bash
+     AUTO_BUILD_MODEL=claude-sonnet-4-5-20250929
+     ```
+
+**Recommendation:** Let `phase_config.py` be the single source of truth for model IDs. Only use `AUTO_BUILD_MODEL` in your project's `.auto-claude/.env` for special testing scenarios.
+
+**Valid Model IDs (as of January 2026):**
+- `claude-opus-4-5-20251101`
+- `claude-sonnet-4-5-20250929`
+- `claude-haiku-4-5-20251001`
+
+### Windows: Stale Process Issues
+
+Windows does not always clean up PTY daemon and child processes when Auto Claude closes. If builds fail to start or hang, kill stale processes:
+
+```bash
+taskkill /F /IM python.exe /IM node.exe /IM electron.exe 2>nul
+```
+
+Then restart Auto Claude.

--- a/tests/test_dependency_validator.py
+++ b/tests/test_dependency_validator.py
@@ -13,8 +13,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 # Add apps/backend directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "apps" / "backend"))
 


### PR DESCRIPTION
## Summary
- Initialize Python environment (venv/pip) at app startup instead of on first task start
- Add IPC channels (PYTHON_ENV_STATUS, PYTHON_ENV_INITIALIZE) for future UI integration
- Export PythonEnvStatus type for renderer consumption

## Problem
On Windows, users frequently encountered confusing errors when trying to run tasks because:
1. Python environment initialization only happened on first task start
2. venv creation and pip install often failed silently or with cryptic errors
3. Users had no visibility into Python setup status

## Solution
- Proactively initialize Python environment at app startup in `index.ts`
- Add IPC handlers to check status and trigger initialization from UI
- This ensures environment is ready before users try to run tasks

## Test plan
- [ ] Start app on Windows with no venv - verify venv is created at startup
- [ ] Check console logs for Python initialization messages
- [ ] Run a task - should work without additional initialization delay

Fixes #1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python environment now proactively initializes at startup when auto-build is configured (non-blocking) and exposes initialization status and errors earlier
  * Frontend can query and manually trigger Python environment initialization
  * Merge operation status messages in Worktrees are localized (EN + FR)

* **Documentation**
  * Added Troubleshooting section to CLI guide covering API model issues and Windows process cleanup

* **Tests**
  * Improved timing control in terminal clipboard tests for CI stability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->