### PR TITLE
fix(windows): use subprocess.run and worktree fallback for Windows compatibility

### DIFF
--- a/apps/backend/core/worktree.py
+++ b/apps/backend/core/worktree.py
@@ -399,7 +399,15 @@ class WorktreeManager:
         """
         # Step 1: Create worktree without checking out files
         result = self._run_git(
-            ["worktree", "add", "--no-checkout", "-b", branch_name, str(worktree_path), start_point]
+            [
+                "worktree",
+                "add",
+                "--no-checkout",
+                "-b",
+                branch_name,
+                str(worktree_path),
+                start_point,
+            ]
         )
         if result.returncode != 0:
             return result
@@ -414,7 +422,9 @@ class WorktreeManager:
                 # Try alternative: git reset followed by checkout-index
                 reset_result = self._run_git(["reset", "HEAD"], cwd=worktree_path)
                 if reset_result.returncode == 0:
-                    result = self._run_git(["checkout-index", "-a", "-f"], cwd=worktree_path)
+                    result = self._run_git(
+                        ["checkout-index", "-a", "-f"], cwd=worktree_path
+                    )
 
         # Single cleanup point for any failure after worktree creation
         if result.returncode != 0:
@@ -578,7 +588,10 @@ class WorktreeManager:
         if result.returncode != 0:
             # On Windows, git worktree add can fail with "Could not reset index file" error.
             # Use fallback approach: create worktree without checkout, then populate it.
-            if sys.platform == "win32" and "could not reset index" in result.stderr.lower():
+            if (
+                sys.platform == "win32"
+                and "could not reset index" in result.stderr.lower()
+            ):
                 print("Standard worktree creation failed, trying Windows fallback...")
                 result = self._create_worktree_windows_fallback(
                     branch_name, worktree_path, start_point

--- a/apps/backend/core/worktree.py
+++ b/apps/backend/core/worktree.py
@@ -579,7 +579,7 @@ class WorktreeManager:
             # On Windows, git worktree add can fail with "Could not reset index file" error.
             # Use fallback approach: create worktree without checkout, then populate it.
             if sys.platform == "win32" and "could not reset index" in result.stderr.lower():
-                print(f"Standard worktree creation failed, trying Windows fallback...")
+                print("Standard worktree creation failed, trying Windows fallback...")
                 result = self._create_worktree_windows_fallback(
                     branch_name, worktree_path, start_point
                 )

--- a/apps/backend/core/worktree.py
+++ b/apps/backend/core/worktree.py
@@ -19,6 +19,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -378,6 +379,54 @@ class WorktreeManager:
             return "auto-claude"
         return None
 
+    def _create_worktree_windows_fallback(
+        self, branch_name: str, worktree_path: Path, start_point: str
+    ) -> subprocess.CompletedProcess:
+        """
+        Create a worktree using Windows-compatible fallback method.
+
+        On Windows, git worktree add can fail with "Could not reset index file" error.
+        This fallback uses --no-checkout followed by read-tree and checkout-index
+        to populate the worktree.
+
+        Args:
+            branch_name: Name of the branch to create
+            worktree_path: Path where worktree should be created
+            start_point: Git ref to base the worktree on
+
+        Returns:
+            CompletedProcess from the final git operation
+        """
+        # Step 1: Create worktree without checking out files
+        result = self._run_git(
+            ["worktree", "add", "--no-checkout", "-b", branch_name, str(worktree_path), start_point]
+        )
+        if result.returncode != 0:
+            return result
+
+        # Step 2: Read the tree into the worktree's index
+        result = self._run_git(["read-tree", "HEAD"], cwd=worktree_path)
+        if result.returncode != 0:
+            # Cleanup on failure
+            shutil.rmtree(worktree_path, ignore_errors=True)
+            self._run_git(["worktree", "prune"])
+            return result
+
+        # Step 3: Checkout files from the index
+        result = self._run_git(["checkout-index", "-a", "-f"], cwd=worktree_path)
+        if result.returncode != 0:
+            # Try alternative: git reset followed by checkout-index
+            reset_result = self._run_git(["reset", "HEAD"], cwd=worktree_path)
+            if reset_result.returncode == 0:
+                result = self._run_git(["checkout-index", "-a", "-f"], cwd=worktree_path)
+
+        if result.returncode != 0:
+            # Cleanup on failure
+            shutil.rmtree(worktree_path, ignore_errors=True)
+            self._run_git(["worktree", "prune"])
+
+        return result
+
     def _get_worktree_stats(self, spec_name: str) -> dict:
         """Get diff statistics for a worktree."""
         worktree_path = self.get_worktree_path(spec_name)
@@ -531,9 +580,21 @@ class WorktreeManager:
         )
 
         if result.returncode != 0:
-            raise WorktreeError(
-                f"Failed to create worktree for {spec_name}: {result.stderr}"
-            )
+            # On Windows, git worktree add can fail with "Could not reset index file" error.
+            # Use fallback approach: create worktree without checkout, then populate it.
+            if sys.platform == "win32" and "could not reset index" in result.stderr.lower():
+                print(f"Standard worktree creation failed, trying Windows fallback...")
+                result = self._create_worktree_windows_fallback(
+                    branch_name, worktree_path, start_point
+                )
+                if result.returncode != 0:
+                    raise WorktreeError(
+                        f"Failed to create worktree for {spec_name} (Windows fallback): {result.stderr}"
+                    )
+            else:
+                raise WorktreeError(
+                    f"Failed to create worktree for {spec_name}: {result.stderr}"
+                )
 
         print(f"Created worktree: {worktree_path.name} on branch {branch_name}")
 

--- a/apps/backend/runners/spec_runner.py
+++ b/apps/backend/runners/spec_runner.py
@@ -374,8 +374,13 @@ Examples:
             # On Windows, os.execv() spawns a new process instead of replacing the current one,
             # which causes issues with process management. Use subprocess.run() instead.
             if sys.platform == "win32":
-                result = subprocess.run(run_cmd)
-                sys.exit(result.returncode)
+                try:
+                    result = subprocess.run(run_cmd)
+                    sys.exit(result.returncode)
+                except KeyboardInterrupt:
+                    # Exit with standard Unix signal code for SIGINT (128 + 2)
+                    # Don't fall through to outer handler which shows spec continuation message
+                    sys.exit(130)
             else:
                 # On Unix, replace current process for cleaner process tree
                 os.execv(sys.executable, run_cmd)

--- a/apps/backend/runners/spec_runner.py
+++ b/apps/backend/runners/spec_runner.py
@@ -47,6 +47,7 @@ if sys.version_info < (3, 10):  # noqa: UP036
 import asyncio
 import io
 import os
+import subprocess
 from pathlib import Path
 
 # Configure safe encoding on Windows BEFORE any imports that might print
@@ -369,8 +370,15 @@ Examples:
             print(f"  {muted('Running:')} {' '.join(run_cmd)}")
             print()
 
-            # Execute run.py - replace current process
-            os.execv(sys.executable, run_cmd)
+            # Execute run.py
+            # On Windows, os.execv() spawns a new process instead of replacing the current one,
+            # which causes issues with process management. Use subprocess.run() instead.
+            if sys.platform == "win32":
+                result = subprocess.run(run_cmd)
+                sys.exit(result.returncode)
+            else:
+                # On Unix, replace current process for cleaner process tree
+                os.execv(sys.executable, run_cmd)
 
         sys.exit(0)
 


### PR DESCRIPTION
## Summary
- Fix `os.execv()` not working properly on Windows in spec_runner.py
- Add Windows fallback for git worktree creation in worktree.py

## Changes

### spec_runner.py
- Use `subprocess.run()` on Windows instead of `os.execv()`
- `os.execv()` spawns a new process on Windows instead of replacing current process
- Properly propagate exit code with `sys.exit(result.returncode)`

### worktree.py
- Add Windows fallback when `git worktree add` fails with "Could not reset index file"
- Uses: `git worktree add --no-checkout` + `git read-tree HEAD` + `git checkout-index -a -f`
- Falls back to `git reset HEAD` + `git checkout-index -a -f` if needed
- Proper cleanup on failure at each step

## Test plan
- [x] Test on Windows: spec creation and build execution
- [x] Test on Unix: ensure original behavior preserved
- [x] Verify worktree creation works on Windows with long paths

Fixes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows support for git worktree creation with improved multi-step workflows, ensuring operations succeed in scenarios where standard approaches encounter issues.
  * Optimized Windows-specific process execution for build operations and build scripts, utilizing enhanced subprocess management techniques for improved compatibility, stability, and overall process control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->