### PR TITLE
fix(auth): auto-sync OAuth tokens from system credentials

### DIFF
--- a/apps/frontend/src/__tests__/integration/subprocess-spawn.test.ts
+++ b/apps/frontend/src/__tests__/integration/subprocess-spawn.test.ts
@@ -66,7 +66,10 @@ const mockProfileManager = {
   getProfile: (_profileId: string) => mockProfile,
   // Token decryption methods - return mock token for tests
   getActiveProfileToken: () => 'mock-decrypted-token-for-testing',
-  getProfileToken: (_profileId: string) => 'mock-decrypted-token-for-testing'
+  getProfileToken: (_profileId: string) => 'mock-decrypted-token-for-testing',
+  // Token expiration methods - mock as non-expired for tests
+  isActiveTokenExpired: () => false,
+  syncProfileTokenFromSystem: (_profileId: string) => true
 };
 
 vi.mock('../../main/claude-profile-manager', () => ({

--- a/apps/frontend/src/main/__tests__/rate-limit-detector.test.ts
+++ b/apps/frontend/src/main/__tests__/rate-limit-detector.test.ts
@@ -18,7 +18,10 @@ vi.mock('../claude-profile-manager', () => ({
       isDefault: true
     })),
     getBestAvailableProfile: vi.fn(() => null),
-    recordRateLimitEvent: vi.fn()
+    recordRateLimitEvent: vi.fn(),
+    // Token expiration methods - mock as non-expired for tests
+    isActiveTokenExpired: vi.fn(() => false),
+    syncProfileTokenFromSystem: vi.fn(() => false)
   }))
 }));
 

--- a/apps/frontend/src/main/claude-profile/profile-utils.ts
+++ b/apps/frontend/src/main/claude-profile/profile-utils.ts
@@ -236,11 +236,16 @@ export function getTokenFromSystemCredentials(configDir?: string): SystemCredent
  * Check if a token from system credentials is expired.
  *
  * @param expiresAt - The expiration timestamp in milliseconds
- * @returns true if the token is expired or will expire in the next 5 minutes
+ * @returns true if the token is expired or will expire in the next 5 minutes.
+ *          Returns false if no expiration is provided (backward compatibility
+ *          for tokens without expiration tracking, e.g., legacy or manually-set tokens).
  */
 export function isTokenExpired(expiresAt?: number): boolean {
   if (!expiresAt) {
-    // If no expiration, assume it's valid
+    // No expiration timestamp means either:
+    // 1. Legacy token without expiration tracking
+    // 2. Manually-set token without server-provided expiration
+    // Assume valid to maintain backward compatibility
     return false;
   }
 

--- a/apps/frontend/src/main/claude-profile/profile-utils.ts
+++ b/apps/frontend/src/main/claude-profile/profile-utils.ts
@@ -158,3 +158,93 @@ export function expandHomePath(path: string): string {
   }
   return path;
 }
