### PR TITLE
fix(onboarding): decrypt OAuth token before saving to .env file

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/env-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/env-handlers.ts
@@ -11,6 +11,7 @@ import { parseEnvFile } from './utils';
 import { getClaudeCliInvocation, getClaudeCliInvocationAsync } from '../claude-cli-utils';
 import { debugError } from '../../shared/utils/debug-logger';
 import { getSpawnOptions, getSpawnCommand } from '../env-utils';
+import { decryptToken } from '../claude-profile/token-encryption';
 
 // GitLab environment variable keys
 const GITLAB_ENV_KEYS = {
@@ -91,7 +92,10 @@ export function registerEnvHandlers(
 
     // Update with new values
     if (config.claudeOAuthToken !== undefined) {
-      existingVars['CLAUDE_CODE_OAUTH_TOKEN'] = config.claudeOAuthToken;
+      // CRITICAL: Decrypt token if encrypted (starts with "enc:") before saving to .env
+      // The backend Python code cannot decrypt encrypted tokens, so we must save plaintext
+      const decryptedToken = decryptToken(config.claudeOAuthToken);
+      existingVars['CLAUDE_CODE_OAUTH_TOKEN'] = decryptedToken;
     }
     if (config.autoBuildModel !== undefined) {
       existingVars['AUTO_BUILD_MODEL'] = config.autoBuildModel;

--- a/apps/frontend/src/main/ipc-handlers/env-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/env-handlers.ts
@@ -11,7 +11,7 @@ import { parseEnvFile } from './utils';
 import { getClaudeCliInvocation, getClaudeCliInvocationAsync } from '../claude-cli-utils';
 import { debugError } from '../../shared/utils/debug-logger';
 import { getSpawnOptions, getSpawnCommand } from '../env-utils';
-import { decryptToken } from '../claude-profile/token-encryption';
+import { decryptToken, isTokenEncrypted } from '../claude-profile/token-encryption';
 
 // GitLab environment variable keys
 const GITLAB_ENV_KEYS = {


### PR DESCRIPTION
## Description

During onboarding and configuration, **encrypted OAuth tokens** (prefixed with `enc:`) were being written directly to the backend's `.env` file. The Python backend cannot decrypt these tokens, causing all agent operations to fail with:

```
Token decryption failed: Encrypted tokens in environment variables are not supported
```

This prevented critical features from working:
- ❌ Ideation mode
- ❌ Spec creation
- ❌ QA agents
- ❌ All backend agent operations

## Root Cause

The frontend stores OAuth tokens **encrypted** in `claude-profiles.json` using Electron's `safeStorage` API (for security). When writing to the backend `.env` file, the encrypted token was being copied directly instead of being decrypted first.

## Changes

This PR fixes the issue by:
- ✅ Adding import of `decryptToken()` from `token-encryption` module
- ✅ Decrypting the token before writing to `CLAUDE_CODE_OAUTH_TOKEN` in `.env`
- ✅ Adding explanatory comments about why decryption is required

**Modified file:** `apps/frontend/src/main/ipc-handlers/env-handlers.ts`

## Code Changes

```typescript
// Before (BROKEN):
if (config.claudeOAuthToken !== undefined) {
  existingVars['CLAUDE_CODE_OAUTH_TOKEN'] = config.claudeOAuthToken; // ← Encrypted!
}

// After (FIXED):
if (config.claudeOAuthToken !== undefined) {
  // CRITICAL: Decrypt token if encrypted (starts with "enc:") before saving to .env
  // The backend Python code cannot decrypt encrypted tokens, so we must save plaintext
  const decryptedToken = decryptToken(config.claudeOAuthToken);
  existingVars['CLAUDE_CODE_OAUTH_TOKEN'] = decryptedToken; // ← Plaintext!
}
```

## Impact

- ✅ Onboarding wizard now correctly saves **usable** (plaintext) tokens to `.env`
- ✅ Backend agents (Ideation, QA, spec creation) can now authenticate properly
- ✅ Users no longer need to manually fix encrypted tokens in `.env`
- ✅ No security regression: token is still encrypted at rest in `claude-profiles.json`, only decrypted when written to `.env` (which is gitignored)

## Testing

1. ✅ Verified token encryption/decryption flow
2. ✅ Tested onboarding wizard with encrypted token from keychain
3. ✅ Confirmed backend agents can now authenticate
4. ✅ Verified Ideation mode now works correctly

## Related Issues

Fixes authentication failures in all backend Python agents during:
- Ideation mode (issue reported by user)
- Spec creation
- QA validation
- All agent operations requiring Claude API access

## Security Note

The `.env` file containing the plaintext token is:
- Gitignored by default (`.env` is in `.gitignore`)
- Only accessible to the user running Auto Claude
- Required for the Python backend to function (cannot use encrypted tokens)

This matches the standard practice for development environment tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication token handling in the app configuration so encrypted tokens are decrypted before being saved. This prevents storing encrypted blobs in the environment file and preserves tokens unchanged if they were already plaintext.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->