### PR TITLE
fix: add .credentials.json to auth file check for Linux

### DIFF
--- a/apps/frontend/src/main/claude-profile/profile-utils.ts
+++ b/apps/frontend/src/main/claude-profile/profile-utils.ts
@@ -94,6 +94,7 @@ export function isProfileAuthenticated(profile: ClaudeProfile): boolean {
     join(configDir, 'credentials'),
     join(configDir, 'credentials.json'),
     join(configDir, '.credentials'),
+    join(configDir, '.credentials.json'),  // Linux Claude CLI stores OAuth tokens here
     join(configDir, 'settings.json'),  // Often contains auth tokens
   ];
 


### PR DESCRIPTION
## Summary
Fixes Linux users not being detected as authenticated when using OAuth.

## Problem
On Linux, Claude CLI stores OAuth tokens in `~/.claude/.credentials.json`. The `isProfileAuthenticated()` function was missing this file from its `possibleAuthFiles` array, causing Linux users to appear unauthenticated even after successfully running `claude /login`.

## Solution
Added `.credentials.json` to the list of legacy auth files to check in `profile-utils.ts`.

## Testing
- Verified `.credentials.json` exists on Linux after OAuth login
- All 2252 frontend tests pass

Closes #1423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication detection to recognize credential files from additional locations, improving compatibility with Linux CLI credentials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->