### PR TITLE
feat: allow project tabs to expand horizontally for full title visibility

### DIFF
--- a/apps/frontend/src/renderer/components/ProjectTabBar.tsx
+++ b/apps/frontend/src/renderer/components/ProjectTabBar.tsx
@@ -87,7 +87,6 @@ export function ProjectTabBar({
   return (
     <div className={cn(
       'flex items-center border-b border-border bg-background',
-      'overflow-x-auto scrollbar-hide',
       className
     )}>
       <div className="flex items-center flex-1 min-w-0 overflow-x-auto scrollbar-hide">

--- a/apps/frontend/src/renderer/components/ProjectTabBar.tsx
+++ b/apps/frontend/src/renderer/components/ProjectTabBar.tsx
@@ -87,7 +87,7 @@ export function ProjectTabBar({
   return (
     <div className={cn(
       'flex items-center border-b border-border bg-background',
-      'overflow-x-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent',
+      'overflow-x-auto scrollbar-hide',
       className
     )}>
       <div className="flex items-center flex-1 min-w-0 overflow-x-auto">

--- a/apps/frontend/src/renderer/components/ProjectTabBar.tsx
+++ b/apps/frontend/src/renderer/components/ProjectTabBar.tsx
@@ -90,7 +90,7 @@ export function ProjectTabBar({
       'overflow-x-auto scrollbar-hide',
       className
     )}>
-      <div className="flex items-center flex-1 min-w-0 overflow-x-auto">
+      <div className="flex items-center flex-1 min-w-0 overflow-x-auto scrollbar-hide">
         {projects.map((project, index) => {
           const isActiveTab = activeProjectId === project.id;
           return (

--- a/apps/frontend/src/renderer/components/ProjectTabBar.tsx
+++ b/apps/frontend/src/renderer/components/ProjectTabBar.tsx
@@ -90,7 +90,7 @@ export function ProjectTabBar({
       'overflow-x-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent',
       className
     )}>
-      <div className="flex items-center flex-1 min-w-0">
+      <div className="flex items-center flex-1 min-w-0 overflow-x-auto">
         {projects.map((project, index) => {
           const isActiveTab = activeProjectId === project.id;
           return (

--- a/apps/frontend/src/renderer/components/SortableProjectTab.tsx
+++ b/apps/frontend/src/renderer/components/SortableProjectTab.tsx
@@ -56,10 +56,7 @@ export function SortableProjectTab({
       style={style}
       className={cn(
         'group relative flex items-center min-w-0',
-        // Responsive max-widths: smaller on mobile, larger on desktop
-        isActive
-          ? 'max-w-[180px] sm:max-w-[220px] md:max-w-[280px]'
-          : 'max-w-[120px] sm:max-w-[160px] md:max-w-[200px]',
+        // Allow tabs to expand to show full title, no max-width constraint
         'border-r border-border last:border-r-0',
         'touch-none transition-all duration-200',
         isDragging && 'opacity-60 scale-[0.98] shadow-lg'

--- a/apps/frontend/src/renderer/components/SortableProjectTab.tsx
+++ b/apps/frontend/src/renderer/components/SortableProjectTab.tsx
@@ -94,7 +94,7 @@ export function SortableProjectTab({
                 'w-1 h-4 bg-muted-foreground rounded-full flex-shrink-0'
               )}
             />
-            <span className="truncate font-medium">
+            <span className="font-medium">
               {project.name}
             </span>
           </div>

--- a/apps/frontend/src/renderer/components/SortableProjectTab.tsx
+++ b/apps/frontend/src/renderer/components/SortableProjectTab.tsx
@@ -67,11 +67,11 @@ export function SortableProjectTab({
         <TooltipTrigger asChild>
           <div
             className={cn(
-              'flex-1 flex items-center gap-1 sm:gap-2',
+              'flex items-center gap-1 sm:gap-2',
               // Responsive padding: tighter on mobile, normal on desktop
               'px-2 sm:px-3 md:px-4 py-2 sm:py-2.5',
               'text-xs sm:text-sm',
-              'min-w-0 truncate hover:bg-muted/50 transition-colors',
+              'hover:bg-muted/50 transition-colors',
               'border-b-2 border-transparent cursor-pointer',
               isActive && [
                 'bg-background border-b-primary text-foreground',

--- a/apps/frontend/src/renderer/components/SortableProjectTab.tsx
+++ b/apps/frontend/src/renderer/components/SortableProjectTab.tsx
@@ -55,7 +55,7 @@ export function SortableProjectTab({
       ref={setNodeRef}
       style={style}
       className={cn(
-        'group relative flex items-center min-w-0',
+        'group relative flex items-center flex-shrink-0',
         // Allow tabs to expand to show full title, no max-width constraint
         'border-r border-border last:border-r-0',
         'touch-none transition-all duration-200',

--- a/apps/frontend/src/renderer/styles/globals.css
+++ b/apps/frontend/src/renderer/styles/globals.css
@@ -1087,6 +1087,16 @@ body {
   background-color: #1A1A1F;
 }
 
+/* Scrollbar hide utility for horizontal scroll without visible scrollbar */
+.scrollbar-hide {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}
+
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;  /* Chrome, Safari and Opera */
+}
+
 /* Custom scrollbar - following design system */
 ::-webkit-scrollbar {
   width: 6px;


### PR DESCRIPTION
## Summary

- Allow project tabs to expand horizontally to show full title instead of truncating
- Add horizontal scrolling for tabs when content overflows
- Hide scrollbar for cleaner UI appearance

## Changes

- **ProjectTabBar.tsx**: Add `overflow-x-auto` and `scrollbar-hide` to inner div container
- **SortableProjectTab.tsx**: Replace max-width constraints with `flex-shrink-0` to allow full-width tabs, remove `truncate` class
- **globals.css**: Add `scrollbar-hide` utility class for cross-browser scrollbar hiding

## Test Plan

- [x] Existing tests pass (2639 passed, 6 skipped)
- [x] Type check passes
- [x] Visual test: tabs now expand to full title width and scroll horizontally when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Project tabs now show longer titles without forced truncation, improving readability.
  * Horizontal scrolling preserved while scrollbars are hidden for a cleaner interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->