### PR TITLE
fix: don't assume merge success on timeout (#1089)

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/task/worktree-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/worktree-handlers.ts
@@ -2034,10 +2034,10 @@ export function registerWorktreeHandlers(
               }
 
               resolve({
-                success: false,
+                success: true,  // Outer success=true so renderer uses i18n handling
                 error: messageKey,  // Fallback for non-i18n consumers
                 data: {
-                  success: false,
+                  success: false,  // Inner success=false indicates actual failure
                   message: messageKey,  // Fallback message
                   messageKey,
                   messageParams

--- a/apps/frontend/src/main/ipc-handlers/task/worktree-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/worktree-handlers.ts
@@ -2022,21 +2022,15 @@ export function registerWorktreeHandlers(
 
               // Build error response with i18n translation keys for the renderer
               // Use structured error with messageKey/messageParams for proper localization
-              let messageKey = 'errors:merge.timeout';
-              let messageParams: Record<string, string> = {};
-              let lastError = '';
+              const messageKey = hasOutput ? 'errors:merge.timeoutWithOutput' : 'errors:merge.timeoutNoOutput';
+              let messageParams: Record<string, string> | undefined;
 
-              if (hasOutput) {
-                messageKey = 'errors:merge.timeoutWithOutput';
-                if (stderr.length > 0) {
+              // Extract last error from stderr if available for the "with output" case
+              if (hasOutput && stderr.length > 0) {
                   const lastStderrLine = stderr.trim().split('\n').pop() || '';
                   if (lastStderrLine.length > 0 && lastStderrLine.length < 200) {
-                    lastError = lastStderrLine;
-                    messageParams = { lastError };
+                    messageParams = { lastError: lastStderrLine };
                   }
-                }
-              } else {
-                messageKey = 'errors:merge.timeoutNoOutput';
               }
 
               resolve({
@@ -2046,7 +2040,7 @@ export function registerWorktreeHandlers(
                   success: false,
                   message: messageKey,  // Fallback message
                   messageKey,
-                  messageParams: lastError ? messageParams : undefined
+                  messageParams
                 }
               });
             }

--- a/apps/frontend/src/renderer/components/Worktrees.tsx
+++ b/apps/frontend/src/renderer/components/Worktrees.tsx
@@ -58,7 +58,7 @@ interface WorktreesProps {
 }
 
 export function Worktrees({ projectId }: WorktreesProps) {
-  const { t } = useTranslation(['common', 'dialogs']);
+  const { t } = useTranslation(['common', 'dialogs', 'errors']);
   const projects = useProjectStore((state) => state.projects);
   const selectedProject = projects.find((p) => p.id === projectId);
   const tasks = useTaskStore((state) => state.tasks);
@@ -813,7 +813,7 @@ export function Worktrees({ projectId }: WorktreesProps) {
                   )}
                   <div>
                     <p className={`font-medium ${mergeResult.success ? 'text-success' : 'text-destructive'}`}>
-                      {mergeResult.success ? 'Merge Successful' : 'Merge Failed'}
+                      {mergeResult.success ? t('errors:merge.success') : t('errors:merge.failed')}
                     </p>
                     <p className="text-muted-foreground mt-1">{mergeResult.message}</p>
                     {mergeResult.conflictFiles && mergeResult.conflictFiles.length > 0 && (

--- a/apps/frontend/src/renderer/components/Worktrees.tsx
+++ b/apps/frontend/src/renderer/components/Worktrees.tsx
@@ -815,7 +815,17 @@ export function Worktrees({ projectId }: WorktreesProps) {
                     <p className={`font-medium ${mergeResult.success ? 'text-success' : 'text-destructive'}`}>
                       {mergeResult.success ? t('errors:merge.success') : t('errors:merge.failed')}
                     </p>
-                    <p className="text-muted-foreground mt-1">{mergeResult.message}</p>
+                    <p className="text-muted-foreground mt-1">
+                      {mergeResult.messageKey
+                        ? t(mergeResult.messageKey, mergeResult.messageParams || {})
+                        : mergeResult.message}
+                      {/* Append last error if present (separate line for clarity) */}
+                      {mergeResult.messageParams?.lastError && (
+                        <span className="block mt-1 text-xs font-mono">
+                          {t('errors:merge.timeoutLastError', { lastError: mergeResult.messageParams.lastError })}
+                        </span>
+                      )}
+                    </p>
                     {mergeResult.conflictFiles && mergeResult.conflictFiles.length > 0 && (
                       <div className="mt-2">
                         <p className="text-xs font-medium">Conflicting files:</p>

--- a/apps/frontend/src/shared/i18n/locales/en/errors.json
+++ b/apps/frontend/src/shared/i18n/locales/en/errors.json
@@ -5,5 +5,13 @@
       "titleSuffix": "(JSON Error)",
       "description": "⚠️ JSON Parse Error: {{error}}\n\nThe implementation_plan.json file is malformed. Run the backend auto-fix or manually repair the file."
     }
+  },
+  "merge": {
+    "success": "Merge Successful",
+    "failed": "Merge Failed",
+    "timeout": "Merge process timed out.",
+    "timeoutWithOutput": "Merge process timed out. Some output was received - please run git status in your project directory to check if the merge completed partially.",
+    "timeoutNoOutput": "Merge process timed out. No output received - the merge may not have started.",
+    "timeoutLastError": "Last error: {{lastError}}"
   }
 }

--- a/apps/frontend/src/shared/i18n/locales/fr/errors.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/errors.json
@@ -5,5 +5,13 @@
       "titleSuffix": "(Erreur JSON)",
       "description": "⚠️ Erreur d'analyse JSON : {{error}}\n\nLe fichier implementation_plan.json est malformé. Exécutez la correction automatique du backend ou réparez le fichier manuellement."
     }
+  },
+  "merge": {
+    "success": "Fusion réussie",
+    "failed": "Échec de la fusion",
+    "timeout": "Le processus de fusion a expiré.",
+    "timeoutWithOutput": "Le processus de fusion a expiré. Une sortie a été reçue - veuillez exécuter git status dans le répertoire de votre projet pour vérifier si la fusion s'est partiellement terminée.",
+    "timeoutNoOutput": "Le processus de fusion a expiré. Aucune sortie reçue - la fusion n'a peut-être pas démarré.",
+    "timeoutLastError": "Dernière erreur : {{lastError}}"
   }
 }

--- a/apps/frontend/src/shared/types/task.ts
+++ b/apps/frontend/src/shared/types/task.ts
@@ -382,6 +382,9 @@ export interface MergeStats {
 export interface WorktreeMergeResult {
   success: boolean;
   message: string;
+  // i18n translation key and params (renderer will translate if present)
+  messageKey?: string;
+  messageParams?: Record<string, string>;
   merged?: boolean;
   conflictFiles?: string[];
   staged?: boolean;


### PR DESCRIPTION
## Summary
- Remove pattern matching success detection on merge timeout
- Always treat timeout as a failure requiring user verification
- Provide contextual error messages with debugging info
- Add logging for branch deletion errors

## Root Cause
The merge handler used pattern matching on stdout (`"staged"`, `"Successfully merged"`, `"Changes from"`) to determine if a merge "might have succeeded" when the process timed out. This caused:
- False success indicators (task marked "Done" at 100%)
- Empty Files tab despite "completion"
- Git repository left in inconsistent state
- Previous commits potentially reverted

## Changes
In `worktree-handlers.ts`:
1. **Timeout handler** (lines 2031-2055): Instead of pattern matching, always return failure on timeout with helpful error message telling user to check `git status`
2. **Branch deletion** (lines 2197-2200): Log errors instead of silently swallowing them

## Test plan
- [x] Start a task and let it run to completion
- [x] Click "Merge with AI" and verify it completes successfully
- [x] Simulate a timeout (artificially lower timeout value) and verify error is shown, not false success
- [x] Check git status after timeout to verify repo state is communicated to user

Fixes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timeouts are now always treated as failures and show clear localized timeout messages; when available, a last-error line is shown. Timeout events and branch-cleanup issues now include improved debug logging with context.

* **New Features**
  * Merge results support translation keys and parameters; the UI displays i18n-driven merge messages.
  * Added English and French merge message translations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->