### PR TITLE
fix: remove dangerous git clean that deletes ALL untracked files

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -440,17 +440,13 @@ export function registerTaskExecutionHandlers(
             console.log('[TASK_REVIEW] Discarded working tree changes in main');
           }
 
-          // Step 3: Clean untracked files that came from the merge
-          // IMPORTANT: Exclude .auto-claude directory to preserve specs and worktree data
-          const cleanResult = spawnSync(getToolPath('git'), ['clean', '-fd', '-e', '.auto-claude'], {
-            cwd: project.path,
-            encoding: 'utf-8',
-            stdio: 'pipe',
-            env: getIsolatedGitEnv()
-          });
-          if (cleanResult.status === 0) {
-            console.log('[TASK_REVIEW] Cleaned untracked files in main (excluding .auto-claude)');
-          }
+          // NOTE: We intentionally do NOT run 'git clean' here.
+          // The previous git clean -fd command was dangerous - it deleted ALL untracked files
+          // in the project, not just files from the merge. This caused data loss (issue #1477).
+          //
+          // If the merge added new files, they will remain as untracked files after checkout.
+          // This is a much safer behavior - users can manually review and delete them if needed.
+          // The worktree still contains all the changes, so nothing from the build is lost.
 
           console.log('[TASK_REVIEW] Main branch restored to pre-merge state');
         }


### PR DESCRIPTION
## Summary
- Removes dangerous `git clean -fd` command that was deleting ALL untracked project files during QA rejection
- Replaces with a comment explaining why git clean is intentionally not run

## Problem
The `git clean -fd -e .auto-claude` command at line 445 of `execution-handlers.ts` was running during QA rejection. This deleted ALL untracked files in the project directory, not just files introduced by the merge. Users lost important untracked files like:
- Local configuration files
- Build artifacts
- Temporary work files
- Any other untracked content

## Solution
Remove the git clean command entirely. The `git reset HEAD` + `git checkout -- .` commands (steps 1 and 2) are sufficient to restore tracked files to pre-merge state. 

Any new files introduced by the merge will remain as untracked files after rejection, which is much safer - users can review and delete them manually if needed. The worktree still contains all the changes, so nothing from the build is lost.

## Test plan
- [ ] Create a project with untracked files
- [ ] Run a task that goes through QA
- [ ] Reject the QA review
- [ ] Verify untracked files are NOT deleted

Fixes #1477

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Untracked files are now preserved during task approval, reducing the risk of unintended data loss.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->