### PR TITLE
fix(windows): add Node.js path detection for claude.cmd validation

### DIFF
--- a/apps/frontend/src/main/platform/index.ts
+++ b/apps/frontend/src/main/platform/index.ts
@@ -18,7 +18,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { OS, ShellType, PathConfig, ShellConfig, BinaryDirectories } from './types';
 
 // Re-export from paths.ts for backward compatibility
-export { getWindowsShellPaths } from './paths';
+export { getWindowsShellPaths, findNodeJsDirectories } from './paths';
 
 /**
  * Get the current operating system

--- a/apps/frontend/src/main/platform/index.ts
+++ b/apps/frontend/src/main/platform/index.ts
@@ -502,3 +502,43 @@ export function killProcessGracefully(
     forceKillTimer.unref();
   }
 }
+
+/**
+ * Sort NVM version directories by semantic version (newest first)
+ *
+ * Filters directory entries to only valid semver directories (e.g., v20.0.0)
+ * and sorts them in descending order so newer versions are tried first.
+ *
+ * @param entries - Directory entries from readdirSync with withFileTypes
+ * @returns Array of directory names sorted by version (newest first)
+ *
+ * @example
+ * const entries = [
+ *   { name: 'v18.0.0', isDirectory: () => true },
+ *   { name: 'v20.0.0', isDirectory: () => true },
+ *   { name: '.DS_Store', isDirectory: () => false },
+ * ];
+ * sortNvmVersionDirs(entries); // ['v20.0.0', 'v18.0.0']
+ */
+export function sortNvmVersionDirs(
+  entries: Array<{ name: string; isDirectory(): boolean }>
+): string[] {
+  // Regex to match valid semver directories: v20.0.0, v18.17.1, etc.
+  // This prevents NaN from malformed versions (e.g., v20.abc.1) breaking sort
+  const semverRegex = /^v\d+\.\d+\.\d+$/;
+
+  return entries
+    .filter((entry) => entry.isDirectory() && semverRegex.test(entry.name))
+    .sort((a, b) => {
+      // Parse version numbers: v20.0.0 -> [20, 0, 0]
+      const vA = a.name.slice(1).split('.').map(Number);
+      const vB = b.name.slice(1).split('.').map(Number);
+      // Compare major, minor, patch in order (descending)
+      for (let i = 0; i < 3; i++) {
+        const diff = (vB[i] ?? 0) - (vA[i] ?? 0);
+        if (diff !== 0) return diff;
+      }
+      return 0;
+    })
+    .map((entry) => entry.name);
+}

--- a/apps/frontend/src/main/platform/index.ts
+++ b/apps/frontend/src/main/platform/index.ts
@@ -18,7 +18,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { OS, ShellType, PathConfig, ShellConfig, BinaryDirectories } from './types';
 
 // Re-export from paths.ts for backward compatibility
-export { getWindowsShellPaths, findNodeJsDirectories } from './paths';
+export { getWindowsShellPaths, findNodeJsDirectories, sortNvmVersionDirs } from './paths';
 
 /**
  * Get the current operating system
@@ -503,42 +503,3 @@ export function killProcessGracefully(
   }
 }
 
-/**
- * Sort NVM version directories by semantic version (newest first)
- *
- * Filters directory entries to only valid semver directories (e.g., v20.0.0)
- * and sorts them in descending order so newer versions are tried first.
- *
- * @param entries - Directory entries from readdirSync with withFileTypes
- * @returns Array of directory names sorted by version (newest first)
- *
- * @example
- * const entries = [
- *   { name: 'v18.0.0', isDirectory: () => true },
- *   { name: 'v20.0.0', isDirectory: () => true },
- *   { name: '.DS_Store', isDirectory: () => false },
- * ];
- * sortNvmVersionDirs(entries); // ['v20.0.0', 'v18.0.0']
- */
-export function sortNvmVersionDirs(
-  entries: Array<{ name: string; isDirectory(): boolean }>
-): string[] {
-  // Regex to match valid semver directories: v20.0.0, v18.17.1, etc.
-  // This prevents NaN from malformed versions (e.g., v20.abc.1) breaking sort
-  const semverRegex = /^v\d+\.\d+\.\d+$/;
-
-  return entries
-    .filter((entry) => entry.isDirectory() && semverRegex.test(entry.name))
-    .sort((a, b) => {
-      // Parse version numbers: v20.0.0 -> [20, 0, 0]
-      const vA = a.name.slice(1).split('.').map(Number);
-      const vB = b.name.slice(1).split('.').map(Number);
-      // Compare major, minor, patch in order (descending)
-      for (let i = 0; i < 3; i++) {
-        const diff = (vB[i] ?? 0) - (vA[i] ?? 0);
-        if (diff !== 0) return diff;
-      }
-      return 0;
-    })
-    .map((entry) => entry.name);
-}

