### PR TITLE
fix: Replace hardcoded token limits with model-specific configuration

### DIFF
--- a/apps/backend/model_limits.json
+++ b/apps/backend/model_limits.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "model_limits_schema.json",
+  "description": "Model-specific token limits for Claude API. All values are in tokens.",
+  "models": {
+    "claude-opus-4-5-20251101": {
+      "display_name": "Claude Opus 4.5",
+      "max_output_tokens": 64000,
+      "context_window": 200000,
+      "max_thinking_tokens": 60000,
+      "notes": "Maximum output increased from 32K (Opus 4.1) to 64K"
+    },
+    "claude-sonnet-4-5-20250929": {
+      "display_name": "Claude Sonnet 4.5",
+      "max_output_tokens": 64000,
+      "context_window": 200000,
+      "max_thinking_tokens": 60000,
+      "notes": "Standard output limit, 1M context available in beta"
+    },
+    "claude-haiku-4-5-20251001": {
+      "display_name": "Claude Haiku 4.5",
+      "max_output_tokens": 64000,
+      "context_window": 200000,
+      "max_thinking_tokens": 60000,
+      "notes": "Output increased from 8K (Haiku 3.5) to 64K"
+    }
+  },
+  "thinking_levels": {
+    "none": {
+      "budget": null,
+      "description": "No extended thinking"
+    },
+    "low": {
+      "budget": 1024,
+      "description": "Brief consideration (1K tokens)"
+    },
+    "medium": {
+      "budget": 4096,
+      "description": "Moderate analysis (4K tokens)"
+    },
+    "high": {
+      "budget": 16384,
+      "description": "Deep thinking for complex tasks (16K tokens)"
+    },
+    "ultrathink": {
+      "budget": 60000,
+      "description": "Maximum reasoning depth (60K tokens, leaves 4K buffer for SDK overhead)",
+      "safety_note": "SDK may reduce max_tokens, so we keep 4K buffer below the 64K limit"
+    }
+  },
+  "validation_rules": {
+    "max_thinking_tokens_must_be_less_than_max_output": true,
+    "min_thinking_budget": 1024,
+    "safety_buffer_tokens": 4000,
+    "notes": "API constraint: max_tokens > thinking.budget_tokens. SDK bug #8756 causes intermittent validation errors when max_tokens is reduced without adjusting thinking budget."
+  }
+}

--- a/apps/frontend/src/shared/constants/models.ts
+++ b/apps/frontend/src/shared/constants/models.ts
@@ -23,12 +23,33 @@ export const MODEL_ID_MAP: Record<string, string> = {
 } as const;
 
 // Maps thinking levels to budget tokens (null = no extended thinking)
+// Must match apps/backend/model_limits.json thinking_levels
 export const THINKING_BUDGET_MAP: Record<string, number | null> = {
   none: null,
   low: 1024,
   medium: 4096,
   high: 16384,
-  ultrathink: 63999 // Maximum reasoning depth (API requires max_tokens >= budget + 1, so 63999 + 1 = 64000 limit)
+  ultrathink: 60000 // Maximum reasoning depth (leaves 4K buffer for SDK overhead, keeps max_tokens under 64K for all Claude 4.5 models)
+} as const;
+
+// Model-specific output token limits (all Claude 4.5 models have 64K max_tokens)
+export const MODEL_OUTPUT_LIMITS: Record<string, number> = {
+  'claude-opus-4-5-20251101': 64000,
+  'claude-sonnet-4-5-20250929': 64000,
+  'claude-haiku-4-5-20251001': 64000,
+  opus: 64000,
+  sonnet: 64000,
+  haiku: 64000
+} as const;
+
+// Maximum safe thinking budget for each model (leaves buffer for SDK overhead)
+export const MODEL_MAX_THINKING: Record<string, number> = {
+  'claude-opus-4-5-20251101': 60000,
+  'claude-sonnet-4-5-20250929': 60000,
+  'claude-haiku-4-5-20251001': 60000,
+  opus: 60000,
+  sonnet: 60000,
+  haiku: 60000
 } as const;
 
 // ============================================

