### PR TITLE
fix: preserve status fields in implementation_plan.json to prevent task jumping to backlog

### DIFF
--- a/apps/backend/core/file_lock.py
+++ b/apps/backend/core/file_lock.py
@@ -172,7 +172,14 @@ class FileLock:
                 time.sleep(0.01)
 
     def _release_lock(self) -> None:
-        """Release the file lock."""
+        """Release the file lock.
+
+        Note: The lock file is intentionally NOT deleted. Removing the lock
+        file after releasing the flock can cause a race condition where another
+        process acquires the lock before the current process has fully released
+        it. Leaving the sentinel file on disk is safe and maintains mutual
+        exclusion.
+        """
         if self._fd is not None:
             try:
                 _unlock(self._fd)
@@ -181,13 +188,6 @@ class FileLock:
                 pass  # Best effort cleanup
             finally:
                 self._fd = None
-
-        # Clean up lock file
-        if self._lock_file and self._lock_file.exists():
-            try:
-                self._lock_file.unlink()
-            except Exception:
-                pass  # Best effort cleanup
 
     def __enter__(self):
         """Synchronous context manager entry."""
@@ -239,8 +239,17 @@ def atomic_write(filepath: str | Path, mode: str = "w", encoding: str = "utf-8")
     try:
         # Open temp file with requested mode and encoding
         # Only use encoding for text modes (not binary modes)
-        with os.fdopen(fd, mode, encoding=encoding if "b" not in mode else None) as f:
+        try:
+            f = os.fdopen(fd, mode, encoding=encoding if "b" not in mode else None)
+        except Exception:
+            # os.fdopen failed - close fd manually before raising
+            os.close(fd)
+            raise
+
+        try:
             yield f
+        finally:
+            f.close()
 
         # Atomic replace - succeeds or fails completely
         os.replace(tmp_path, filepath)
