### PR TITLE
fix: prefer source backend over stale settings path in dev mode

### DIFF
--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -304,6 +304,28 @@ app.whenReady().then(() => {
     // Validate and migrate autoBuildPath - must contain runners/spec_runner.py
     // Uses EAFP pattern (try/catch with accessSync) instead of existsSync to avoid TOCTOU race conditions
     let validAutoBuildPath = settings.autoBuildPath;
+
+    // DEV MODE FIX: When running in development (not packaged), prefer the source backend
+    // over any stale path saved in settings (e.g., from a previously installed packaged app).
+    // This prevents confusing errors when `npm run dev` uses a venv without required dependencies.
+    if (!app.isPackaged) {
+      const sourceBackendPath = resolve(__dirname, '..', '..', '..', 'backend');
+      const sourceSpecRunnerPath = join(sourceBackendPath, 'runners', 'spec_runner.py');
+      let sourceBackendExists = false;
+      try {
+        accessSync(sourceSpecRunnerPath);
+        sourceBackendExists = true;
+      } catch {
+        // Source backend doesn't exist
+      }
+
+      if (sourceBackendExists && validAutoBuildPath !== sourceBackendPath) {
+        console.log('[main] Dev mode detected - preferring source backend over settings');
+        console.log('[main]   Settings path:', validAutoBuildPath);
+        console.log('[main]   Source path:', sourceBackendPath);
+        validAutoBuildPath = sourceBackendPath;
+      }
+    }
     if (validAutoBuildPath) {
       const specRunnerPath = join(validAutoBuildPath, 'runners', 'spec_runner.py');
       let specRunnerExists = false;


### PR DESCRIPTION
## Summary
- When running `npm run dev` after previously using the packaged DMG, `settings.json` may retain `autoBuildPath` pointing to the packaged app's backend
- This causes confusing errors like "require is not defined" in Graphiti setup because the wrong Python venv is used
- This fix detects dev mode and automatically prefers the source backend when available

## The Problem
1. User installs Auto-Claude from DMG
2. User later clones source and runs `npm run dev`
3. `settings.json` still points to `/Applications/Auto-Claude.app/Contents/Resources/backend`
4. Dev mode uses the packaged venv instead of source venv
5. Missing/mismatched dependencies cause cryptic errors

## The Fix
Added dev-mode detection in `apps/frontend/src/main/index.ts`:
- Checks `!app.isPackaged` to detect dev mode
- Validates source backend exists at `../../../backend`
- If source backend exists and differs from settings, prefers source backend
- Logs informative messages when overriding

No changes to packaged app behavior.

## Test plan
- [x] Verify settings.json has stale path pointing to packaged app backend
- [x] Run `npm run dev`
- [x] Confirm logs show dev mode detection and override
- [x] Verify Graphiti setup works correctly with source backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed development build path resolution to correctly locate the Python backend from source code, improving the development experience when running in non-packaged mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->