### PR TITLE
fix(windows): improve Claude CLI scan for paths with spaces

### DIFF
--- a/apps/frontend/src/main/cli-tool-manager.ts
+++ b/apps/frontend/src/main/cli-tool-manager.ts
@@ -957,7 +957,9 @@ class CLIToolManager {
         }
         const cmdExe = process.env.ComSpec
           || path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'cmd.exe');
-        const cmdLine = `""${unquotedCmd}" --version"`;
+        // Use chcp 65001 to set UTF-8 code page, then run the command with proper quoting.
+        // This prevents garbled error messages when paths contain special characters.
+        const cmdLine = `chcp 65001 >nul && ""${unquotedCmd}" --version"`;
         const execOptions: ExecFileSyncOptionsWithVerbatim = {
           encoding: 'utf-8',
           timeout: 5000,
@@ -1096,7 +1098,9 @@ class CLIToolManager {
         }
         const cmdExe = process.env.ComSpec
           || path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'cmd.exe');
-        const cmdLine = `""${unquotedCmd}" --version"`;
+        // Use chcp 65001 to set UTF-8 code page, then run the command with proper quoting.
+        // This prevents garbled error messages when paths contain special characters.
+        const cmdLine = `chcp 65001 >nul && ""${unquotedCmd}" --version"`;
         const execOptions: ExecFileAsyncOptionsWithVerbatim = {
           encoding: 'utf-8',
           timeout: 5000,

--- a/apps/frontend/src/main/cli-tool-manager.ts
+++ b/apps/frontend/src/main/cli-tool-manager.ts
@@ -959,7 +959,9 @@ class CLIToolManager {
           || path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'cmd.exe');
         // Use chcp 65001 to set UTF-8 code page, then run the command with proper quoting.
         // This prevents garbled error messages when paths contain special characters.
-        const cmdLine = `chcp 65001 >nul && ""${unquotedCmd}" --version"`;
+        // Note: We use simple double-quote wrapping since the command doesn't start with
+        // a quote (chcp prefix), so cmd.exe /s won't strip outer quotes.
+        const cmdLine = `chcp 65001 >nul && "${unquotedCmd}" --version`;
         const execOptions: ExecFileSyncOptionsWithVerbatim = {
           encoding: 'utf-8',
           timeout: 5000,
@@ -1100,7 +1102,9 @@ class CLIToolManager {
           || path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'cmd.exe');
         // Use chcp 65001 to set UTF-8 code page, then run the command with proper quoting.
         // This prevents garbled error messages when paths contain special characters.
-        const cmdLine = `chcp 65001 >nul && ""${unquotedCmd}" --version"`;
+        // Note: We use simple double-quote wrapping since the command doesn't start with
+        // a quote (chcp prefix), so cmd.exe /s won't strip outer quotes.
+        const cmdLine = `chcp 65001 >nul && "${unquotedCmd}" --version`;
         const execOptions: ExecFileAsyncOptionsWithVerbatim = {
           encoding: 'utf-8',
           timeout: 5000,

--- a/apps/frontend/src/main/utils/windows-paths.ts
+++ b/apps/frontend/src/main/utils/windows-paths.ts
@@ -156,12 +156,13 @@ export function findWindowsExecutableViaWhere(
     }).trim();
 
     // 'where' returns multiple paths separated by newlines if found in multiple locations
-    // Prefer paths with .cmd or .exe extensions (executable files)
+    // Only consider paths with .cmd, .bat, or .exe extensions - extensionless paths
+    // on Windows are not directly executable and cause ENOENT errors.
     const paths = result.split(/\r?\n/).filter(p => p.trim());
+    const executablePaths = paths.filter(p => /\.(cmd|bat|exe)$/i.test(p));
 
-    if (paths.length > 0) {
-      // Prefer .cmd, .bat, or .exe extensions, otherwise take first path
-      const foundPath = (paths.find(p => /\.(cmd|bat|exe)$/i.test(p)) || paths[0]).trim();
+    if (executablePaths.length > 0) {
+      const foundPath = executablePaths[0].trim();
 
       // Validate the path exists and is secure
       if (existsSync(foundPath) && isSecurePath(foundPath)) {
@@ -259,12 +260,13 @@ export async function findWindowsExecutableViaWhereAsync(
     });
 
     // 'where' returns multiple paths separated by newlines if found in multiple locations
-    // Prefer paths with .cmd, .bat, or .exe extensions (executable files)
+    // Only consider paths with .cmd, .bat, or .exe extensions - extensionless paths
+    // on Windows are not directly executable and cause ENOENT errors.
     const paths = stdout.trim().split(/\r?\n/).filter(p => p.trim());
+    const executablePaths = paths.filter(p => /\.(cmd|bat|exe)$/i.test(p));
 
-    if (paths.length > 0) {
-      // Prefer .cmd, .bat, or .exe extensions, otherwise take first path
-      const foundPath = (paths.find(p => /\.(cmd|bat|exe)$/i.test(p)) || paths[0]).trim();
+    if (executablePaths.length > 0) {
+      const foundPath = executablePaths[0].trim();
 
       // Validate the path exists and is secure
       try {


### PR DESCRIPTION
## Summary
- Skip extensionless paths from `where claude` on Windows
- Fix garbled error messages by setting UTF-8 code page

## Problem
When clicking "Claude Code" in the sidebar, the installation scan fails:
1. Tries to validate extensionless `D:\Program Files\...\claude` → ENOENT
2. Validates `claude.cmd` but stderr is garbled Chinese characters

## Solution

### 1. Filter extensionless paths
```typescript
// On Windows, skip extensionless paths - they're not directly executable.
// Only consider .cmd, .exe, .bat files which are the actual executables.
if (!/\.(cmd|exe|bat)$/i.test(trimmed)) {
  console.log('[Claude Code] Skipping non-executable path:', trimmed);
  continue;
}
```

### 2. Set UTF-8 code page
```typescript
// Use chcp 65001 to set UTF-8 code page before running command
const cmdLine = `chcp 65001 >nul && ""${cliPath}" --version"`;
```

## Test plan
- [x] Verify CLI scan works with paths containing spaces (e.g., `D:\Program Files\...`)
- [x] Verify no ENOENT errors for extensionless paths
- [x] Verify error messages are readable (not garbled)

Fixes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows UTF-8 handling for CLI version checks so output is no longer garbled (applies to sync and async flows).
  * Improved Windows CLI invocation to ensure proper quoting and encoding on CMD.
  * Improved executable detection to only consider .exe/.cmd/.bat, skipping extensionless entries to reduce false positives and ENOENT errors.

* **Tests**
  * Stabilized terminal copy/paste tests by using fake timers, deferring animation-frame callbacks, and adding proper timer cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->