### PR TITLE
fix(build): replace dynamic require with static import in profile manager

### DIFF
--- a/apps/frontend/src/main/claude-profile-manager.ts
+++ b/apps/frontend/src/main/claude-profile-manager.ts
@@ -48,7 +48,8 @@ import {
   createProfileDirectory as createProfileDirectoryImpl,
   isProfileAuthenticated as isProfileAuthenticatedImpl,
   hasValidToken,
-  expandHomePath
+  expandHomePath,
+  getEmailFromConfigDir
 } from './claude-profile/profile-utils';
 
 /**
@@ -111,8 +112,7 @@ export class ClaudeProfileManager {
         continue;
       }
 
-      // Import dynamically to avoid circular dependency issues
-      const { getEmailFromConfigDir } = require('./claude-profile/profile-utils');
+      // Get the authoritative email from Claude's config file
       const configEmail = getEmailFromConfigDir(profile.configDir);
 
       if (configEmail && profile.email !== configEmail) {


### PR DESCRIPTION
## Description

The profile manager was using a dynamic `require()` to import `getEmailFromConfigDir`, which caused a critical build error after Vite bundling:

```
Error: Cannot find module './claude-profile/profile-utils'
Require stack:
- /Users/.../apps/frontend/out/main/index.js
```

## Root Cause

Vite bundles all code into a single file (`out/main/index.js`), and dynamic `require()` calls don't work with bundled ESM modules. The module path `'./claude-profile/profile-utils'` becomes invalid after bundling.

## Changes

This PR fixes the issue by:
- ✅ Adding `getEmailFromConfigDir` to the **static import** at the top of the file
- ✅ Removing the problematic **dynamic `require()`** call (line 115)
- ✅ Preserving the exact same functionality

## Before
```typescript
// Line 115 - BROKEN after build
const { getEmailFromConfigDir } = require('./claude-profile/profile-utils');
```

## After
```typescript
// Top of file - static import
import {
  // ... other imports
  getEmailFromConfigDir  // ← Added here
} from './claude-profile/profile-utils';
```

## Impact

- The app now **builds and starts without errors**
- Profile email migration works correctly
- No functional changes, only build compatibility fix

## Testing

- ✅ Tested with `npm start` - app starts successfully
- ✅ Profile manager initializes without errors
- ✅ Email migration logic still works as expected

Fixes the "Cannot find module" error on `npm start`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for more consistent and reliable email configuration retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->