### PR TITLE
feat(tray): add system tray with task status

### DIFF
--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -46,6 +46,7 @@ import { pythonEnvManager } from './python-env-manager';
 import { getUsageMonitor } from './claude-profile/usage-monitor';
 import { initializeUsageMonitorForwarding } from './ipc-handlers/terminal-handlers';
 import { initializeAppUpdater, stopPeriodicUpdates } from './app-updater';
+import { initializeTray, destroyTray, setTrayTaskCounts, type TrayTaskCounts } from './tray-manager';
 import { DEFAULT_APP_SETTINGS } from '../shared/constants';
 import { readSettingsFile } from './settings-utils';
 import { setupErrorLogging } from './app-logger';
@@ -380,6 +381,10 @@ app.whenReady().then(() => {
   // Create window
   createWindow();
 
+  // Initialize system tray
+  initializeTray(() => mainWindow);
+  console.log('[main] System tray initialized');
+
   // Pre-warm CLI tool cache in background (non-blocking)
   // This ensures CLI detection is done before user needs it
   // Include all commonly used tools to prevent sync blocking on first use
@@ -472,6 +477,9 @@ app.on('before-quit', async () => {
   const usageMonitor = getUsageMonitor();
   usageMonitor.stop();
   console.warn('[main] Usage monitor stopped');
+
+  // Destroy system tray
+  destroyTray();
 
   // Kill all running agent processes
   if (agentManager) {

--- a/apps/frontend/src/main/ipc-handlers/index.ts
+++ b/apps/frontend/src/main/ipc-handlers/index.ts
@@ -33,6 +33,7 @@ import { registerClaudeCodeHandlers } from './claude-code-handlers';
 import { registerMcpHandlers } from './mcp-handlers';
 import { registerProfileHandlers } from './profile-handlers';
 import { registerScreenshotHandlers } from './screenshot-handlers';
+import { registerTrayHandlers } from './tray-handlers';
 import { registerTerminalWorktreeIpcHandlers } from './terminal';
 import { notificationService } from '../notification-service';
 
@@ -122,6 +123,9 @@ export function setupIpcHandlers(
   // Screenshot capture handlers
   registerScreenshotHandlers();
 
+  // System tray handlers
+  registerTrayHandlers();
+
   console.warn('[IPC] All handler modules registered successfully');
 }
 
@@ -149,5 +153,6 @@ export {
   registerClaudeCodeHandlers,
   registerMcpHandlers,
   registerProfileHandlers,
-  registerScreenshotHandlers
+  registerScreenshotHandlers,
+  registerTrayHandlers
 };

--- a/apps/frontend/src/main/ipc-handlers/tray-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/tray-handlers.ts
@@ -1,0 +1,20 @@
+/**
+ * IPC handlers for system tray operations
+ */
+
+import { ipcMain } from 'electron';
+import { IPC_CHANNELS } from '../../shared/constants/ipc';
+import { setTrayTaskCounts, type TrayTaskCounts } from '../tray-manager';
+
+/**
+ * Register tray-related IPC handlers
+ */
+export function registerTrayHandlers(): void {
+  // Handle tray status updates from renderer
+  ipcMain.handle(IPC_CHANNELS.TRAY_UPDATE_STATUS, (_event, counts: TrayTaskCounts) => {
+    setTrayTaskCounts(counts);
+    return { success: true };
+  });
+
+  console.warn('[IPC] Tray handlers registered');
+}

--- a/apps/frontend/src/main/tray-manager.ts
+++ b/apps/frontend/src/main/tray-manager.ts
@@ -1,0 +1,250 @@
+/**
+ * System Tray Manager for Auto Claude
+ *
+ * Provides a system tray icon with:
+ * - Status indicator (idle, running, review, error)
+ * - Quick access menu with task counts
+ * - Actions to open window, create tasks, etc.
+ */
+
+import { Tray, Menu, nativeImage, app, BrowserWindow } from 'electron';
+import { join } from 'path';
+import { isWindows, isMacOS } from './platform';
+
+export type TrayStatus = 'idle' | 'running' | 'review' | 'error';
+
+export interface TrayTaskCounts {
+  running: number;
+  review: number;
+  pending: number;
+  completed: number;
+}
+
+let tray: Tray | null = null;
+let mainWindowGetter: (() => BrowserWindow | null) | null = null;
+let currentStatus: TrayStatus = 'idle';
+let taskCounts: TrayTaskCounts = { running: 0, review: 0, pending: 0, completed: 0 };
+
+/**
+ * Get the path to tray icon based on status and platform
+ */
+function getTrayIconPath(status: TrayStatus): string {
+  // For macOS, we use template images (monochrome icons that adapt to menu bar)
+  // For Windows/Linux, we use colored icons
+  const resourcesPath = app.isPackaged
+    ? join(process.resourcesPath, 'resources')
+    : join(__dirname, '../../resources');
+
+  // Use the 16x16 icon as base - works on all platforms
+  // In a full implementation, you'd have status-specific icons
+  const iconName = isMacOS() ? 'icons/16x16.png' : 'icons/16x16.png';
+
+  return join(resourcesPath, iconName);
+}
+
+/**
+ * Create the tray icon image
+ */
+function createTrayImage(status: TrayStatus): Electron.NativeImage {
+  const iconPath = getTrayIconPath(status);
+  let image = nativeImage.createFromPath(iconPath);
+
+  // On macOS, mark as template image so it adapts to light/dark menu bar
+  if (isMacOS()) {
+    image = image.resize({ width: 16, height: 16 });
+    image.setTemplateImage(true);
+  }
+
+  return image;
+}
+
+/**
+ * Get tooltip text based on current status and task counts
+ */
+function getTooltip(): string {
+  const parts: string[] = ['Auto Claude'];
+
+  if (taskCounts.running > 0) {
+    parts.push(`${taskCounts.running} running`);
+  }
+  if (taskCounts.review > 0) {
+    parts.push(`${taskCounts.review} awaiting review`);
+  }
+
+  if (parts.length === 1) {
+    parts.push('Idle');
+  }
+
+  return parts.join(' - ');
+}
+
+/**
+ * Build the context menu for the tray
+ */
+function buildContextMenu(): Electron.Menu {
+  const menuItems: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: 'Auto Claude',
+      enabled: false,
+      icon: createTrayImage('idle').resize({ width: 16, height: 16 })
+    },
+    { type: 'separator' },
+    // Status section
+    {
+      label: `${taskCounts.running} task${taskCounts.running !== 1 ? 's' : ''} running`,
+      enabled: false
+    },
+    {
+      label: `${taskCounts.review} awaiting review`,
+      enabled: false
+    },
+    { type: 'separator' },
+    // Actions
+    {
+      label: 'Open Auto Claude',
+      click: () => {
+        const mainWindow = mainWindowGetter?.();
+        if (mainWindow) {
+          if (mainWindow.isMinimized()) {
+            mainWindow.restore();
+          }
+          mainWindow.show();
+          mainWindow.focus();
+        }
+      },
+      accelerator: 'CmdOrCtrl+Shift+A'
+    },
+    {
+      label: 'New Task...',
+      click: () => {
+        const mainWindow = mainWindowGetter?.();
+        if (mainWindow) {
+          mainWindow.show();
+          mainWindow.focus();
+          // Send IPC to open new task dialog
+          mainWindow.webContents.send('tray:new-task');
+        }
+      }
+    },
+    { type: 'separator' },
+    {
+      label: 'Settings',
+      click: () => {
+        const mainWindow = mainWindowGetter?.();
+        if (mainWindow) {
+          mainWindow.show();
+          mainWindow.focus();
+          // Send IPC to open settings
+          mainWindow.webContents.send('tray:open-settings');
+        }
+      }
+    },
+    { type: 'separator' },
+    {
+      label: 'Quit Auto Claude',
+      click: () => {
+        app.quit();
+      },
+      accelerator: 'CmdOrCtrl+Q'
+    }
+  ];
+
+  return Menu.buildFromTemplate(menuItems);
+}
+
+/**
+ * Update the tray icon and menu
+ */
+function updateTray(): void {
+  if (!tray) return;
+
+  // Update icon based on status
+  tray.setImage(createTrayImage(currentStatus));
+
+  // Update tooltip
+  tray.setToolTip(getTooltip());
+
+  // Update context menu
+  tray.setContextMenu(buildContextMenu());
+}
+
+/**
+ * Initialize the system tray
+ */
+export function initializeTray(getMainWindow: () => BrowserWindow | null): Tray {
+  mainWindowGetter = getMainWindow;
+
+  // Create tray with initial icon
+  const image = createTrayImage('idle');
+  tray = new Tray(image);
+
+  // Set initial tooltip and menu
+  tray.setToolTip('Auto Claude - Idle');
+  tray.setContextMenu(buildContextMenu());
+
+  // Click behavior differs by platform
+  // macOS: Click shows menu (default behavior)
+  // Windows/Linux: Click opens the app window
+  if (!isMacOS()) {
+    tray.on('click', () => {
+      const mainWindow = mainWindowGetter?.();
+      if (mainWindow) {
+        if (mainWindow.isVisible()) {
+          if (mainWindow.isMinimized()) {
+            mainWindow.restore();
+          }
+          mainWindow.focus();
+        } else {
+          mainWindow.show();
+        }
+      }
+    });
+  }
+
+  console.log('[tray] System tray initialized');
+  return tray;
+}
+
+/**
+ * Update the tray status
+ */
+export function setTrayStatus(status: TrayStatus): void {
+  currentStatus = status;
+  updateTray();
+}
+
+/**
+ * Update task counts displayed in tray menu
+ */
+export function setTrayTaskCounts(counts: TrayTaskCounts): void {
+  taskCounts = counts;
+
+  // Determine status based on counts
+  if (counts.running > 0) {
+    currentStatus = 'running';
+  } else if (counts.review > 0) {
+    currentStatus = 'review';
+  } else {
+    currentStatus = 'idle';
+  }
+
+  updateTray();
+}
+
+/**
+ * Destroy the tray icon
+ */
+export function destroyTray(): void {
+  if (tray) {
+    tray.destroy();
+    tray = null;
+    console.log('[tray] System tray destroyed');
+  }
+}
+
+/**
+ * Check if tray is initialized
+ */
+export function isTrayInitialized(): boolean {
+  return tray !== null;
+}

--- a/apps/frontend/src/main/tray-manager.ts
+++ b/apps/frontend/src/main/tray-manager.ts
@@ -204,8 +204,9 @@ function updateTray(): void {
 /**
  * Initialize the system tray
  */
-export function initializeTray(getMainWindow: () => BrowserWindow | null): Tray {
-  mainWindowGetter = getMainWindow;
+export function initializeTray(getMainWindow: () => BrowserWindow | null): Tray | null {
+  try {
+    mainWindowGetter = getMainWindow;
 
   // Create tray with initial icon
   const image = createTrayImage('idle');
@@ -234,8 +235,12 @@ export function initializeTray(getMainWindow: () => BrowserWindow | null): Tray 
     });
   }
 
-  console.log('[tray] System tray initialized');
-  return tray;
+    console.log('[tray] System tray initialized');
+    return tray;
+  } catch (error) {
+    console.error('[tray] Failed to initialize system tray:', error);
+    return null;
+  }
 }
 
 /**

--- a/apps/frontend/src/preload/api/index.ts
+++ b/apps/frontend/src/preload/api/index.ts
@@ -14,6 +14,7 @@ import { ClaudeCodeAPI, createClaudeCodeAPI } from './modules/claude-code-api';
 import { McpAPI, createMcpAPI } from './modules/mcp-api';
 import { ProfileAPI, createProfileAPI } from './profile-api';
 import { ScreenshotAPI, createScreenshotAPI } from './screenshot-api';
+import { TrayAPI, createTrayAPI } from './tray-api';
 
 export interface ElectronAPI extends
   ProjectAPI,
@@ -30,7 +31,8 @@ export interface ElectronAPI extends
   ClaudeCodeAPI,
   McpAPI,
   ProfileAPI,
-  ScreenshotAPI {
+  ScreenshotAPI,
+  TrayAPI {
   github: GitHubAPI;
 }
 
@@ -47,6 +49,7 @@ export const createElectronAPI = (): ElectronAPI => ({
   ...createMcpAPI(),
   ...createProfileAPI(),
   ...createScreenshotAPI(),
+  ...createTrayAPI(),
   github: createGitHubAPI()
 });
 
@@ -65,7 +68,8 @@ export {
   createDebugAPI,
   createClaudeCodeAPI,
   createMcpAPI,
-  createScreenshotAPI
+  createScreenshotAPI,
+  createTrayAPI
 };
 
 export type {
@@ -84,5 +88,6 @@ export type {
   DebugAPI,
   ClaudeCodeAPI,
   McpAPI,
-  ScreenshotAPI
+  ScreenshotAPI,
+  TrayAPI
 };

--- a/apps/frontend/src/preload/api/tray-api.ts
+++ b/apps/frontend/src/preload/api/tray-api.ts
@@ -1,0 +1,48 @@
+/**
+ * System Tray API
+ *
+ * Provides system tray functionality via IPC to the main process.
+ * Allows renderer to update tray status and task counts.
+ */
+import { IPC_CHANNELS } from '../../shared/constants/ipc';
+import { ipcRenderer } from 'electron';
+
+export interface TrayTaskCounts {
+  running: number;
+  review: number;
+  pending: number;
+  completed: number;
+}
+
+export interface TrayAPI {
+  /**
+   * Update task counts displayed in system tray
+   */
+  updateStatus: (counts: TrayTaskCounts) => Promise<{ success: boolean }>;
+
+  /**
+   * Listen for "New Task" action from tray menu
+   */
+  onNewTask: (callback: () => void) => () => void;
+
+  /**
+   * Listen for "Settings" action from tray menu
+   */
+  onOpenSettings: (callback: () => void) => () => void;
+}
+
+export const createTrayAPI = (): TrayAPI => ({
+  updateStatus: (counts) => ipcRenderer.invoke(IPC_CHANNELS.TRAY_UPDATE_STATUS, counts),
+
+  onNewTask: (callback) => {
+    const handler = () => callback();
+    ipcRenderer.on(IPC_CHANNELS.TRAY_NEW_TASK, handler);
+    return () => ipcRenderer.removeListener(IPC_CHANNELS.TRAY_NEW_TASK, handler);
+  },
+
+  onOpenSettings: (callback) => {
+    const handler = () => callback();
+    ipcRenderer.on(IPC_CHANNELS.TRAY_OPEN_SETTINGS, handler);
+    return () => ipcRenderer.removeListener(IPC_CHANNELS.TRAY_OPEN_SETTINGS, handler);
+  }
+});

--- a/apps/frontend/src/renderer/App.tsx
+++ b/apps/frontend/src/renderer/App.tsx
@@ -65,6 +65,7 @@ import { GlobalDownloadIndicator } from './components/GlobalDownloadIndicator';
 import { useIpcListeners } from './hooks/useIpc';
 import { useGlobalTerminalListeners } from './hooks/useGlobalTerminalListeners';
 import { useTerminalProfileChange } from './hooks/useTerminalProfileChange';
+import { useTraySync } from './hooks/useTraySync';
 import { COLOR_THEMES, UI_SCALE_MIN, UI_SCALE_MAX, UI_SCALE_DEFAULT } from '../shared/constants';
 import type { Task, Project, ColorTheme } from '../shared/types';
 import { ProjectTabBar } from './components/ProjectTabBar';
@@ -114,6 +115,9 @@ export function App() {
 
   // Handle terminal profile change events (recreate terminals on profile switch)
   useTerminalProfileChange();
+
+  // Sync task state to system tray
+  useTraySync();
 
   // Stores
   const projects = useProjectStore((state) => state.projects);
@@ -191,6 +195,21 @@ export function App() {
 
     return () => {
       cleanupDownloadListener();
+    };
+  }, []);
+
+  // Listen for tray menu actions
+  useEffect(() => {
+    const cleanupNewTask = window.electronAPI.onNewTask(() => {
+      setIsNewTaskDialogOpen(true);
+    });
+    const cleanupSettings = window.electronAPI.onOpenSettings(() => {
+      setIsSettingsDialogOpen(true);
+    });
+
+    return () => {
+      cleanupNewTask();
+      cleanupSettings();
     };
   }, []);
 

--- a/apps/frontend/src/renderer/App.tsx
+++ b/apps/frontend/src/renderer/App.tsx
@@ -200,6 +200,11 @@ export function App() {
 
   // Listen for tray menu actions
   useEffect(() => {
+    // Guard: Only set up listeners if electronAPI is available
+    if (!window.electronAPI?.onNewTask || !window.electronAPI?.onOpenSettings) {
+      return;
+    }
+
     const cleanupNewTask = window.electronAPI.onNewTask(() => {
       setIsNewTaskDialogOpen(true);
     });

--- a/apps/frontend/src/renderer/hooks/useTraySync.ts
+++ b/apps/frontend/src/renderer/hooks/useTraySync.ts
@@ -1,0 +1,61 @@
+/**
+ * Hook to sync task store state with the system tray
+ *
+ * This hook subscribes to the task store and updates the system tray
+ * with current task counts whenever tasks change.
+ */
+
+import { useEffect } from 'react';
+import { useTaskStore } from '../stores/task-store';
+
+/**
+ * Count tasks by status for tray display
+ */
+function getTaskCounts(tasks: { status: string }[]) {
+  let running = 0;
+  let review = 0;
+  let pending = 0;
+  let completed = 0;
+
+  for (const task of tasks) {
+    switch (task.status) {
+      case 'running':
+      case 'spec_running':
+        running++;
+        break;
+      case 'review':
+        review++;
+        break;
+      case 'pending':
+      case 'queued':
+        pending++;
+        break;
+      case 'done':
+      case 'merged':
+      case 'archived':
+        completed++;
+        break;
+    }
+  }
+
+  return { running, review, pending, completed };
+}
+
+/**
+ * Hook that syncs task state to system tray
+ * Should be called once in the root App component
+ */
+export function useTraySync(): void {
+  const tasks = useTaskStore((state) => state.tasks);
+
+  useEffect(() => {
+    // Calculate task counts
+    const counts = getTaskCounts(tasks);
+
+    // Update tray via IPC
+    window.electronAPI.updateStatus(counts).catch((error) => {
+      // Silently ignore errors - tray might not be available
+      console.debug('[useTraySync] Failed to update tray:', error);
+    });
+  }, [tasks]);
+}

--- a/apps/frontend/src/renderer/hooks/useTraySync.ts
+++ b/apps/frontend/src/renderer/hooks/useTraySync.ts
@@ -49,6 +49,11 @@ export function useTraySync(): void {
   const tasks = useTaskStore((state) => state.tasks);
 
   useEffect(() => {
+    // Guard: Only run if electronAPI is available
+    if (!window.electronAPI?.updateStatus) {
+      return;
+    }
+
     // Calculate task counts
     const counts = getTaskCounts(tasks);
 

--- a/apps/frontend/src/renderer/lib/browser-mock.ts
+++ b/apps/frontend/src/renderer/lib/browser-mock.ts
@@ -328,6 +328,11 @@ const browserMockAPI: ElectronAPI = {
     error: 'Screenshot capture not available in browser mode'
   }),
 
+  // System tray operations
+  updateStatus: async () => ({ success: true }),
+  onNewTask: () => () => {},
+  onOpenSettings: () => () => {},
+
   // Debug Operations
   getDebugInfo: async () => ({
     systemInfo: {

--- a/apps/frontend/src/shared/constants/ipc.ts
+++ b/apps/frontend/src/shared/constants/ipc.ts
@@ -542,5 +542,10 @@ export const IPC_CHANNELS = {
 
   // Screenshot capture
   SCREENSHOT_GET_SOURCES: 'screenshot:getSources',  // Get available screens/windows
-  SCREENSHOT_CAPTURE: 'screenshot:capture'          // Capture screenshot from source
+  SCREENSHOT_CAPTURE: 'screenshot:capture',          // Capture screenshot from source
+
+  // System tray operations
+  TRAY_UPDATE_STATUS: 'tray:updateStatus',           // Update tray task counts (renderer -> main)
+  TRAY_NEW_TASK: 'tray:newTask',                     // Tray clicked "New Task" (main -> renderer)
+  TRAY_OPEN_SETTINGS: 'tray:openSettings'            // Tray clicked "Settings" (main -> renderer)
 } as const;

--- a/apps/frontend/src/shared/types/ipc.ts
+++ b/apps/frontend/src/shared/types/ipc.ts
@@ -852,6 +852,11 @@ export interface ElectronAPI {
     thumbnail: string;
   }>>>;
   capture: (options: { sourceId: string }) => Promise<IPCResult<string>>;
+
+  // System tray operations
+  updateStatus: (counts: { running: number; review: number; pending: number; completed: number }) => Promise<{ success: boolean }>;
+  onNewTask: (callback: () => void) => () => void;
+  onOpenSettings: (callback: () => void) => () => void;
 }
 
 declare global {


### PR DESCRIPTION
## Summary
- Add system tray icon that shows in menu bar (macOS) / system tray (Windows/Linux)
- Display task counts (running, awaiting review) in tooltip and menu
- Context menu with quick actions:
  - Open Auto Claude window
  - New Task
  - Settings
  - Quit
- Cross-platform support for macOS, Windows, and Linux
- IPC handlers for renderer to update tray status in real-time

## Test plan
- [ ] macOS: Verify tray icon appears in menu bar
- [ ] macOS: Click icon to see context menu with task counts
- [ ] Windows: Verify tray icon appears in system tray
- [ ] Linux: Verify tray icon appears (may need app indicator)
- [ ] Click "Open Auto Claude" - should focus/show window
- [ ] Click "New Task" - should open new task dialog
- [ ] Click "Settings" - should open settings
- [ ] Click "Quit" - should quit the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System tray added showing app status (idle, running, review, error) and live task counts (running, review, pending, completed).
  * Tray menu with quick actions: open app, New Task, Settings, and Quit.
  * Real-time sync: task state updates propagate to the tray and renderer can trigger New Task and Open Settings from the tray.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->