--- a/tests/test_model_limits.py
+++ b/tests/test_model_limits.py
@@ -1,0 +1,152 @@
+"""
+Tests for model-specific limits and validation in phase_config module.
+
+Ensures that thinking budgets are properly validated against model limits
+and that the configuration system correctly handles model-specific constraints.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+# Add auto-claude to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "apps" / "backend"))
+
+from phase_config import (
+    get_model_max_output_tokens,
+    get_model_max_thinking_tokens,
+    get_thinking_budget,
+    validate_thinking_budget,
+)
+
+
+class TestModelLimits:
+    """Test model-specific token limits and validation."""
+
+    def test_all_models_have_64k_output_limit(self):
+        """Test that all Claude 4.5 models have 64,000 max_tokens limit."""
+        models = [
+            "claude-opus-4-5-20251101",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5-20251001",
+        ]
+
+        for model_id in models:
+            max_output = get_model_max_output_tokens(model_id)
+            assert (
+                max_output == 64000
+            ), f"{model_id} should have 64000 max_tokens, got {max_output}"
+
+    def test_all_models_have_60k_thinking_limit(self):
+        """Test that all models have 60,000 max thinking tokens (4K buffer)."""
+        models = [
+            "claude-opus-4-5-20251101",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5-20251001",
+        ]
+
+        for model_id in models:
+            max_thinking = get_model_max_thinking_tokens(model_id)
+            assert (
+                max_thinking == 60000
+            ), f"{model_id} should have 60000 max thinking tokens, got {max_thinking}"
+
+    def test_unknown_model_uses_defaults(self):
+        """Test that unknown models default to 64K output and 60K thinking."""
+        unknown_model = "claude-unknown-model-v99"
+
+        max_output = get_model_max_output_tokens(unknown_model)
+        max_thinking = get_model_max_thinking_tokens(unknown_model)
+
+        assert max_output == 64000, "Unknown model should default to 64000 max_tokens"
+        assert (
+            max_thinking == 60000
+        ), "Unknown model should default to 60000 max thinking tokens"
+
+    def test_validate_thinking_budget_within_limits(self):
+        """Test that valid thinking budgets pass validation unchanged."""
+        model_id = "claude-opus-4-5-20251101"
+        budgets = [1024, 4096, 16384, 50000, 60000]
+
+        for budget in budgets:
+            result, was_capped = validate_thinking_budget(budget, model_id)
+            assert result == budget, f"Budget {budget} should not be modified"
+            assert not was_capped, f"Budget {budget} should not be capped"
+
+    def test_validate_thinking_budget_caps_excessive_budget(self, caplog):
+        """Test that thinking budgets exceeding model limits are capped."""
+        model_id = "claude-opus-4-5-20251101"
+        excessive_budgets = [60001, 63999, 64000, 100000]
+
+        with caplog.at_level(logging.WARNING):
+            for budget in excessive_budgets:
+                result, was_capped = validate_thinking_budget(budget, model_id)
+                assert result == 60000, f"Budget {budget} should be capped to 60000"
+                assert was_capped, f"Budget {budget} should be flagged as capped"
+
+            # Should have logged warnings for each excessive budget
+            assert len(caplog.records) == len(excessive_budgets)
+            for record in caplog.records:
+                assert "exceeds model limit" in record.message
+
+    def test_validate_thinking_budget_handles_none(self):
+        """Test that None thinking budget passes through validation."""
+        model_id = "claude-opus-4-5-20251101"
+        result, was_capped = validate_thinking_budget(None, model_id)
+
+        assert result is None, "None budget should pass through unchanged"
+        assert not was_capped, "None budget should not be flagged as capped"
+
+    def test_get_thinking_budget_with_model_validation(self, caplog):
+        """Test that get_thinking_budget validates against model limits when model_id provided."""
+        model_id = "claude-opus-4-5-20251101"
+
+        # Normal levels should work fine
+        budget = get_thinking_budget("low", model_id=model_id)
+        assert budget == 1024
+
+        budget = get_thinking_budget("medium", model_id=model_id)
+        assert budget == 4096
+
+        budget = get_thinking_budget("high", model_id=model_id)
+        assert budget == 16384
+
+        # Ultrathink should be capped at 60000 (not exceed it)
+        budget = get_thinking_budget("ultrathink", model_id=model_id)
+        assert budget == 60000
+
+    def test_get_thinking_budget_without_model_validation(self):
+        """Test that get_thinking_budget works without model_id (backward compatibility)."""
+        # Should work without model_id parameter
+        budget = get_thinking_budget("low")
+        assert budget == 1024
+
+        budget = get_thinking_budget("ultrathink")
+        assert budget == 60000
+
+    def test_thinking_budget_leaves_buffer_for_sdk(self):
+        """Test that max thinking budget leaves adequate buffer for SDK overhead."""
+        model_id = "claude-opus-4-5-20251101"
+        max_output = get_model_max_output_tokens(model_id)
+        max_thinking = get_model_max_thinking_tokens(model_id)
+
+        # Buffer should be at least 4000 tokens (mentioned in model_limits.json)
+        buffer = max_output - max_thinking
+        assert buffer >= 4000, f"Buffer should be at least 4K tokens, got {buffer}"
+
+    def test_api_constraint_satisfied(self):
+        """Test that thinking budget is strictly less than max_tokens (API constraint)."""
+        model_id = "claude-opus-4-5-20251101"
+        max_output = get_model_max_output_tokens(model_id)
+        max_thinking = get_model_max_thinking_tokens(model_id)
+
+        # API constraint: max_tokens > thinking.budget_tokens
+        assert (
+            max_thinking < max_output
+        ), f"thinking budget ({max_thinking}) must be < max_tokens ({max_output})"
+
+        # Also test with ultrathink budget
+        ultrathink_budget = get_thinking_budget("ultrathink", model_id=model_id)
+        assert (
+            ultrathink_budget < max_output
+        ), f"ultrathink ({ultrathink_budget}) must be < max_tokens ({max_output})"

--- a/tests/test_thinking_level_validation.py
+++ b/tests/test_thinking_level_validation.py
@@ -32,8 +32,8 @@ class TestThinkingLevelValidation:
         assert get_thinking_budget("none") is None
 
     def test_ultrathink_max_budget(self):
-        """Test that 'ultrathink' returns maximum budget (63999 so max_tokens = 63999 + 1 = 64000 limit)."""
-        assert get_thinking_budget("ultrathink") == 63999
+        """Test that 'ultrathink' returns maximum budget (60000 to keep max_tokens under 64000 with 4K SDK buffer)."""
+        assert get_thinking_budget("ultrathink") == 60000
 
     def test_invalid_level_logs_warning(self, caplog):
         """Test that invalid thinking level logs a warning."""
@@ -89,4 +89,4 @@ class TestThinkingLevelValidation:
         assert get_thinking_budget("low") == 1024
         assert get_thinking_budget("medium") == 4096
         assert get_thinking_budget("high") == 16384
-        assert get_thinking_budget("ultrathink") == 63999
+        assert get_thinking_budget("ultrathink") == 60000


### PR DESCRIPTION
## Problem

Spec creation was failing with `max_tokens: 65537 > 64000` error for Claude Opus 4.5. The codebase had magic numbers scattered throughout (62000, 63999, 64000) with no validation against model-specific limits.

## Root Cause

1. **Magic numbers**: Token limits hardcoded in multiple files
2. **No model validation**: Thinking budgets not validated against model-specific limits
3. **SDK bug workaround needed**: [Issue #8756](https://github.com/anthropics/claude-code/issues/8756) - SDK sometimes reduces max_tokens without adjusting thinking budget

## Solution

Created a comprehensive model-specific configuration system:

### Changes

- **apps/backend/model_limits.json**: New configuration file with all Claude 4.5 model limits
  - All models: 64K max_output_tokens (Opus, Sonnet, Haiku 4.5)
  - Safe thinking budget: 60K tokens (leaves 4K buffer for SDK overhead)
  - Documents validation rules and SDK bug workaround

- **apps/backend/phase_config.py**: Load limits from config, add validation
  - `get_model_max_output_tokens()`: Get model's max_tokens limit
  - `get_model_max_thinking_tokens()`: Get safe thinking budget
  - `validate_thinking_budget()`: Caps budgets to model limits with warnings
  - All thinking budget calls now validate against model limits

- **apps/frontend/src/shared/constants/models.ts**: Add model limit constants
  - `MODEL_OUTPUT_LIMITS`: 64K for all models
  - `MODEL_MAX_THINKING`: 60K safe limit
  - Updated `THINKING_BUDGET_MAP` ultrathink to 60K

- **tests/test_model_limits.py**: New comprehensive tests (10 tests)
  - Validates all models have correct limits
  - Tests budget capping for excessive values
  - Tests API constraint (thinking < max_tokens)
  - Tests 4K+ buffer for SDK overhead

- **tests/test_thinking_level_validation.py**: Updated ultrathink budget to 60K

### Technical Details

- **API constraint**: max_tokens > thinking.budget_tokens (strictly greater)
- **All Claude 4.5 models**: 64K max output, 200K context window
- **Safe thinking budget**: 60K tokens (4K buffer for SDK overhead)
- **Graceful degradation**: Warns and caps excessive budgets instead of failing

### Why 60,000 instead of 63,999?

- Model limit: 64,000 max_tokens
- SDK overhead: ~4,000 tokens buffer needed
- Safe budget: 60,000 tokens
- Prevents `max_tokens: 65537 > 64000` error

## Testing

✅ All 19 tests pass (9 existing + 10 new)
- Validates budget capping
- Validates API constraints  
- Validates buffer requirements
- Backward compatibility maintained

## References

- [Claude 4.5 Models Documentation](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-5)
- [Extended Thinking Documentation](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)
- [SDK Bug #8756](https://github.com/anthropics/claude-code/issues/8756)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model-specific token limits now enforced across the system (64,000 output, 60,000 thinking budget)
  * Added validation to cap thinking budgets within model constraints and log warnings when limits are exceeded

* **Tests**
  * Added comprehensive test coverage for model limits and thinking budget validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->