### PR TITLE
Add skip-cleanup option to WorktreeCleanupDialog

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -567,6 +567,7 @@ export function registerTaskExecutionHandlers(
    * Update task status manually
    * Options:
    * - forceCleanup: When setting to 'done' with a worktree present, delete the worktree first
+   * - skipCleanup: When setting to 'done' with a worktree present, mark done without deleting worktree/branch
    */
   ipcMain.handle(
     IPC_CHANNELS.TASK_UPDATE_STATUS,
@@ -574,7 +575,7 @@ export function registerTaskExecutionHandlers(
       _,
       taskId: string,
       status: TaskStatus,
-      options?: { forceCleanup?: boolean }
+      options?: { forceCleanup?: boolean; skipCleanup?: boolean }
     ): Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }> => {
       // Find task and project first (needed for worktree check)
       const { task, project } = findTaskAndProject(taskId);
@@ -592,7 +593,10 @@ export function registerTaskExecutionHandlers(
         const hasWorktree = worktreePath !== null;
 
         if (hasWorktree) {
-          if (options?.forceCleanup) {
+          if (options?.skipCleanup) {
+            // User chose to keep the worktree and branch — skip cleanup entirely
+            console.warn(`[TASK_UPDATE_STATUS] Skipping worktree cleanup for task ${taskId} — user chose to keep branch`);
+          } else if (options?.forceCleanup) {
             // User confirmed cleanup - delete worktree and branch
             console.warn(`[TASK_UPDATE_STATUS] Cleaning up worktree for task ${taskId} (user confirmed)`);
             try {

--- a/apps/frontend/src/preload/api/task-api.ts
+++ b/apps/frontend/src/preload/api/task-api.ts
@@ -42,7 +42,7 @@ export interface TaskAPI {
   updateTaskStatus: (
     taskId: string,
     status: TaskStatus,
-    options?: { forceCleanup?: boolean }
+    options?: { forceCleanup?: boolean; skipCleanup?: boolean }
   ) => Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }>;
   recoverStuckTask: (
     taskId: string,
@@ -125,7 +125,7 @@ export const createTaskAPI = (): TaskAPI => ({
   updateTaskStatus: (
     taskId: string,
     status: TaskStatus,
-    options?: { forceCleanup?: boolean }
+    options?: { forceCleanup?: boolean; skipCleanup?: boolean }
   ): Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }> =>
     ipcRenderer.invoke(IPC_CHANNELS.TASK_UPDATE_STATUS, taskId, status, options),
 

--- a/apps/frontend/src/renderer/components/WorktreeCleanupDialog.tsx
+++ b/apps/frontend/src/renderer/components/WorktreeCleanupDialog.tsx
@@ -1,5 +1,5 @@
 import { useTranslation, Trans } from 'react-i18next';
-import { AlertCircle, CheckCircle2, FolderX, Loader2, RefreshCw } from 'lucide-react';
+import { AlertCircle, CheckCircle2, FolderX, GitBranch, Loader2, RefreshCw } from 'lucide-react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -19,6 +19,7 @@ interface WorktreeCleanupDialogProps {
   error?: string;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
+  onSkipCleanup?: () => void;
 }
 
 /**
@@ -31,7 +32,8 @@ export function WorktreeCleanupDialog({
   isProcessing,
   error,
   onOpenChange,
-  onConfirm
+  onConfirm,
+  onSkipCleanup
 }: WorktreeCleanupDialogProps) {
   const { t } = useTranslation(['dialogs', 'common']);
 
@@ -80,6 +82,28 @@ export function WorktreeCleanupDialog({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isProcessing}>{t('common:buttons.cancel')}</AlertDialogCancel>
+          {!error && onSkipCleanup && (
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                onSkipCleanup();
+              }}
+              disabled={isProcessing}
+              className="bg-primary text-primary-foreground hover:bg-primary/90"
+            >
+              {isProcessing ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {t('dialogs:worktreeCleanup.completing')}
+                </>
+              ) : (
+                <>
+                  <GitBranch className="mr-2 h-4 w-4" />
+                  {t('dialogs:worktreeCleanup.skipCleanup')}
+                </>
+              )}
+            </AlertDialogAction>
+          )}
           <AlertDialogAction
             onClick={(e) => {
               e.preventDefault();

--- a/apps/frontend/src/renderer/stores/task-store.ts
+++ b/apps/frontend/src/renderer/stores/task-store.ts
@@ -772,7 +772,7 @@ export interface PersistStatusResult {
 export async function persistTaskStatus(
   taskId: string,
   status: TaskStatus,
-  options?: { forceCleanup?: boolean }
+  options?: { forceCleanup?: boolean; skipCleanup?: boolean }
 ): Promise<PersistStatusResult> {
   const store = useTaskStore.getState();
 
@@ -811,6 +811,14 @@ export async function persistTaskStatus(
  */
 export async function forceCompleteTask(taskId: string): Promise<PersistStatusResult> {
   return persistTaskStatus(taskId, 'done', { forceCleanup: true });
+}
+
+/**
+ * Complete a task without cleaning up its worktree/branch
+ * Used when user wants to mark task as done but keep the branch for manual work
+ */
+export async function skipCleanupCompleteTask(taskId: string): Promise<PersistStatusResult> {
+  return persistTaskStatus(taskId, 'done', { skipCleanup: true });
 }
 
 /**

--- a/apps/frontend/src/shared/i18n/locales/en/dialogs.json
+++ b/apps/frontend/src/shared/i18n/locales/en/dialogs.json
@@ -69,7 +69,9 @@
     "completing": "Completing...",
     "retry": "Try Again",
     "errorTitle": "Cleanup Failed",
-    "errorDescription": "Failed to cleanup worktree. Please try again."
+    "errorDescription": "Failed to cleanup worktree. Please try again.",
+    "skipCleanup": "Mark Done (Keep Branch)",
+    "skipCleanupDescription": "Complete the task without deleting the worktree or branch."
   },
   "update": {
     "title": "Auto Claude",

--- a/apps/frontend/src/shared/i18n/locales/fr/dialogs.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/dialogs.json
@@ -69,7 +69,9 @@
     "completing": "Finalisation...",
     "retry": "Réessayer",
     "errorTitle": "Échec du nettoyage",
-    "errorDescription": "Échec du nettoyage du worktree. Veuillez réessayer."
+    "errorDescription": "Échec du nettoyage du worktree. Veuillez réessayer.",
+    "skipCleanup": "Terminer (Garder la branche)",
+    "skipCleanupDescription": "Terminer la tâche sans supprimer le worktree ni la branche."
   },
   "update": {
     "title": "Auto Claude",


### PR DESCRIPTION
When a user drags a task from the "human review" column to the "done" column on the Kanban board, a `WorktreeCleanupDialog` appears that currently offers only two choices: cancel or delete the worktree/branch and complete. This task adds a third option — "Complete Without Cleanup" — that marks the task as done while preserving the worktree and branch. This supports users who are manually working on a task's branch and want to clear it from the board without losing their workspace.