### PR TITLE
fix: propagate model settings from UI to task_metadata.json (#1084)

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
@@ -115,13 +115,14 @@ export function registerTaskCRUDHandlers(agentManager: AgentManager): void {
       const phaseModels = metadata?.phaseModels || settings.customPhaseModels;
 
       const taskMetadata: TaskMetadata = {
+        // Spread metadata first, then override with computed values
+        ...metadata,
         sourceType: 'manual',
         // Add model configuration so backend uses correct models
         model: (metadata?.model || modelFromSettings) as ModelType,
         isAutoProfile,
         phaseModels: phaseModels as PhaseModelConfig | undefined,
         thinkingLevel: metadata?.thinkingLevel || settings.thinkingLevel,
-        ...metadata
       };
 
       // Process and save attached images

--- a/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/crud-handlers.ts
@@ -1,12 +1,13 @@
 import { ipcMain } from 'electron';
-import { IPC_CHANNELS, AUTO_BUILD_PATHS, getSpecsDir } from '../../../shared/constants';
-import type { IPCResult, Task, TaskMetadata } from '../../../shared/types';
+import { IPC_CHANNELS, AUTO_BUILD_PATHS, getSpecsDir, DEFAULT_APP_SETTINGS } from '../../../shared/constants';
+import type { IPCResult, Task, TaskMetadata, ModelType, PhaseModelConfig, AppSettings } from '../../../shared/types';
 import path from 'path';
 import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
 import { projectStore } from '../../project-store';
 import { titleGenerator } from '../../title-generator';
 import { AgentManager } from '../../agent';
 import { findTaskAndProject } from './shared';
+import { readSettingsFile } from '../../settings-utils';
 
 /**
  * Register task CRUD (Create, Read, Update, Delete) handlers
@@ -102,8 +103,24 @@ export function registerTaskCRUDHandlers(agentManager: AgentManager): void {
       mkdirSync(specDir, { recursive: true });
 
       // Build metadata with source type
+      // FIX (#1084): Include model settings from app settings
+      const rawSettings = readSettingsFile();
+      const settings = { ...DEFAULT_APP_SETTINGS, ...rawSettings } as AppSettings;
+
+      // Determine model configuration
+      // Priority: passed metadata > project settings > app settings > defaults
+      const projectSettings = project.settings;
+      const modelFromSettings = projectSettings?.model || settings.defaultModel || 'opus';
+      const isAutoProfile = settings.customPhaseModels !== undefined || metadata?.isAutoProfile === true;
+      const phaseModels = metadata?.phaseModels || settings.customPhaseModels;
+
       const taskMetadata: TaskMetadata = {
         sourceType: 'manual',
+        // Add model configuration so backend uses correct models
+        model: (metadata?.model || modelFromSettings) as ModelType,
+        isAutoProfile,
+        phaseModels: phaseModels as PhaseModelConfig | undefined,
+        thinkingLevel: metadata?.thinkingLevel || settings.thinkingLevel,
         ...metadata
       };
 

--- a/apps/frontend/src/shared/constants/config.ts
+++ b/apps/frontend/src/shared/constants/config.ts
@@ -27,6 +27,7 @@ export const DEFAULT_APP_SETTINGS = {
   theme: 'system' as const,
   colorTheme: 'default' as const,
   defaultModel: 'opus',
+  thinkingLevel: 'medium' as const,  // Default thinking level for task execution
   agentFramework: 'auto-claude',
   pythonPath: undefined as string | undefined,
   gitPath: undefined as string | undefined,

--- a/apps/frontend/src/shared/types/settings.ts
+++ b/apps/frontend/src/shared/types/settings.ts
@@ -220,6 +220,7 @@ export interface AppSettings {
   theme: 'light' | 'dark' | 'system';
   colorTheme?: ColorTheme;
   defaultModel: string;
+  thinkingLevel?: ThinkingLevel;  // Default thinking level for task execution
   agentFramework: string;
   pythonPath?: string;
   gitPath?: string;


### PR DESCRIPTION
## Summary
- Read app settings when creating tasks
- Include model, isAutoProfile, phaseModels, and thinkingLevel in task_metadata.json
- Ensures backend uses user's configured model instead of hardcoded defaults

## Root Cause
When tasks were created, the TASK_CREATE handler was not reading or including model settings from UI (settings.json). This caused the backend's `get_phase_model()` to fall back to `DEFAULT_PHASE_MODELS` which is hardcoded to "sonnet" for all phases - even when users had configured "opus" in the UI.

## Changes
In `crud-handlers.ts` TASK_CREATE handler:
1. Import `readSettingsFile` from settings-utils
2. Read app settings when creating task
3. Build taskMetadata with model configuration:
   - `model`: from passed metadata > project settings > app settings > 'opus'
   - `isAutoProfile`: true if custom phase models exist
   - `phaseModels`: per-phase model config from settings
   - `thinkingLevel`: from metadata > app settings

## Test plan
- [x] Set `defaultModel: "opus"` in Auto-Claude settings
- [x] Create a new task
- [x] Check `task_metadata.json` includes model configuration
- [x] Start the task and verify Claude CLI is invoked with correct model

Fixes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added thinking level configuration to app settings (defaults to "medium") for controlling task execution behavior.
  * Tasks now inherit model and thinking level settings from task, project, or global app configuration (priority-based resolution).
  * Tasks expose model selection, per-phase model configs, and an auto-profile flag derived from resolved settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->