@@ -282,11 +291,9 @@ async def locked_write(
     """
     filepath = Path(filepath)
 
-    # Acquire lock
+    # Acquire lock using explicit async context manager
     lock = FileLock(filepath, timeout=timeout, exclusive=True)
-    await lock.__aenter__()
-
-    try:
+    async with lock:
         # Atomic write in thread pool (since it uses sync file I/O)
         fd, tmp_path = await asyncio.get_running_loop().run_in_executor(
             None,
@@ -298,7 +305,13 @@ async def locked_write(
         try:
             # Open temp file and yield to caller
             # Only use encoding for text modes (not binary modes)
-            f = os.fdopen(fd, mode, encoding=encoding if "b" not in mode else None)
+            try:
+                f = os.fdopen(fd, mode, encoding=encoding if "b" not in mode else None)
+            except Exception:
+                # os.fdopen failed - close fd manually before raising
+                os.close(fd)
+                raise
+
             try:
                 yield f
             finally:
@@ -319,10 +332,6 @@ async def locked_write(
                 pass
             raise
 
-    finally:
-        # Release lock
-        await lock.__aexit__(None, None, None)
-
 
 @asynccontextmanager
 async def locked_read(filepath: str | Path, timeout: float = 5.0) -> Any:
@@ -342,24 +351,16 @@ async def locked_read(filepath: str | Path, timeout: float = 5.0) -> Any:
 
     Raises:
         FileLockTimeout: If lock cannot be acquired within timeout
-        FileNotFoundError: If file doesn't exist
+        FileNotFoundError: If file doesn't exist (raised by open())
     """
     filepath = Path(filepath)
 
-    if not filepath.exists():
-        raise FileNotFoundError(f"File not found: {filepath}")
-
-    # Acquire shared lock (allows multiple readers)
+    # Acquire shared lock (allows multiple readers) using explicit async context manager
     lock = FileLock(filepath, timeout=timeout, exclusive=False)
-    await lock.__aenter__()
-
-    try:
-        # Open file for reading
+    async with lock:
+        # Open file for reading - let open() raise FileNotFoundError if file was removed
         with open(filepath, encoding="utf-8") as f:
             yield f
-    finally:
-        # Release lock
-        await lock.__aexit__(None, None, None)
 
 
 async def locked_json_write(
@@ -421,7 +422,8 @@ async def locked_json_update(
 
     Args:
         filepath: File path to update
-        updater: Function that takes current data and returns updated data
+        updater: Function that takes current data (may be None if file doesn't
+            exist) and returns updated data
         timeout: Lock timeout in seconds (default: 5.0)
         indent: JSON indentation (default: 2)
 
@@ -430,6 +432,8 @@ async def locked_json_update(
 
     Example:
         def add_item(data):
+            if data is None:
+                data = {"items": []}
             data["items"].append({"new": "item"})
             return data
 
@@ -437,14 +441,13 @@ async def locked_json_update(
 
     Raises:
         FileLockTimeout: If lock cannot be acquired within timeout
+        json.JSONDecodeError: If file contains invalid JSON
     """
     filepath = Path(filepath)
 
-    # Acquire exclusive lock
+    # Acquire exclusive lock using explicit async context manager
     lock = FileLock(filepath, timeout=timeout, exclusive=True)
-    await lock.__aenter__()
-
-    try:
+    async with lock:
         # Read current data
         def _read_json():
             if filepath.exists():
@@ -457,32 +460,22 @@ async def locked_json_update(
         # Apply update function
         updated_data = updater(data)
 
-        # Write atomically
-        fd, tmp_path = await asyncio.get_running_loop().run_in_executor(
-            None,
-            lambda: tempfile.mkstemp(
+        # Write atomically - move all blocking I/O into executor
+        def _write_json():
+            fd, tmp_path = tempfile.mkstemp(
                 dir=filepath.parent, prefix=f".{filepath.name}.tmp.", suffix=""
-            ),
-        )
-
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(updated_data, f, indent=indent)
-
-            await asyncio.get_running_loop().run_in_executor(
-                None, os.replace, tmp_path, filepath
             )
-
-        except Exception:
             try:
-                await asyncio.get_running_loop().run_in_executor(
-                    None, os.unlink, tmp_path
-                )
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(updated_data, f, indent=indent)
+                os.replace(tmp_path, filepath)
             except Exception:
-                pass
-            raise
+                try:
+                    os.unlink(tmp_path)
+                except Exception:
+                    pass
+                raise
+
+        await asyncio.get_running_loop().run_in_executor(None, _write_json)
 
         return updated_data
-
-    finally:
-        await lock.__aexit__(None, None, None)

--- a/apps/backend/core/file_lock.py
+++ b/apps/backend/core/file_lock.py
@@ -339,15 +339,19 @@ async def locked_read(filepath: str | Path, timeout: float = 5.0) -> Any:
     Async context manager for locked file reading.
 
     Acquires shared lock for reading, allowing multiple concurrent readers
-    but blocking writers.
+    but blocking writers. The file contents are read synchronously in the
+    executor and yielded as a string to avoid blocking the event loop.
 
     Args:
         filepath: File path to read
         timeout: Lock timeout in seconds (default: 5.0)
 
     Example:
-        async with locked_read("/path/to/file.json", timeout=5.0) as f:
-            data = json.load(f)
+        async with locked_read("/path/to/file.json", timeout=5.0) as contents:
+            data = json.loads(contents)
+
+    Returns:
+        Yields the file contents as a string (not a file handle)
 
     Raises:
         FileLockTimeout: If lock cannot be acquired within timeout
@@ -358,9 +362,13 @@ async def locked_read(filepath: str | Path, timeout: float = 5.0) -> Any:
     # Acquire shared lock (allows multiple readers) using explicit async context manager
     lock = FileLock(filepath, timeout=timeout, exclusive=False)
     async with lock:
-        # Open file for reading - let open() raise FileNotFoundError if file was removed
-        with open(filepath, encoding="utf-8") as f:
-            yield f
+        # Read file contents in executor to avoid blocking event loop
+        def _read_file():
+            with open(filepath, encoding="utf-8") as f:
+                return f.read()
+
+        contents = await asyncio.get_running_loop().run_in_executor(None, _read_file)
+        yield contents
 
 
 async def locked_json_write(
@@ -404,8 +412,8 @@ async def locked_json_read(filepath: str | Path, timeout: float = 5.0) -> Any:
         FileNotFoundError: If file doesn't exist
         json.JSONDecodeError: If file contains invalid JSON
     """
-    async with locked_read(filepath, timeout=timeout) as f:
-        return json.load(f)
+    async with locked_read(filepath, timeout=timeout) as contents:
+        return json.loads(contents)
 
 
 async def locked_json_update(

--- a/apps/backend/core/file_lock.py
+++ b/apps/backend/core/file_lock.py
@@ -31,7 +31,9 @@ from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import Any
 
-_IS_WINDOWS = os.name == "nt"
+from core.platform import is_windows
+
+_IS_WINDOWS = is_windows()
 _WINDOWS_LOCK_SIZE = 1024 * 1024
 
 try:
@@ -276,6 +278,10 @@ async def locked_write(
     Acquires exclusive lock, writes to temp file, atomically replaces target.
     This is the recommended way to safely write shared state files.
 
+    Note: Writes to the returned file handle run synchronously on the event
+    loop and can block for large writes. For heavy writes, consider offloading
+    to the executor or using locked_json_update which handles JSON serialization.
+
     Args:
         filepath: Target file path
         timeout: Lock timeout in seconds (default: 5.0)
@@ -481,12 +487,8 @@ async def locked_json_update(
                 try:
                     f = os.fdopen(fd, "w", encoding="utf-8")
                 except Exception:
-                    # os.fdopen failed - close fd and clean up temp file before raising
+                    # os.fdopen failed - close fd before raising
                     os.close(fd)
-                    try:
-                        os.unlink(tmp_path)
-                    except Exception:
-                        pass
                     raise
 
                 try:

--- a/apps/backend/core/file_lock.py
+++ b/apps/backend/core/file_lock.py
@@ -149,8 +149,8 @@ class FileLock:
         # Open lock file
         self._fd = os.open(str(self._lock_file), os.O_CREAT | os.O_RDWR)
 
-        # Try to acquire lock with timeout
-        start_time = time.time()
+        # Try to acquire lock with timeout (use monotonic clock for reliable timeouts)
+        start_time = time.monotonic()
 
         while True:
             try:
@@ -159,7 +159,7 @@ class FileLock:
                 return  # Lock acquired
             except (BlockingIOError, OSError):
                 # Lock held by another process
-                elapsed = time.time() - start_time
+                elapsed = time.monotonic() - start_time
                 if elapsed >= self.timeout:
                     os.close(self._fd)
                     self._fd = None
@@ -431,7 +431,10 @@ async def locked_json_update(
     Args:
         filepath: File path to update
         updater: Function that takes current data (may be None if file doesn't
-            exist) and returns updated data
+            exist) and returns updated data. The updater runs SYNCHRONOUSLY on
+            the event loop and must be CPU-light and non-blocking. For heavy
+            or I/O-bound work, offload via asyncio.get_running_loop().run_in_executor()
+            or make the updater async and await it separately.
         timeout: Lock timeout in seconds (default: 5.0)
         indent: JSON indentation (default: 2)
 
@@ -474,10 +477,26 @@ async def locked_json_update(
                 dir=filepath.parent, prefix=f".{filepath.name}.tmp.", suffix=""
             )
             try:
-                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                # Open fd for writing - ensure fd is closed on any exception
+                try:
+                    f = os.fdopen(fd, "w", encoding="utf-8")
+                except Exception:
+                    # os.fdopen failed - close fd and clean up temp file before raising
+                    os.close(fd)
+                    try:
+                        os.unlink(tmp_path)
+                    except Exception:
+                        pass
+                    raise
+
+                try:
                     json.dump(updated_data, f, indent=indent)
+                finally:
+                    f.close()
+
                 os.replace(tmp_path, filepath)
             except Exception:
+                # Clean up temp file on error (fd already closed by f.close())
                 try:
                     os.unlink(tmp_path)
                 except Exception:

--- a/apps/backend/core/file_lock.py
+++ b/apps/backend/core/file_lock.py
@@ -177,6 +177,7 @@ class FileLock:
                 try:
                     os.close(self._fd)
                 except Exception:
+                    # Best-effort cleanup: ignore errors when closing fd during error handling
                     pass
                 self._fd = None
             raise

--- a/apps/backend/core/file_lock.py
+++ b/apps/backend/core/file_lock.py
@@ -1,0 +1,488 @@
+"""
+File Locking for Concurrent Operations
+=====================================
+
+Thread-safe and process-safe file locking utilities.
+Uses fcntl.flock() on Unix systems and msvcrt.locking() on Windows for proper
+cross-process locking.
+
+Example Usage:
+    # Simple file locking
+    async with FileLock("path/to/file.json", timeout=5.0):
+        # Do work with locked file
+        pass
+
+    # Atomic write with locking
+    async with locked_write("path/to/file.json", timeout=5.0) as f:
+        json.dump(data, f)
+
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+import time
+import warnings
+from collections.abc import Callable
+from contextlib import asynccontextmanager, contextmanager
+from pathlib import Path
+from typing import Any
+
+_IS_WINDOWS = os.name == "nt"
+_WINDOWS_LOCK_SIZE = 1024 * 1024
+
+try:
+    import fcntl  # type: ignore
+except ImportError:  # pragma: no cover
+    fcntl = None
+
+try:
+    import msvcrt  # type: ignore
+except ImportError:  # pragma: no cover
+    msvcrt = None
+
+
+def _try_lock(fd: int, exclusive: bool) -> None:
+    if _IS_WINDOWS:
+        if msvcrt is None:
+            raise FileLockError("msvcrt is required for file locking on Windows")
+        if not exclusive:
+            warnings.warn(
+                "Shared file locks are not supported on Windows; using exclusive lock",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+        msvcrt.locking(fd, msvcrt.LK_NBLCK, _WINDOWS_LOCK_SIZE)
+        return
+
+    if fcntl is None:
+        raise FileLockError(
+            "fcntl is required for file locking on non-Windows platforms"
+        )
+
+    lock_mode = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    fcntl.flock(fd, lock_mode | fcntl.LOCK_NB)
+
+
+def _unlock(fd: int) -> None:
+    if _IS_WINDOWS:
+        if msvcrt is None:
+            warnings.warn(
+                "msvcrt unavailable; cannot unlock file descriptor",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+            return
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, _WINDOWS_LOCK_SIZE)
+        return
+
+    if fcntl is None:
+        warnings.warn(
+            "fcntl unavailable; cannot unlock file descriptor",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+        return
+    fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+class FileLockError(Exception):
+    """Raised when file locking operations fail."""
+
+    pass
+
+
+class FileLockTimeout(FileLockError):
+    """Raised when lock acquisition times out."""
+
+    pass
+
+
+class FileLock:
+    """
+    Cross-process file lock using platform-specific locking (fcntl.flock on Unix,
+    msvcrt.locking on Windows).
+
+    Supports both sync and async context managers for flexible usage.
+
+    Args:
+        filepath: Path to file to lock (will be created if needed)
+        timeout: Maximum seconds to wait for lock (default: 5.0)
+        exclusive: Whether to use exclusive lock (default: True)
+
+    Example:
+        # Synchronous usage
+        with FileLock("/path/to/file.json"):
+            # File is locked
+            pass
+
+        # Asynchronous usage
+        async with FileLock("/path/to/file.json"):
+            # File is locked
+            pass
+    """
+
+    def __init__(
+        self,
+        filepath: str | Path,
+        timeout: float = 5.0,
+        exclusive: bool = True,
+    ):
+        self.filepath = Path(filepath)
+        self.timeout = timeout
+        self.exclusive = exclusive
+        self._lock_file: Path | None = None
+        self._fd: int | None = None
+
+    def _get_lock_file(self) -> Path:
+        """Get lock file path (separate .lock file)."""
+        return self.filepath.parent / f"{self.filepath.name}.lock"
+
+    def _acquire_lock(self) -> None:
+        """Acquire the file lock (blocking with timeout)."""
+        self._lock_file = self._get_lock_file()
+        self._lock_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Open lock file
+        self._fd = os.open(str(self._lock_file), os.O_CREAT | os.O_RDWR)
+
+        # Try to acquire lock with timeout
+        start_time = time.time()
+
+        while True:
+            try:
+                # Non-blocking lock attempt
+                _try_lock(self._fd, self.exclusive)
+                return  # Lock acquired
+            except (BlockingIOError, OSError):
+                # Lock held by another process
+                elapsed = time.time() - start_time
+                if elapsed >= self.timeout:
+                    os.close(self._fd)
+                    self._fd = None
+                    raise FileLockTimeout(
+                        f"Failed to acquire lock on {self.filepath} within "
+                        f"{self.timeout}s"
+                    )
+
+                # Wait a bit before retrying
+                time.sleep(0.01)
+
+    def _release_lock(self) -> None:
+        """Release the file lock."""
+        if self._fd is not None:
+            try:
+                _unlock(self._fd)
+                os.close(self._fd)
+            except Exception:
+                pass  # Best effort cleanup
+            finally:
+                self._fd = None
+
+        # Clean up lock file
+        if self._lock_file and self._lock_file.exists():
+            try:
+                self._lock_file.unlink()
+            except Exception:
+                pass  # Best effort cleanup
+
+    def __enter__(self):
+        """Synchronous context manager entry."""
+        self._acquire_lock()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Synchronous context manager exit."""
+        self._release_lock()
+        return False
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        # Run blocking lock acquisition in thread pool
+        await asyncio.get_running_loop().run_in_executor(None, self._acquire_lock)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit."""
+        await asyncio.get_running_loop().run_in_executor(None, self._release_lock)
+        return False
+
+
+@contextmanager
+def atomic_write(filepath: str | Path, mode: str = "w", encoding: str = "utf-8"):
+    """
+    Atomic file write using temp file and rename.
+
+    Writes to .tmp file first, then atomically replaces target file
+    using os.replace() which is atomic on POSIX systems.
+
+    Args:
+        filepath: Target file path
+        mode: File open mode (default: "w")
+        encoding: File encoding (default: "utf-8")
+
+    Example:
+        with atomic_write("/path/to/file.json") as f:
+            json.dump(data, f)
+    """
+    filepath = Path(filepath)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+
+    # Create temp file in same directory for atomic rename
+    fd, tmp_path = tempfile.mkstemp(
+        dir=filepath.parent, prefix=f".{filepath.name}.tmp.", suffix=""
+    )
+
+    try:
+        # Open temp file with requested mode and encoding
+        # Only use encoding for text modes (not binary modes)
+        with os.fdopen(fd, mode, encoding=encoding if "b" not in mode else None) as f:
+            yield f
+
+        # Atomic replace - succeeds or fails completely
+        os.replace(tmp_path, filepath)
+
+    except Exception:
+        # Clean up temp file on error
+        try:
+            os.unlink(tmp_path)
+        except Exception:
+            pass
+        raise
+
+
+@asynccontextmanager
+async def locked_write(
+    filepath: str | Path,
+    timeout: float = 5.0,
+    mode: str = "w",
+    encoding: str = "utf-8",
+) -> Any:
+    """
+    Async context manager combining file locking and atomic writes.
+
+    Acquires exclusive lock, writes to temp file, atomically replaces target.
+    This is the recommended way to safely write shared state files.
+
+    Args:
+        filepath: Target file path
+        timeout: Lock timeout in seconds (default: 5.0)
+        mode: File open mode (default: "w")
+        encoding: Text encoding (default: "utf-8")
+
+    Example:
+        async with locked_write("/path/to/file.json", timeout=5.0) as f:
+            json.dump(data, f, indent=2)
+
+    Raises:
+        FileLockTimeout: If lock cannot be acquired within timeout
+    """
+    filepath = Path(filepath)
+
+    # Acquire lock
+    lock = FileLock(filepath, timeout=timeout, exclusive=True)
+    await lock.__aenter__()
+
+    try:
+        # Atomic write in thread pool (since it uses sync file I/O)
+        fd, tmp_path = await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: tempfile.mkstemp(
+                dir=filepath.parent, prefix=f".{filepath.name}.tmp.", suffix=""
+            ),
+        )
+
+        try:
+            # Open temp file and yield to caller
+            # Only use encoding for text modes (not binary modes)
+            f = os.fdopen(fd, mode, encoding=encoding if "b" not in mode else None)
+            try:
+                yield f
+            finally:
+                f.close()
+
+            # Atomic replace
+            await asyncio.get_running_loop().run_in_executor(
+                None, os.replace, tmp_path, filepath
+            )
+
+        except Exception:
+            # Clean up temp file on error
+            try:
+                await asyncio.get_running_loop().run_in_executor(
+                    None, os.unlink, tmp_path
+                )
+            except Exception:
+                pass
+            raise
+
+    finally:
+        # Release lock
+        await lock.__aexit__(None, None, None)
+
+
+@asynccontextmanager
+async def locked_read(filepath: str | Path, timeout: float = 5.0) -> Any:
+    """
+    Async context manager for locked file reading.
+
+    Acquires shared lock for reading, allowing multiple concurrent readers
+    but blocking writers.
+
+    Args:
+        filepath: File path to read
+        timeout: Lock timeout in seconds (default: 5.0)
+
+    Example:
+        async with locked_read("/path/to/file.json", timeout=5.0) as f:
+            data = json.load(f)
+
+    Raises:
+        FileLockTimeout: If lock cannot be acquired within timeout
+        FileNotFoundError: If file doesn't exist
+    """
+    filepath = Path(filepath)
+
+    if not filepath.exists():
+        raise FileNotFoundError(f"File not found: {filepath}")
+
+    # Acquire shared lock (allows multiple readers)
+    lock = FileLock(filepath, timeout=timeout, exclusive=False)
+    await lock.__aenter__()
+
+    try:
+        # Open file for reading
+        with open(filepath, encoding="utf-8") as f:
+            yield f
+    finally:
+        # Release lock
+        await lock.__aexit__(None, None, None)
+
+
+async def locked_json_write(
+    filepath: str | Path, data: Any, timeout: float = 5.0, indent: int = 2
+) -> None:
+    """
+    Helper function for writing JSON with locking and atomicity.
+
+    Args:
+        filepath: Target file path
+        data: Data to serialize as JSON
+        timeout: Lock timeout in seconds (default: 5.0)
+        indent: JSON indentation (default: 2)
+
+    Example:
+        await locked_json_write("/path/to/file.json", {"key": "value"})
+
+    Raises:
+        FileLockTimeout: If lock cannot be acquired within timeout
+    """
+    async with locked_write(filepath, timeout=timeout) as f:
+        json.dump(data, f, indent=indent)
+
+
+async def locked_json_read(filepath: str | Path, timeout: float = 5.0) -> Any:
+    """
+    Helper function for reading JSON with locking.
+
+    Args:
+        filepath: File path to read
+        timeout: Lock timeout in seconds (default: 5.0)
+
+    Returns:
+        Parsed JSON data
+
+    Example:
+        data = await locked_json_read("/path/to/file.json")
+
+    Raises:
+        FileLockTimeout: If lock cannot be acquired within timeout
+        FileNotFoundError: If file doesn't exist
+        json.JSONDecodeError: If file contains invalid JSON
+    """
+    async with locked_read(filepath, timeout=timeout) as f:
+        return json.load(f)
+
+
+async def locked_json_update(
+    filepath: str | Path,
+    updater: Callable[[Any], Any],
+    timeout: float = 5.0,
+    indent: int = 2,
+) -> Any:
+    """
+    Helper for atomic read-modify-write of JSON files.
+
+    Acquires exclusive lock, reads current data, applies updater function,
+    writes updated data atomically.
+
+    Args:
+        filepath: File path to update
+        updater: Function that takes current data and returns updated data
+        timeout: Lock timeout in seconds (default: 5.0)
+        indent: JSON indentation (default: 2)
+
+    Returns:
+        Updated data
+
+    Example:
+        def add_item(data):
+            data["items"].append({"new": "item"})
+            return data
+
+        updated = await locked_json_update("/path/to/file.json", add_item)
+
+    Raises:
+        FileLockTimeout: If lock cannot be acquired within timeout
+    """
+    filepath = Path(filepath)
+
+    # Acquire exclusive lock
+    lock = FileLock(filepath, timeout=timeout, exclusive=True)
+    await lock.__aenter__()
+
+    try:
+        # Read current data
+        def _read_json():
+            if filepath.exists():
+                with open(filepath, encoding="utf-8") as f:
+                    return json.load(f)
+            return None
+
+        data = await asyncio.get_running_loop().run_in_executor(None, _read_json)
+
+        # Apply update function
+        updated_data = updater(data)
+
+        # Write atomically
+        fd, tmp_path = await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: tempfile.mkstemp(
+                dir=filepath.parent, prefix=f".{filepath.name}.tmp.", suffix=""
+            ),
+        )
+
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(updated_data, f, indent=indent)
+
+            await asyncio.get_running_loop().run_in_executor(
+                None, os.replace, tmp_path, filepath
+            )
+
+        except Exception:
+            try:
+                await asyncio.get_running_loop().run_in_executor(
+                    None, os.unlink, tmp_path
+                )
+            except Exception:
+                pass
+            raise
+
+        return updated_data
+
+    finally:
+        await lock.__aexit__(None, None, None)

--- a/apps/backend/core/file_lock.py
+++ b/apps/backend/core/file_lock.py
@@ -151,27 +151,35 @@ class FileLock:
         # Open lock file
         self._fd = os.open(str(self._lock_file), os.O_CREAT | os.O_RDWR)
 
-        # Try to acquire lock with timeout (use monotonic clock for reliable timeouts)
-        start_time = time.monotonic()
+        try:
+            # Try to acquire lock with timeout (use monotonic clock for reliable timeouts)
+            start_time = time.monotonic()
 
-        while True:
-            try:
-                # Non-blocking lock attempt
-                _try_lock(self._fd, self.exclusive)
-                return  # Lock acquired
-            except (BlockingIOError, OSError):
-                # Lock held by another process
-                elapsed = time.monotonic() - start_time
-                if elapsed >= self.timeout:
+            while True:
+                try:
+                    # Non-blocking lock attempt
+                    _try_lock(self._fd, self.exclusive)
+                    return  # Lock acquired
+                except (BlockingIOError, OSError):
+                    # Lock held by another process
+                    elapsed = time.monotonic() - start_time
+                    if elapsed >= self.timeout:
+                        raise FileLockTimeout(
+                            f"Failed to acquire lock on {self.filepath} within "
+                            f"{self.timeout}s"
+                        )
+
+                    # Wait a bit before retrying
+                    time.sleep(0.01)
+        except Exception:
+            # Close fd on any exception before re-raising
+            if self._fd is not None:
+                try:
                     os.close(self._fd)
-                    self._fd = None
-                    raise FileLockTimeout(
-                        f"Failed to acquire lock on {self.filepath} within "
-                        f"{self.timeout}s"
-                    )
-
-                # Wait a bit before retrying
-                time.sleep(0.01)
+                except Exception:
+                    pass
+                self._fd = None
+            raise
 
     def _release_lock(self) -> None:
         """Release the file lock.

--- a/apps/backend/implementation_plan/plan.py
+++ b/apps/backend/implementation_plan/plan.py
@@ -56,15 +56,15 @@ class ImplementationPlan:
             "updated_at": self.updated_at,
             "spec_file": self.spec_file,
         }
-        # Include status fields if set (synced with UI)
-        if self.status:
-            result["status"] = self.status
-        if self.planStatus:
-            result["planStatus"] = self.planStatus
+        # Always include status fields - provide defaults if None
+        # Frontend expects these fields to exist for proper state management
+        result["status"] = self.status or "backlog"
+        result["planStatus"] = self.planStatus or "pending"
         if self.recoveryNote:
             result["recoveryNote"] = self.recoveryNote
         if self.qa_signoff:
             result["qa_signoff"] = self.qa_signoff
+
         return result
 
     @classmethod

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -64,7 +64,7 @@ def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
                 return True
             except OSError:
                 return False
-    except FileLockTimeout:
+    except (FileLockTimeout, OSError):
         return False
 
 

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -36,7 +36,7 @@ def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
     try:
         with open(plan_file, encoding="utf-8") as f:
             existing = json.load(f)
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
         existing = {}
 
     # Create a shallow copy to avoid mutating the caller's dict

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -34,7 +34,7 @@ def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
 
     # Read existing file to preserve frontend fields (status, planStatus, etc.)
     try:
-        with open(plan_file, "r", encoding="utf-8") as f:
+        with open(plan_file, encoding="utf-8") as f:
             existing = json.load(f)
     except (OSError, json.JSONDecodeError):
         existing = {}

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -11,9 +11,8 @@ from pathlib import Path
 from core.file_utils import write_json_atomic
 from progress import is_build_complete
 
-# =============================================================================
-# IMPLEMENTATION PLAN I/O
-# =============================================================================
+# Use existing FileLock from GitHub runners for cross-process file locking
+from runners.github.file_lock import FileLock
 
 
 def load_implementation_plan(spec_dir: Path) -> dict | None:
@@ -32,36 +31,39 @@ def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
     """Save the implementation plan JSON while preserving frontend fields."""
     plan_file = spec_dir / "implementation_plan.json"
 
-    # Read existing file to preserve frontend fields (status, planStatus, etc.)
-    try:
-        with open(plan_file, encoding="utf-8") as f:
-            existing = json.load(f)
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        existing = {}
+    # Acquire cross-process lock to prevent TOCTOU race during read-merge-write
+    # Uses FileLock from runners.github.file_lock for cross-platform locking
+    with FileLock(plan_file, timeout=5.0):
+        # Read existing file to preserve frontend fields (status, planStatus, etc.)
+        try:
+            with open(plan_file, encoding="utf-8") as f:
+                existing = json.load(f)
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            existing = {}
 
-    # Create a shallow copy to avoid mutating the caller's dict
-    new_plan = dict(plan)
+        # Create a shallow copy to avoid mutating the caller's dict
+        new_plan = dict(plan)
 
-    # Preserve fields from existing file that aren't in the new plan dict
-    # Includes frontend fields (status, planStatus, etc.) and qa_stats
-    preserve_fields = [
-        "status",
-        "planStatus",
-        "reviewReason",
-        "xstateState",
-        "executionPhase",
-        "recoveryNote",
-        "qa_stats",
-    ]
-    for field in preserve_fields:
-        if field in existing and field not in new_plan:
-            new_plan[field] = existing[field]
+        # Preserve fields from existing file that aren't in the new plan dict
+        # Includes frontend fields (status, planStatus, etc.) and qa_stats
+        preserve_fields = [
+            "status",
+            "planStatus",
+            "reviewReason",
+            "xstateState",
+            "executionPhase",
+            "recoveryNote",
+            "qa_stats",
+        ]
+        for field in preserve_fields:
+            if field in existing and field not in new_plan:
+                new_plan[field] = existing[field]
 
-    try:
-        write_json_atomic(plan_file, new_plan, indent=2, ensure_ascii=False)
-        return True
-    except OSError:
-        return False
+        try:
+            write_json_atomic(plan_file, new_plan, indent=2, ensure_ascii=False)
+            return True
+        except OSError:
+            return False
 
 
 # =============================================================================

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -8,6 +8,7 @@ Manages acceptance criteria validation and status tracking.
 import json
 from pathlib import Path
 
+from core.file_lock import FileLock, FileLockTimeout
 from core.file_utils import write_json_atomic
 from progress import is_build_complete
 
@@ -26,10 +27,6 @@ def load_implementation_plan(spec_dir: Path) -> dict | None:
 
 def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
     """Save the implementation plan JSON while preserving frontend fields."""
-    # Lazy import to avoid circular import with runners.github.file_lock
-    # which imports runners.__init__ which imports ideation_runner which imports cli
-    from runners.github.file_lock import FileLock, FileLockTimeout
-
     plan_file = spec_dir / "implementation_plan.json"
 
     try:

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from core.file_utils import write_json_atomic
 from progress import is_build_complete
-from runners.github.file_lock import FileLock, FileLockTimeout
 
 
 def load_implementation_plan(spec_dir: Path) -> dict | None:
@@ -27,6 +26,10 @@ def load_implementation_plan(spec_dir: Path) -> dict | None:
 
 def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
     """Save the implementation plan JSON while preserving frontend fields."""
+    # Lazy import to avoid circular import with runners.github.file_lock
+    # which imports runners.__init__ which imports ideation_runner which imports cli
+    from runners.github.file_lock import FileLock, FileLockTimeout
+
     plan_file = spec_dir / "implementation_plan.json"
 
     try:

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -8,6 +8,7 @@ Manages acceptance criteria validation and status tracking.
 import json
 from pathlib import Path
 
+from core.file_utils import write_json_atomic
 from progress import is_build_complete
 
 # =============================================================================
@@ -28,11 +29,30 @@ def load_implementation_plan(spec_dir: Path) -> dict | None:
 
 
 def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
-    """Save the implementation plan JSON."""
+    """Save the implementation plan JSON while preserving frontend fields."""
     plan_file = spec_dir / "implementation_plan.json"
+
+    # Read existing file to preserve frontend fields (status, planStatus, etc.)
     try:
-        with open(plan_file, "w", encoding="utf-8") as f:
-            json.dump(plan, f, indent=2)
+        with open(plan_file, "r", encoding="utf-8") as f:
+            existing = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        existing = {}
+
+    # Frontend fields to preserve (may not be in the plan dict)
+    frontend_fields = ["status", "planStatus", "reviewReason", "xstateState", "executionPhase", "recoveryNote"]
+    preserved_fields = []
+    for field in frontend_fields:
+        if field in existing and field not in plan:
+            plan[field] = existing[field]
+            preserved_fields.append(field)
+
+    # Merge qa_stats if present in existing but not in plan
+    if "qa_stats" in existing and "qa_stats" not in plan:
+        plan["qa_stats"] = existing["qa_stats"]
+
+    try:
+        write_json_atomic(plan_file, plan, indent=2, ensure_ascii=False)
         return True
     except OSError:
         return False

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -39,20 +39,26 @@ def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
     except (OSError, json.JSONDecodeError):
         existing = {}
 
-    # Frontend fields to preserve (may not be in the plan dict)
-    frontend_fields = ["status", "planStatus", "reviewReason", "xstateState", "executionPhase", "recoveryNote"]
-    preserved_fields = []
-    for field in frontend_fields:
-        if field in existing and field not in plan:
-            plan[field] = existing[field]
-            preserved_fields.append(field)
+    # Create a shallow copy to avoid mutating the caller's dict
+    new_plan = dict(plan)
 
-    # Merge qa_stats if present in existing but not in plan
-    if "qa_stats" in existing and "qa_stats" not in plan:
-        plan["qa_stats"] = existing["qa_stats"]
+    # Preserve fields from existing file that aren't in the new plan dict
+    # Includes frontend fields (status, planStatus, etc.) and qa_stats
+    preserve_fields = [
+        "status",
+        "planStatus",
+        "reviewReason",
+        "xstateState",
+        "executionPhase",
+        "recoveryNote",
+        "qa_stats",
+    ]
+    for field in preserve_fields:
+        if field in existing and field not in new_plan:
+            new_plan[field] = existing[field]
 
     try:
-        write_json_atomic(plan_file, plan, indent=2, ensure_ascii=False)
+        write_json_atomic(plan_file, new_plan, indent=2, ensure_ascii=False)
         return True
     except OSError:
         return False

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -6,13 +6,11 @@ Manages acceptance criteria validation and status tracking.
 """
 
 import json
-import os
-import time
 from pathlib import Path
 
 from core.file_utils import write_json_atomic
-from core.platform import is_windows
 from progress import is_build_complete
+from runners.github.file_lock import FileLock, FileLockTimeout
 
 
 def load_implementation_plan(spec_dir: Path) -> dict | None:
@@ -30,95 +28,41 @@ def load_implementation_plan(spec_dir: Path) -> dict | None:
 def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
     """Save the implementation plan JSON while preserving frontend fields."""
     plan_file = spec_dir / "implementation_plan.json"
-    lock_file = plan_file.with_suffix(".lock")
-    lock_timeout = 5.0  # seconds
-
-    # Create lock file parent directory if needed
-    lock_file.parent.mkdir(parents=True, exist_ok=True)
-
-    # Open lock file for locking
-    try:
-        lock_fd = os.open(str(lock_file), os.O_CREAT | os.O_RDWR)
-    except OSError:
-        return False
-
-    # Try to acquire lock with timeout
-    start_time = time.time()
-    lock_acquired = False
 
     try:
-        while time.time() - start_time < lock_timeout:
+        with FileLock(plan_file, timeout=5.0):
+            # Read existing plan
             try:
-                if is_windows():
-                    import msvcrt
+                with open(plan_file, encoding="utf-8") as f:
+                    existing = json.load(f)
+            except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+                existing = {}
 
-                    msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1024 * 1024)
-                else:
-                    import fcntl
+            # Create a shallow copy to avoid mutating the caller's dict
+            new_plan = dict(plan)
 
-                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                lock_acquired = True
-                break
-            except (BlockingIOError, OSError):
-                # Lock held by another process, retry after short delay
-                time.sleep(0.01)
+            # Preserve fields from existing file that aren't in the new plan dict
+            # Includes frontend fields (status, planStatus, etc.) and qa_stats
+            preserve_fields = [
+                "status",
+                "planStatus",
+                "reviewReason",
+                "xstateState",
+                "executionPhase",
+                "recoveryNote",
+                "qa_stats",
+            ]
+            for field in preserve_fields:
+                if field in existing and field not in new_plan:
+                    new_plan[field] = existing[field]
 
-        if not lock_acquired:
-            # Timeout - failed to acquire lock
-            return False
-
-        # Lock acquired - now do read-merge-write atomically
-        try:
-            with open(plan_file, encoding="utf-8") as f:
-                existing = json.load(f)
-        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-            existing = {}
-
-        # Create a shallow copy to avoid mutating the caller's dict
-        new_plan = dict(plan)
-
-        # Preserve fields from existing file that aren't in the new plan dict
-        # Includes frontend fields (status, planStatus, etc.) and qa_stats
-        preserve_fields = [
-            "status",
-            "planStatus",
-            "reviewReason",
-            "xstateState",
-            "executionPhase",
-            "recoveryNote",
-            "qa_stats",
-        ]
-        for field in preserve_fields:
-            if field in existing and field not in new_plan:
-                new_plan[field] = existing[field]
-
-        try:
-            write_json_atomic(plan_file, new_plan, indent=2, ensure_ascii=False)
-            return True
-        except OSError:
-            return False
-    finally:
-        # Always release the lock and close the file descriptor
-        try:
-            if lock_acquired:
-                if is_windows():
-                    import msvcrt
-
-                    msvcrt.locking(lock_fd, msvcrt.LK_UNLCK, 1024 * 1024)
-                else:
-                    import fcntl
-
-                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            os.close(lock_fd)
-        except Exception:
-            pass  # Best-effort cleanup
-
-        # Clean up lock file
-        try:
-            if lock_file.exists():
-                lock_file.unlink()
-        except Exception:
-            pass  # Best-effort cleanup
+            try:
+                write_json_atomic(plan_file, new_plan, indent=2, ensure_ascii=False)
+                return True
+            except OSError:
+                return False
+    except FileLockTimeout:
+        return False
 
 
 # =============================================================================

--- a/apps/backend/qa/criteria.py
+++ b/apps/backend/qa/criteria.py
@@ -6,13 +6,13 @@ Manages acceptance criteria validation and status tracking.
 """
 
 import json
+import os
+import time
 from pathlib import Path
 
 from core.file_utils import write_json_atomic
+from core.platform import is_windows
 from progress import is_build_complete
-
-# Use existing FileLock from GitHub runners for cross-process file locking
-from runners.github.file_lock import FileLock
 
 
 def load_implementation_plan(spec_dir: Path) -> dict | None:
@@ -30,11 +30,44 @@ def load_implementation_plan(spec_dir: Path) -> dict | None:
 def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
     """Save the implementation plan JSON while preserving frontend fields."""
     plan_file = spec_dir / "implementation_plan.json"
+    lock_file = plan_file.with_suffix(".lock")
+    lock_timeout = 5.0  # seconds
 
-    # Acquire cross-process lock to prevent TOCTOU race during read-merge-write
-    # Uses FileLock from runners.github.file_lock for cross-platform locking
-    with FileLock(plan_file, timeout=5.0):
-        # Read existing file to preserve frontend fields (status, planStatus, etc.)
+    # Create lock file parent directory if needed
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Open lock file for locking
+    try:
+        lock_fd = os.open(str(lock_file), os.O_CREAT | os.O_RDWR)
+    except OSError:
+        return False
+
+    # Try to acquire lock with timeout
+    start_time = time.time()
+    lock_acquired = False
+
+    try:
+        while time.time() - start_time < lock_timeout:
+            try:
+                if is_windows():
+                    import msvcrt
+
+                    msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1024 * 1024)
+                else:
+                    import fcntl
+
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                lock_acquired = True
+                break
+            except (BlockingIOError, OSError):
+                # Lock held by another process, retry after short delay
+                time.sleep(0.01)
+
+        if not lock_acquired:
+            # Timeout - failed to acquire lock
+            return False
+
+        # Lock acquired - now do read-merge-write atomically
         try:
             with open(plan_file, encoding="utf-8") as f:
                 existing = json.load(f)
@@ -64,6 +97,28 @@ def save_implementation_plan(spec_dir: Path, plan: dict) -> bool:
             return True
         except OSError:
             return False
+    finally:
+        # Always release the lock and close the file descriptor
+        try:
+            if lock_acquired:
+                if is_windows():
+                    import msvcrt
+
+                    msvcrt.locking(lock_fd, msvcrt.LK_UNLCK, 1024 * 1024)
+                else:
+                    import fcntl
+
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+        except Exception:
+            pass  # Best-effort cleanup
+
+        # Clean up lock file
+        try:
+            if lock_file.exists():
+                lock_file.unlink()
+        except Exception:
+            pass  # Best-effort cleanup
 
 
 # =============================================================================

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -526,17 +526,18 @@ export function registerTaskExecutionHandlers(
       status: TaskStatus,
       options?: { forceCleanup?: boolean }
     ): Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }> => {
-      // IMPORTANT: Clear TaskStateManager's internal cache AND refresh projectStore cache
+      // IMPORTANT: Clear both caches to ensure fresh data is loaded from files
       // TaskStateManager has its own cache (taskContextById) that must be cleared
-      taskStateManager.clearTask(taskId);
+      // Preserve sequence number to prevent duplicate/stale event processing
+      taskStateManager.clearTaskPreserveSequence(taskId);
 
-      // Also refresh the projectStore cache to ensure fresh data from files
+      // Invalidate projectStore cache so findTaskAndProject() below reloads from disk
       const cached = findTaskAndProject(taskId);
       if (cached.project) {
         projectStore.invalidateTasksCache(cached.project.id);
       }
 
-      // Now find task and project again with fresh data from file
+      // Now find task and project again - cache miss ensures fresh data from file
       const { task, project } = findTaskAndProject(taskId);
 
       if (!task || !project) {

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -533,8 +533,7 @@ export function registerTaskExecutionHandlers(
       // Also refresh the projectStore cache to ensure fresh data from files
       const cached = findTaskAndProject(taskId);
       if (cached.project) {
-        // Force refresh ensures the cache is immediately updated from files
-        projectStore.getTasks(cached.project.id, { forceRefresh: true });
+        projectStore.invalidateTasksCache(cached.project.id);
       }
 
       // Now find task and project again with fresh data from file

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -526,7 +526,18 @@ export function registerTaskExecutionHandlers(
       status: TaskStatus,
       options?: { forceCleanup?: boolean }
     ): Promise<IPCResult & { worktreeExists?: boolean; worktreePath?: string }> => {
-      // Find task and project first (needed for worktree check)
+      // IMPORTANT: Clear TaskStateManager's internal cache AND refresh projectStore cache
+      // TaskStateManager has its own cache (taskContextById) that must be cleared
+      taskStateManager.clearTask(taskId);
+
+      // Also refresh the projectStore cache to ensure fresh data from files
+      const cached = findTaskAndProject(taskId);
+      if (cached.project) {
+        // Force refresh ensures the cache is immediately updated from files
+        projectStore.getTasks(cached.project.id, { forceRefresh: true });
+      }
+
+      // Now find task and project again with fresh data from file
       const { task, project } = findTaskAndProject(taskId);
 
       if (!task || !project) {
@@ -658,6 +669,10 @@ export function registerTaskExecutionHandlers(
             // Invalidate cache after creating new plan
             projectStore.invalidateTasksCache(project.id);
           }
+        } else {
+          // TaskStateManager handled the status change - invalidate cache to ensure fresh data
+          // This prevents stale task data from being used after status transitions
+          projectStore.invalidateTasksCache(project.id);
         }
 
         // Auto-stop task when status changes AWAY from 'in_progress' and process IS running

--- a/apps/frontend/src/main/project-store.ts
+++ b/apps/frontend/src/main/project-store.ts
@@ -341,6 +341,8 @@ export class ProjectStore {
         const newIsMain = task.location === 'main';
 
         if (existingIsMain && !newIsMain) {
+          // Main wins, keep existing
+          continue;
         } else if (!existingIsMain && newIsMain) {
           // New is main, replace existing worktree
           taskMap.set(task.id, task);

--- a/apps/frontend/src/main/project-store.ts
+++ b/apps/frontend/src/main/project-store.ts
@@ -341,8 +341,6 @@ export class ProjectStore {
         const newIsMain = task.location === 'main';
 
         if (existingIsMain && !newIsMain) {
-          // Main wins, keep existing
-          continue;
         } else if (!existingIsMain && newIsMain) {
           // New is main, replace existing worktree
           taskMap.set(task.id, task);

--- a/apps/frontend/src/main/task-state-manager.ts
+++ b/apps/frontend/src/main/task-state-manager.ts
@@ -188,6 +188,23 @@ export class TaskStateManager {
   }
 
   /**
+   * Clear task state while preserving the sequence number.
+   * Use this when you need to refresh state but still want to reject
+   * duplicate/stale events by sequence number.
+   */
+  clearTaskPreserveSequence(taskId: string): void {
+    this.lastStateByTask.delete(taskId);
+    this.terminalEventSeen.delete(taskId);
+    this.taskContextById.delete(taskId);
+    const actor = this.actors.get(taskId);
+    if (actor) {
+      actor.stop();
+      this.actors.delete(taskId);
+    }
+    // Note: lastSequenceByTask is NOT deleted, preserving duplicate detection
+  }
+
+  /**
    * Clear all task state. Called by TASK_LIST handler when forceRefresh is true.
    * This ensures actors are recreated with fresh task data when the user
    * triggers a manual refresh from the UI.

--- a/apps/frontend/src/main/task-state-manager.ts
+++ b/apps/frontend/src/main/task-state-manager.ts
@@ -131,7 +131,7 @@ export class TaskStateManager {
       case 'backlog':
         this.handleUiEvent(taskId, { type: 'USER_STOPPED', hasPlan: false }, task, project);
         return true;
-      case 'human_review':
+      case 'human_review': {
         // IMPORTANT: Must persist status to file, not just emit!
         // Previously this only emitted the status event, causing the file to have stale data.
         // Now we persist the status to ensure the implementation_plan.json is updated.
@@ -141,6 +141,7 @@ export class TaskStateManager {
         this.persistStatus(task, project, 'human_review', reviewReason, xstateState, executionPhase);
         this.emitStatus(taskId, 'human_review', reviewReason, project.id);
         return true;
+      }
       default:
         return false;
     }

--- a/apps/frontend/src/main/task-state-manager.ts
+++ b/apps/frontend/src/main/task-state-manager.ts
@@ -132,9 +132,14 @@ export class TaskStateManager {
         this.handleUiEvent(taskId, { type: 'USER_STOPPED', hasPlan: false }, task, project);
         return true;
       case 'human_review':
-        // Already in human_review (e.g., stage-only merge keeps task in review).
-        // Emit status directly since there's no XState transition needed.
-        this.emitStatus(taskId, 'human_review', task.reviewReason ?? 'completed', project.id);
+        // IMPORTANT: Must persist status to file, not just emit!
+        // Previously this only emitted the status event, causing the file to have stale data.
+        // Now we persist the status to ensure the implementation_plan.json is updated.
+        const reviewReason = task.reviewReason ?? 'completed';
+        const xstateState = 'human_review';
+        const executionPhase = this.mapStateToExecutionPhase(xstateState);
+        this.persistStatus(task, project, 'human_review', reviewReason, xstateState, executionPhase);
+        this.emitStatus(taskId, 'human_review', reviewReason, project.id);
         return true;
       default:
         return false;


### PR DESCRIPTION
## Summary

Fixes race conditions and missing status fields in `implementation_plan.json` that were causing tasks to jump to `backlog` on board refresh.

## Root Causes Fixed

### 1. Backend Conditional Writing
**File:** `apps/backend/implementation_plan/plan.py`

The `to_dict()` method was conditionally writing status fields only when they had truthy values. When `status` was `None`, the fields were not written to JSON, causing them to disappear.

**Fix:** Always write `status` and `planStatus` fields with sensible defaults (`"backlog"` and `"pending"` when `None`).

### 2. QA Module Overwriting Fields
**File:** `apps/backend/qa/criteria.py`

The QA module loaded the plan as a dict, modified it, and wrote it back with `json.dump()`, bypassing the `ImplementationPlan` class. This removed frontend fields that weren't in the dict.

**Fix:** Read existing file first and preserve frontend fields (`status`, `planStatus`, `reviewReason`, `xstateState`, `executionPhase`, `recoveryNote`) when writing. Also switched to atomic writes.

### 3. Frontend human_review Not Persisting
**File:** `apps/frontend/src/main/task-state-manager.ts`

The `human_review` case only emitted a status event but didn't persist the status to file, causing the file to have stale data.

**Fix:** Call `persistStatus()` to write to file before emitting the event.

### 4. Cache Issues
**File:** `apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts`

The task was loaded from cache before status update, causing stale data to be used.

**Fix:** Clear TaskStateManager cache and force refresh projectStore cache before loading task.

## Test Scenarios Covered

- ✅ Manual "Mark as done" from `human_review`
- ✅ QA approval (preserves frontend fields)
- ✅ Manual status changes via Drag&Drop/Dropdown
- ✅ Backend to_dict() always includes status fields with defaults

## Verification

1. Set task to `human_review` → Status is written to file ✅
2. Click "Mark as done" → Status persists correctly ✅
3. Refresh board → Task stays in `done` ✅
4. Check `implementation_plan.json` → All status fields present ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human-review status is now persisted before emission.
  * Ability to clear per-task state while preserving sequence tracking to avoid duplicate processing.

* **Bug Fixes**
  * Status fields now default when unset to stabilize UI state.
  * Implementation plan saves are atomic and preserve frontend-related fields when missing.
  * Cross-process file locking and safe JSON read/write prevent concurrent corruption.
  * Task cache synchronization ensures fresh data after status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->