+
+/**
+ * Result of reading OAuth token from system credentials
+ */
+export interface SystemCredentialsResult {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;  // Unix timestamp in milliseconds
+  email?: string;
+}
+
+/**
+ * Read OAuth token from system credentials file.
+ * Checks .claude.json (macOS/Windows) and .credentials.json (Linux).
+ *
+ * @param configDir - The config directory to check (defaults to ~/.claude)
+ * @returns The OAuth credentials if found, or undefined
+ */
+export function getTokenFromSystemCredentials(configDir?: string): SystemCredentialsResult | undefined {
+  const dir = configDir ? expandHomePath(configDir) : DEFAULT_CLAUDE_CONFIG_DIR;
+
+  // Check .claude.json first (modern format, used on macOS/Windows)
+  const claudeJsonPath = join(dir, '.claude.json');
+  if (existsSync(claudeJsonPath)) {
+    try {
+      const content = readFileSync(claudeJsonPath, 'utf-8');
+      const data = JSON.parse(content);
+      if (data?.oauthAccount?.accessToken) {
+        return {
+          accessToken: data.oauthAccount.accessToken,
+          refreshToken: data.oauthAccount.refreshToken,
+          expiresAt: data.oauthAccount.expiresAt,
+          email: data.oauthAccount.emailAddress
+        };
+      }
+    } catch (error) {
+      console.warn('[profile-utils] Failed to read .claude.json:', error);
+    }
+  }
+
+  // Check .credentials.json (Linux format)
+  const credentialsJsonPath = join(dir, '.credentials.json');
+  if (existsSync(credentialsJsonPath)) {
+    try {
+      const content = readFileSync(credentialsJsonPath, 'utf-8');
+      const data = JSON.parse(content);
+
+      // Format: { claudeAiOauth: { accessToken, refreshToken, expiresAt, ... } }
+      if (data?.claudeAiOauth?.accessToken) {
+        return {
+          accessToken: data.claudeAiOauth.accessToken,
+          refreshToken: data.claudeAiOauth.refreshToken,
+          expiresAt: data.claudeAiOauth.expiresAt,
+          email: data.claudeAiOauth.email || data.claudeAiOauth.emailAddress
+        };
+      }
+
+      // Alternative format: { oauthAccount: { ... } }
+      if (data?.oauthAccount?.accessToken) {
+        return {
+          accessToken: data.oauthAccount.accessToken,
+          refreshToken: data.oauthAccount.refreshToken,
+          expiresAt: data.oauthAccount.expiresAt,
+          email: data.oauthAccount.emailAddress
+        };
+      }
+    } catch (error) {
+      console.warn('[profile-utils] Failed to read .credentials.json:', error);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Check if a token from system credentials is expired.
+ *
+ * @param expiresAt - The expiration timestamp in milliseconds
+ * @returns true if the token is expired or will expire in the next 5 minutes
+ */
+export function isTokenExpired(expiresAt?: number): boolean {
+  if (!expiresAt) {
+    // If no expiration, assume it's valid
+    return false;
+  }
+
+  // Add 5 minute buffer to avoid edge cases
+  const bufferMs = 5 * 60 * 1000;
+  return Date.now() + bufferMs >= expiresAt;
+}

--- a/apps/frontend/src/main/ipc-handlers/env-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/env-handlers.ts
@@ -231,8 +231,8 @@ export function registerEnvHandlers(
     const content = `# Auto Claude Framework Environment Variables
 # Managed by Auto Claude UI
 
-# Claude Code OAuth Token (passed via profile manager, not stored in .env)
-# If you need to override, uncomment and set the token below:
+# Claude Code OAuth Token (managed by profile manager, preserved if manually set)
+# The UI does not write tokens here; if you manually set one, it will be preserved:
 ${existingVars['CLAUDE_CODE_OAUTH_TOKEN'] ? `CLAUDE_CODE_OAUTH_TOKEN=${existingVars['CLAUDE_CODE_OAUTH_TOKEN']}` : '# CLAUDE_CODE_OAUTH_TOKEN='}
 
 # Model override (OPTIONAL)

--- a/apps/frontend/src/main/ipc-handlers/env-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/env-handlers.ts
@@ -231,8 +231,9 @@ export function registerEnvHandlers(
     const content = `# Auto Claude Framework Environment Variables
 # Managed by Auto Claude UI
 
-# Claude Code OAuth Token (REQUIRED)
-CLAUDE_CODE_OAUTH_TOKEN=${existingVars['CLAUDE_CODE_OAUTH_TOKEN'] || ''}
+# Claude Code OAuth Token (passed via profile manager, not stored in .env)
+# If you need to override, uncomment and set the token below:
+${existingVars['CLAUDE_CODE_OAUTH_TOKEN'] ? `CLAUDE_CODE_OAUTH_TOKEN=${existingVars['CLAUDE_CODE_OAUTH_TOKEN']}` : '# CLAUDE_CODE_OAUTH_TOKEN='}
 
 # Model override (OPTIONAL)
 ${existingVars['AUTO_BUILD_MODEL'] ? `AUTO_BUILD_MODEL=${existingVars['AUTO_BUILD_MODEL']}` : '# AUTO_BUILD_MODEL=claude-opus-4-5-20251101'}

--- a/apps/frontend/src/main/rate-limit-detector.ts
+++ b/apps/frontend/src/main/rate-limit-detector.ts
@@ -286,7 +286,7 @@ export function getProfileEnv(profileId?: string): Record<string, string> {
       console.warn('[getProfileEnv] Token expired, attempting to sync from system credentials');
       const synced = profileManager.syncProfileTokenFromSystem(profile.id);
       if (synced) {
-        console.warn('[getProfileEnv] Successfully synced fresh token from system credentials');
+        console.log('[getProfileEnv] Successfully synced fresh token from system credentials');
       } else {
         console.warn('[getProfileEnv] Failed to sync token - system credentials may also be expired');
       }
@@ -309,7 +309,7 @@ export function getProfileEnv(profileId?: string): Record<string, string> {
     console.warn('[getProfileEnv] No stored token, attempting to sync from system credentials');
     const synced = profileManager.syncProfileTokenFromSystem(profile.id);
     if (synced) {
-      console.warn('[getProfileEnv] Successfully synced token from system credentials');
+      console.log('[getProfileEnv] Successfully synced token from system credentials');
       const freshToken = profileManager.getProfileToken(profile.id);
       if (freshToken) {
         return {

--- a/apps/frontend/src/shared/types/agent.ts
+++ b/apps/frontend/src/shared/types/agent.ts
@@ -108,6 +108,8 @@ export interface ClaudeProfile {
   email?: string;
   /** When the OAuth token was created (for expiry tracking - 1 year validity) */
   tokenCreatedAt?: Date;
+  /** When the OAuth token expires (Unix timestamp in milliseconds from server) */
+  tokenExpiresAt?: number;
   /**
    * Path to the Claude config directory (e.g., ~/.claude or ~/.claude-profiles/work)
    * @deprecated Use oauthToken instead for reliable multi-profile switching


### PR DESCRIPTION
## Summary
- Fixes issue where users get "OAuth token expired" errors despite being authenticated in the UI
- The profile manager now automatically syncs fresh tokens from `~/.claude/.credentials.json` when the stored token is expired

## Changes
- Add `getTokenFromSystemCredentials()` to read tokens from system files
- Add `syncProfileTokenFromSystem()` to profile manager for auto-sync
- Add `tokenExpiresAt` field to `ClaudeProfile` for proper expiration tracking
- Update `getProfileEnv()` to check expiration and auto-sync before use
- Fix `.env` file to not clear manually-added tokens on settings update

## Test plan
- [ ] Create a profile with OAuth token
- [ ] Wait for token to expire (or manually set expired timestamp)
- [ ] Verify token auto-syncs from system credentials on next use
- [ ] Verify `.env` file preserves manually-added tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic synchronization of OAuth tokens from system credential stores.
  * Per-profile token expiry tracking and explicit expiration checks.

* **Bug Fixes**
  * Preserves manually set tokens; refreshes expired tokens more reliably.
  * Environment export emits a token line only when a token exists, otherwise a commented placeholder.
  * Added Linux credential-file lookup as an additional token source.

* **Tests**
  * Test mocks updated to simulate token sync and expiration behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->