--- a/apps/frontend/src/main/platform/paths.ts
+++ b/apps/frontend/src/main/platform/paths.ts
@@ -228,6 +228,9 @@ export function findNodeJsDirectories(): string[] {
   const programFilesX86 = process.env['ProgramFiles(x86)'];
   const appData = process.env.APPDATA;
   const programData = process.env.ProgramData;
+  // NVM for Windows custom installation paths
+  const nvmHome = process.env.NVM_HOME;
+  const nvmSymlink = process.env.NVM_SYMLINK;
 
   const candidates: string[] = [];
 
@@ -254,8 +257,15 @@ export function findNodeJsDirectories(): string[] {
     candidates.push(joinPaths(programData, 'chocolatey', 'bin'));
   }
 
-  // For NVM, we need to find the active Node.js version directory
-  const nvmPath = appData ? joinPaths(appData, 'nvm') : null;
+  // NVM for Windows: prefer NVM_SYMLINK (active version) and NVM_HOME (custom install path)
+  // Fall back to default APPDATA/nvm location if env vars not set
+  if (nvmSymlink) {
+    // NVM_SYMLINK points directly to the active Node.js version
+    candidates.push(nvmSymlink);
+  }
+
+  // Determine NVM root directory: prefer NVM_HOME, fall back to APPDATA/nvm
+  const nvmPath = nvmHome || (appData ? joinPaths(appData, 'nvm') : null);
   if (nvmPath && existsSync(nvmPath)) {
     try {
       // Find all version directories (e.g., v20.0.0, v18.17.1)

--- a/apps/frontend/src/main/platform/paths.ts
+++ b/apps/frontend/src/main/platform/paths.ts
@@ -184,27 +184,33 @@ export function findNodeJsDirectories(): string[] {
   }
 
   const homeDir = os.homedir();
+  // Use environment variables with fallbacks for cross-system compatibility
+  const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
+  const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
+  const appData = process.env.APPDATA || joinPaths(homeDir, 'AppData', 'Roaming');
+  const programData = process.env.ProgramData || 'C:\\ProgramData';
+
   const candidates: string[] = [
     // Standard Node.js installer location
-    joinPaths('C:\\Program Files', 'nodejs'),
-    joinPaths('C:\\Program Files (x86)', 'nodejs'),
+    joinPaths(programFiles, 'nodejs'),
+    joinPaths(programFilesX86, 'nodejs'),
 
     // User-level npm global directory (may contain node.exe with nvm-windows)
-    joinPaths(homeDir, 'AppData', 'Roaming', 'npm'),
+    joinPaths(appData, 'npm'),
 
     // NVM for Windows default location
-    joinPaths(homeDir, 'AppData', 'Roaming', 'nvm'),
-    joinPaths('C:\\Program Files', 'nvm'),
+    joinPaths(appData, 'nvm'),
+    joinPaths(programFiles, 'nvm'),
 
     // Scoop installation
     joinPaths(homeDir, 'scoop', 'apps', 'nodejs', 'current'),
 
     // Chocolatey installation
-    joinPaths('C:\\ProgramData', 'chocolatey', 'bin'),
+    joinPaths(programData, 'chocolatey', 'bin'),
   ];
 
   // For NVM, we need to find the active Node.js version directory
-  const nvmPath = joinPaths(homeDir, 'AppData', 'Roaming', 'nvm');
+  const nvmPath = joinPaths(appData, 'nvm');
   if (existsSync(nvmPath)) {
     try {
       // Find all version directories (e.g., v20.0.0, v18.17.1)


### PR DESCRIPTION
## Problem

Windows users with Claude CLI installed via npm (as `claude.cmd`) experience detection failures because `claude.cmd` requires Node.js to be in PATH to execute.

## Solution

Added automatic Node.js directory detection on Windows and augmented PATH when validating/running `.cmd` files.

### Changes:
- Added `findNodeJsDirectories()` to detect Node.js installations (standard installer, NVM, Scoop, Chocolatey)
- Updated Claude CLI validation to include Node.js paths when validating `.cmd` files
- Applies to: cli-tool-manager.ts, claude-code-handlers.ts, claude-cli-utils.ts

## Testing

Tested on Windows 11 with Claude CLI installed via `npm install -g @anthropic-ai/claude-code`

**Before:** Claude CLI not detected, `node is not recognized` errors
**After:** Claude CLI properly detected and validated

## Technical Details

The fix detects Node.js installations from:
- Standard installer locations (`C:\Program Files\nodejs`)
- npm global directory (`%APPDATA%\npm`)
- NVM for Windows (finds newest version automatically)
- Scoop and Chocolatey installations

When validating `claude.cmd`, the fix automatically adds these directories to PATH so `node.exe` can be found.

---

This improves Windows user experience significantly, eliminating a common setup pain point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows PATH augmentation: Node.js installation directories are detected and appended when needed, and only missing entries are added.

* **Other**
  * PATH construction now aggregates necessary directories instead of always prepending a single directory.
  * Centralized and re-exported version-directory sorting and Node.js discovery utilities for platform detection.

* **Tests**
  * Updated platform-aware tests to simulate Windows/macOS/Linux scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->