### PR TITLE
fix(tests): isolate git operations in test fixtures from parent repository

### DIFF
--- a/tests/test_merge_fixtures.py
+++ b/tests/test_merge_fixtures.py
@@ -9,11 +9,12 @@ Contains:
 - Factory functions for creating test data
 """
 
+import os
 import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Generator
 from unittest.mock import MagicMock
 
 import pytest
@@ -164,7 +165,7 @@ class Greeter:
 # =============================================================================
 
 @pytest.fixture
-def temp_project(tmp_path: Path) -> Path:
+def temp_project(tmp_path: Path) -> Generator[Path, None, None]:
     """Create a temporary project directory with git repo.
 
     IMPORTANT: This fixture properly isolates git operations by clearing
@@ -221,7 +222,7 @@ def temp_project(tmp_path: Path) -> Path:
         # Ensure branch is named 'main' (some git configs default to 'master')
         subprocess.run(["git", "branch", "-M", "main"], cwd=tmp_path, capture_output=True)
 
-        return tmp_path
+        yield tmp_path
     finally:
         # Restore original environment variables
         for key, value in orig_env.items():

--- a/tests/test_merge_fixtures.py
+++ b/tests/test_merge_fixtures.py
@@ -165,34 +165,70 @@ class Greeter:
 
 @pytest.fixture
 def temp_project(tmp_path: Path) -> Path:
-    """Create a temporary project directory with git repo."""
-    # Initialize git repo
-    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@example.com"],
-        cwd=tmp_path, capture_output=True
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test User"],
-        cwd=tmp_path, capture_output=True
-    )
+    """Create a temporary project directory with git repo.
 
-    # Create initial files
-    (tmp_path / "src").mkdir()
-    (tmp_path / "src" / "App.tsx").write_text(SAMPLE_REACT_COMPONENT)
-    (tmp_path / "src" / "utils.py").write_text(SAMPLE_PYTHON_MODULE)
+    IMPORTANT: This fixture properly isolates git operations by clearing
+    git environment variables that may be set by pre-commit hooks. Without
+    this isolation, git operations could affect the parent repository when
+    tests run inside a git worktree (e.g., during pre-commit validation).
+    """
+    # Save original environment values to restore later
+    orig_env = {}
 
-    # Initial commit
-    subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        cwd=tmp_path, capture_output=True
-    )
+    # These git env vars may be set by pre-commit hooks and MUST be cleared
+    git_vars_to_clear = [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    ]
 
-    # Ensure branch is named 'main' (some git configs default to 'master')
-    subprocess.run(["git", "branch", "-M", "main"], cwd=tmp_path, capture_output=True)
+    # Clear interfering git environment variables
+    for key in git_vars_to_clear:
+        orig_env[key] = os.environ.get(key)
+        if key in os.environ:
+            del os.environ[key]
 
-    return tmp_path
+    # Set GIT_CEILING_DIRECTORIES to prevent git from discovering parent .git
+    orig_env["GIT_CEILING_DIRECTORIES"] = os.environ.get("GIT_CEILING_DIRECTORIES")
+    os.environ["GIT_CEILING_DIRECTORIES"] = str(tmp_path.parent)
+
+    try:
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=tmp_path, capture_output=True
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=tmp_path, capture_output=True
+        )
+
+        # Create initial files
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "App.tsx").write_text(SAMPLE_REACT_COMPONENT)
+        (tmp_path / "src" / "utils.py").write_text(SAMPLE_PYTHON_MODULE)
+
+        # Initial commit
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=tmp_path, capture_output=True
+        )
+
+        # Ensure branch is named 'main' (some git configs default to 'master')
+        subprocess.run(["git", "branch", "-M", "main"], cwd=tmp_path, capture_output=True)
+
+        return tmp_path
+    finally:
+        # Restore original environment variables
+        for key, value in orig_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 # =============================================================================

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -59,7 +59,7 @@ def setup_test_environment():
     os.environ["GIT_CEILING_DIRECTORIES"] = str(temp_dir)
 
     # Initialize git repo in project dir
-    subprocess.run(["git", "init"], cwd=project_dir, capture_output=True)
+    subprocess.run(["git", "init"], cwd=project_dir, capture_output=True, check=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=project_dir, capture_output=True)
     subprocess.run(["git", "config", "user.name", "Test User"], cwd=project_dir, capture_output=True)
 
@@ -69,26 +69,31 @@ def setup_test_environment():
     subprocess.run(["git", "add", "."], cwd=project_dir, capture_output=True)
     subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=project_dir, capture_output=True)
 
-    # Restore environment (note: caller should call cleanup which handles this)
-    for key, value in saved_env.items():
-        if value is None:
-            os.environ.pop(key, None)
-        else:
-            os.environ[key] = value
+    # Ensure branch is named 'main' (some git configs default to 'master')
+    subprocess.run(["git", "branch", "-M", "main"], cwd=project_dir, capture_output=True)
 
-    return temp_dir, spec_dir, project_dir
+    # Return saved_env so caller can restore it in cleanup
+    return temp_dir, spec_dir, project_dir, saved_env
 
 
-def cleanup_test_environment(temp_dir):
-    """Remove temporary directories."""
+def cleanup_test_environment(temp_dir, saved_env=None):
+    """Remove temporary directories and restore environment variables."""
     shutil.rmtree(temp_dir, ignore_errors=True)
+
+    # Restore original environment variables if provided
+    if saved_env is not None:
+        for key, value in saved_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def test_initialization():
     """Test RecoveryManager initialization."""
     print("TEST: Initialization")
 
