### PR TITLE
fix(auth): add OAuth token format validation to prevent 401 errors

### DIFF
--- a/apps/frontend/src/main/claude-profile/token-encryption.ts
+++ b/apps/frontend/src/main/claude-profile/token-encryption.ts
@@ -24,8 +24,9 @@ export function encryptToken(token: string): string {
 
 /**
  * Decrypt a token. Handles both encrypted (enc:...) and legacy plain tokens.
+ * Returns undefined if decryption fails, allowing callers to handle the failure appropriately.
  */
-export function decryptToken(storedToken: string): string {
+export function decryptToken(storedToken: string): string | undefined {
   try {
     if (storedToken.startsWith('enc:') && safeStorage.isEncryptionAvailable()) {
       const encryptedData = Buffer.from(storedToken.slice(4), 'base64');
@@ -33,7 +34,7 @@ export function decryptToken(storedToken: string): string {
     }
   } catch (error) {
     console.error('[TokenEncryption] Failed to decrypt token:', error);
-    return ''; // Return empty string on decryption failure
+    return undefined; // Return undefined on decryption failure
   }
   // Return as-is for legacy unencrypted tokens
   return storedToken;

--- a/apps/frontend/src/main/title-generator.ts
+++ b/apps/frontend/src/main/title-generator.ts
@@ -138,12 +138,15 @@ export class TitleGenerator extends EventEmitter {
     debug('Generating title for description:', description.substring(0, 100) + '...');
 
     const autoBuildEnv = this.loadAutoBuildEnv();
-    debug('Environment loaded', {
-      hasOAuthToken: !!autoBuildEnv.CLAUDE_CODE_OAUTH_TOKEN
-    });
-
-    // Get active Claude profile environment (CLAUDE_CONFIG_DIR if not default)
     const profileEnv = getProfileEnv();
+
+    // Log token sources for debugging (masked for security)
+    const maskToken = (t: string | undefined) => t ? `${t.substring(0, 15)}...` : 'none';
+    debug('Token sources:', {
+      autoBuildEnv: maskToken(autoBuildEnv.CLAUDE_CODE_OAUTH_TOKEN),
+      profileEnv: maskToken(profileEnv.CLAUDE_CODE_OAUTH_TOKEN),
+      effectiveSource: profileEnv.CLAUDE_CODE_OAUTH_TOKEN ? 'profile' : (autoBuildEnv.CLAUDE_CODE_OAUTH_TOKEN ? 'autoBuildEnv' : 'none')
+    });
 
     return new Promise((resolve) => {
       // Parse Python command to handle space-separated commands like "py -3"


### PR DESCRIPTION
## Summary
- Add `isValidTokenFormat()` helper to validate OAuth token format (must match `sk-ant-oat01-` pattern)
- Update `hasValidToken()` to validate token format before use
- Validate token format in `setProfileToken()` before storage
- Validate decrypted tokens in `getProfileEnv()` and `getActiveProfileEnv()`
- Return `undefined` instead of empty string on decryption failure for better error handling
- Add token source debug logging for troubleshooting authentication issues

## Test plan
- [x] TypeScript typecheck passes
- [x] Manual testing confirmed 401 errors are resolved when valid token is configured
- [x] Code review completed with 4 specialized agents (code-reviewer, comment-analyzer, type-design-analyzer, silent-failure-hunter)
- [ ] Verify invalid tokens are rejected with clear error messages
- [ ] Verify valid tokens from .env are used when profile token is invalid

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token format validation now prevents invalid tokens from being stored or used.
  * Improved error handling during token decryption with proper fallback to alternative authentication methods.
  * Profile configuration backward compatibility restored when tokens are unavailable or invalid.

* **Improvements**
  * Enhanced debug logging with masked token information and authentication source tracking for troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->