### PR TITLE
fix(onboarding): improve database not found message during Graphiti setup

### DIFF
--- a/apps/frontend/src/renderer/components/onboarding/GraphitiStep.tsx
+++ b/apps/frontend/src/renderer/components/onboarding/GraphitiStep.tsx
@@ -249,11 +249,17 @@ export function GraphitiStep({ onNext, onBack, onSkip }: GraphitiStepProps) {
       });
 
       if (result?.success && result?.data) {
+        // During onboarding, "database not found" is expected - don't treat it as an error
+        const isDatabaseNotFound = result.data.database.message?.includes('Database not found');
+        const databaseSuccess = result.data.database.success || isDatabaseNotFound;
+
         setValidationStatus({
           database: {
             tested: true,
-            success: result.data.database.success,
-            message: result.data.database.message
+            success: databaseSuccess,
+            message: isDatabaseNotFound
+              ? 'Database will be created automatically'
+              : result.data.database.message
           },
           provider: {
             tested: true,
@@ -266,7 +272,8 @@ export function GraphitiStep({ onNext, onBack, onSkip }: GraphitiStepProps) {
 
         if (!result.data.ready) {
           const errors: string[] = [];
-          if (!result.data.database.success) {
+          // Only show database error if it's not just "not found" (which is expected during onboarding)
+          if (!result.data.database.success && !isDatabaseNotFound) {
             errors.push(`Database: ${result.data.database.message}`);
           }
           if (!result.data.llmProvider.success) {


### PR DESCRIPTION
## Description

During the onboarding wizard's Graphiti configuration step, users were seeing a misleading error **"Database not found"** even though this is completely expected during first-time setup - the database is created automatically when first needed.

## Changes

This PR improves the user experience by:
- ✅ Detecting when the error is just "database not found" during onboarding
- ✅ Treating it as a success state instead of an error  
- ✅ Showing a friendly message: **"Database will be created automatically"**
- ✅ Only displaying actual errors (connection issues, invalid API keys)

## Impact

This makes the onboarding flow much clearer for new users setting up Auto Claude for the first time. Users will no longer see a scary red error box when the database doesn't exist yet.

## Testing

- Tested manually during onboarding wizard
- Database creation still works as expected
- Real errors (invalid API keys, connection issues) are still displayed correctly

## Screenshots

**Before:** Red error "Database not found"  
**After:** Green success "Database will be created automatically"

Fixes the confusing UX in the Memory & Context onboarding step (step 7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **Enhanced database validation during onboarding**: The setup flow now properly handles scenarios where a database doesn't yet exist, allowing users to proceed with automatic database creation instead of failing validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->