### PR TITLE
fix: reset subtasks when task description changes (#1085)

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
@@ -317,9 +317,9 @@ export function registerTaskCRUDHandlers(agentManager: AgentManager): void {
             // Don't reset 'done', 'pr_created', or 'in_progress' tasks as that would lose progress
             // in_progress tasks might have partial work even if agent isn't actively running
             // Also check agentManager.isRunning() to prevent race condition during agent shutdown
-            const replanableStates = ['backlog', 'error'];
+            const replannableStates = ['backlog', 'error'];
             const isAgentRunning = agentManager.isRunning(taskId);
-            const canReplan = replanableStates.includes(task.status) && !isAgentRunning;
+            const canReplan = replannableStates.includes(task.status) && !isAgentRunning;
 
             if (descriptionChanged && canReplan && plan.phases && plan.phases.length > 0) {
               console.warn('[TASK_UPDATE] Description changed, resetting subtasks for re-planning');

--- a/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
@@ -313,12 +313,15 @@ export function registerTaskCRUDHandlers(agentManager: AgentManager): void {
               oldDescription.trim() !== newDescription.trim();
 
             if (descriptionChanged && plan.phases && plan.phases.length > 0) {
-              console.log('[TASK_UPDATE] Description changed, resetting subtasks for re-planning');
+              console.warn('[TASK_UPDATE] Description changed, resetting subtasks for re-planning');
               // Reset all subtasks to pending so they can be re-processed
               for (const phase of plan.phases) {
                 if (phase.subtasks) {
                   for (const subtask of phase.subtasks) {
-                    subtask.status = 'pending';
+                    // Defensive check in case subtasks array has null/undefined entries
+                    if (subtask) {
+                      subtask.status = 'pending';
+                    }
                   }
                 }
               }

--- a/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
@@ -316,7 +316,7 @@ export function registerTaskCRUDHandlers(agentManager: AgentManager): void {
             // Only reset status for tasks in states where re-planning makes sense
             // Don't reset 'done' or 'pr_created' tasks as that would lose their completion state
             // Also don't reset while agent is actively running to prevent corrupting execution state
-            const replanableStates = ['backlog', 'failed', 'in_progress'];
+            const replanableStates = ['backlog', 'error', 'in_progress'];
             const isAgentRunning = agentManager.isRunning(taskId);
             const canReplan = replanableStates.includes(task.status) && !isAgentRunning;
 
@@ -329,6 +329,10 @@ export function registerTaskCRUDHandlers(agentManager: AgentManager): void {
                     // Defensive check in case subtasks array has null/undefined entries
                     if (subtask) {
                       subtask.status = 'pending';
+                      // Clear execution metadata to match pattern in execution-handlers.ts
+                      delete subtask.actual_output;
+                      delete subtask.started_at;
+                      delete subtask.completed_at;
                     }
                   }
                 }


### PR DESCRIPTION
## Summary
- Detect when task description changes in TASK_UPDATE handler
- Reset all subtask statuses to "pending" when description differs
- Reset planStatus to "pending" to allow re-planning

## Root Cause
When a completed task's description was updated and the task was restarted, `is_build_complete()` returned true because all subtasks were still marked "completed". The task bounced back to human_review without processing the new description.

## Changes
In `crud-handlers.ts` TASK_UPDATE handler:
- Compare old and new description
- If description changed and phases exist, reset all subtasks to pending
- Reset planStatus to trigger re-planning

## Test plan
- [x] Complete a task to human_review
- [x] Edit the task description with new requirements
- [x] Move task back to backlog/planning and start it
- [x] Verify task processes the new description instead of bouncing back

Fixes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Task description updates now automatically reset associated subtasks, clear prior execution metadata, and set subtask statuses to pending when significant changes are detected, prompting re-planning so plans stay aligned with the updated description.
  * If re-planning is not permitted (e.g., agent actively running or task state ineligible), the system preserves current state and records a clear warning explaining why re-planning was skipped.


<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->