-    temp_dir, spec_dir, project_dir = setup_test_environment()
+    temp_dir, spec_dir, project_dir, saved_env = setup_test_environment()
 
     try:
         manager = RecoveryManager(spec_dir, project_dir)
@@ -113,14 +118,14 @@ def test_initialization():
         print()
 
     finally:
-        cleanup_test_environment(temp_dir)
+        cleanup_test_environment(temp_dir, saved_env)
 
 
 def test_record_attempt():
     """Test recording chunk attempts."""
     print("TEST: Recording Attempts")
 
-    temp_dir, spec_dir, project_dir = setup_test_environment()
+    temp_dir, spec_dir, project_dir, saved_env = setup_test_environment()
 
     try:
         manager = RecoveryManager(spec_dir, project_dir)
@@ -162,14 +167,14 @@ def test_record_attempt():
         print()
 
     finally:
-        cleanup_test_environment(temp_dir)
+        cleanup_test_environment(temp_dir, saved_env)
 
 
 def test_circular_fix_detection():
     """Test circular fix detection."""
     print("TEST: Circular Fix Detection")
 
-    temp_dir, spec_dir, project_dir = setup_test_environment()
+    temp_dir, spec_dir, project_dir, saved_env = setup_test_environment()
 
     try:
         manager = RecoveryManager(spec_dir, project_dir)
@@ -194,14 +199,14 @@ def test_circular_fix_detection():
         print()
 
     finally:
-        cleanup_test_environment(temp_dir)
+        cleanup_test_environment(temp_dir, saved_env)
 
 
 def test_failure_classification():
     """Test failure type classification."""
     print("TEST: Failure Classification")
 
-    temp_dir, spec_dir, project_dir = setup_test_environment()
+    temp_dir, spec_dir, project_dir, saved_env = setup_test_environment()
 
     try:
         manager = RecoveryManager(spec_dir, project_dir)
@@ -224,14 +229,14 @@ def test_failure_classification():
         print()
 
     finally:
-        cleanup_test_environment(temp_dir)
+        cleanup_test_environment(temp_dir, saved_env)
 
 
 def test_recovery_action_determination():
     """Test recovery action determination."""
     print("TEST: Recovery Action Determination")
 
-    temp_dir, spec_dir, project_dir = setup_test_environment()
+    temp_dir, spec_dir, project_dir, saved_env = setup_test_environment()
 
     try:
         manager = RecoveryManager(spec_dir, project_dir)
@@ -264,14 +269,14 @@ def test_recovery_action_determination():
         print()
 
     finally:
-        cleanup_test_environment(temp_dir)
+        cleanup_test_environment(temp_dir, saved_env)
 
 
 def test_good_commit_tracking():
     """Test tracking of good commits."""
     print("TEST: Good Commit Tracking")
 
-    temp_dir, spec_dir, project_dir = setup_test_environment()
+    temp_dir, spec_dir, project_dir, saved_env = setup_test_environment()
 
     try:
         manager = RecoveryManager(spec_dir, project_dir)
@@ -317,14 +322,14 @@ def test_good_commit_tracking():
         print()
 
     finally:
-        cleanup_test_environment(temp_dir)
+        cleanup_test_environment(temp_dir, saved_env)
 
 
 def test_mark_subtask_stuck():
     """Test marking chunks as stuck."""
     print("TEST: Mark Chunk Stuck")
 
-    temp_dir, spec_dir, project_dir = setup_test_environment()
+    temp_dir, spec_dir, project_dir, saved_env = setup_test_environment()
 
     try:
         manager = RecoveryManager(spec_dir, project_dir)
@@ -351,14 +356,14 @@ def test_mark_subtask_stuck():
         print()
 
     finally:
-        cleanup_test_environment(temp_dir)
+        cleanup_test_environment(temp_dir, saved_env)
 
 
 def test_recovery_hints():
     """Test recovery hints generation."""
     print("TEST: Recovery Hints")
 
-    temp_dir, spec_dir, project_dir = setup_test_environment()
+    temp_dir, spec_dir, project_dir, saved_env = setup_test_environment()
 
     try:
         manager = RecoveryManager(spec_dir, project_dir)
@@ -383,7 +388,7 @@ def test_recovery_hints():
         print()
 
     finally:
-        cleanup_test_environment(temp_dir)
+        cleanup_test_environment(temp_dir, saved_env)
 
 
 def run_all_tests():


### PR DESCRIPTION
## Summary
- Fix test fixtures that run git operations without clearing environment variables set by pre-commit hooks
- When tests run inside a worktree during pre-commit validation, `GIT_DIR` and `GIT_WORK_TREE` env vars cause git operations to affect the parent repository instead of temp directories
- Applied consistent isolation pattern to `temp_git_repo`, `temp_project`, and `setup_test_environment` fixtures

## Root Cause
Pre-commit hook sets `GIT_DIR` and `GIT_WORK_TREE` → pytest inherits these → test fixtures use `subprocess.run(["git", ...], cwd=temp_dir)` → git uses env vars instead of `cwd` → test commits go to worktree instead of temp directory

## Changes
- `tests/conftest.py` - `temp_git_repo` fixture
- `tests/test_merge_fixtures.py` - `temp_project` fixture
- `tests/test_recovery.py` - `setup_test_environment` function

## Test plan
- [x] Verified tests pass after changes
- [x] Pattern matches existing isolation in `test_pr_worktree_manager.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixtures converted to yield-based setup/teardown and updated return values for better cleanup.
  * Expanded git/environment isolation to prevent parent-repo interference and ensure deterministic test runs.
  * Environment state is now saved and reliably restored after tests to avoid cross-test pollution.
  * Updated test helpers and signatures to propagate and handle saved environment information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->