### PR TITLE
feat(tasks): add post-QA automation options (auto-create PR, auto-merge)

### DIFF
--- a/apps/frontend/src/renderer/App.tsx
+++ b/apps/frontend/src/renderer/App.tsx
@@ -66,6 +66,7 @@ import { useIpcListeners } from './hooks/useIpc';
 import { useGlobalTerminalListeners } from './hooks/useGlobalTerminalListeners';
 import { useTerminalProfileChange } from './hooks/useTerminalProfileChange';
 import { usePostQaAutomation } from './hooks/usePostQaAutomation';
+import { useToast } from './hooks/use-toast';
 import { COLOR_THEMES, UI_SCALE_MIN, UI_SCALE_MAX, UI_SCALE_DEFAULT } from '../shared/constants';
 import type { Task, Project, ColorTheme } from '../shared/types';
 import { ProjectTabBar } from './components/ProjectTabBar';
@@ -116,6 +117,9 @@ export function App() {
   // Handle terminal profile change events (recreate terminals on profile switch)
   useTerminalProfileChange();
 
+  // Toast for notifications
+  const { toast } = useToast();
+
   // Handle post-QA automation (auto-create PR, auto-merge, auto-archive)
   usePostQaAutomation({
     onAutomationTriggered: (taskId, action) => {
@@ -123,6 +127,11 @@ export function App() {
     },
     onAutomationFailed: (taskId, error) => {
       console.error(`[App] Post-QA automation failed for task ${taskId}:`, error);
+      toast({
+        variant: 'destructive',
+        title: 'Post-QA Automation Failed',
+        description: `Task "${taskId}" automation failed: ${error}`,
+      });
     }
   });
 

--- a/apps/frontend/src/renderer/App.tsx
+++ b/apps/frontend/src/renderer/App.tsx
@@ -65,6 +65,7 @@ import { GlobalDownloadIndicator } from './components/GlobalDownloadIndicator';
 import { useIpcListeners } from './hooks/useIpc';
 import { useGlobalTerminalListeners } from './hooks/useGlobalTerminalListeners';
 import { useTerminalProfileChange } from './hooks/useTerminalProfileChange';
+import { usePostQaAutomation } from './hooks/usePostQaAutomation';
 import { COLOR_THEMES, UI_SCALE_MIN, UI_SCALE_MAX, UI_SCALE_DEFAULT } from '../shared/constants';
 import type { Task, Project, ColorTheme } from '../shared/types';
 import { ProjectTabBar } from './components/ProjectTabBar';
@@ -114,6 +115,16 @@ export function App() {
 
   // Handle terminal profile change events (recreate terminals on profile switch)
   useTerminalProfileChange();
+
+  // Handle post-QA automation (auto-create PR, auto-merge, auto-archive)
+  usePostQaAutomation({
+    onAutomationTriggered: (taskId, action) => {
+      console.log(`[App] Post-QA automation triggered for task ${taskId}: ${action}`);
+    },
+    onAutomationFailed: (taskId, error) => {
+      console.error(`[App] Post-QA automation failed for task ${taskId}:`, error);
+    }
+  });
 
   // Stores
   const projects = useProjectStore((state) => state.projects);

--- a/apps/frontend/src/renderer/App.tsx
+++ b/apps/frontend/src/renderer/App.tsx
@@ -120,6 +120,9 @@ export function App() {
   // Toast for notifications
   const { toast } = useToast();
 
+  // i18n must be initialized before usePostQaAutomation because the callback uses t()
+  const { t, i18n } = useTranslation(['dialogs', 'tasks']);
+
   // Handle post-QA automation (auto-create PR, auto-merge, auto-archive)
   usePostQaAutomation({
     onAutomationTriggered: (taskId, action) => {
@@ -129,8 +132,8 @@ export function App() {
       console.error(`[App] Post-QA automation failed for task ${taskId}:`, error);
       toast({
         variant: 'destructive',
-        title: 'Post-QA Automation Failed',
-        description: `Task "${taskId}" automation failed: ${error}`,
+        title: t('tasks:automation.failedTitle'),
+        description: t('tasks:automation.failedDescription', { taskId, error }),
       });
     }
   });
@@ -328,7 +331,6 @@ export function App() {
   };
 
   // Sync i18n language with settings
-  const { t, i18n } = useTranslation('dialogs');
   useEffect(() => {
     if (settings.language && settings.language !== i18n.language) {
       i18n.changeLanguage(settings.language);

--- a/apps/frontend/src/renderer/components/TaskCreationWizard.tsx
+++ b/apps/frontend/src/renderer/components/TaskCreationWizard.tsx
@@ -123,6 +123,9 @@ export function TaskCreationWizard({
   // Review setting
   const [requireReviewBeforeCoding, setRequireReviewBeforeCoding] = useState(false);
 
+  // Post-QA action setting
+  const [postQaAction, setPostQaAction] = useState<'do_nothing' | 'auto_create_pr' | 'auto_merge'>('do_nothing');
+
   // Draft state
   const [isDraftRestored, setIsDraftRestored] = useState(false);
 
@@ -161,6 +164,7 @@ export function TaskCreationWizard({
         setImages(draft.images);
         setReferencedFiles(draft.referencedFiles ?? []);
         setRequireReviewBeforeCoding(draft.requireReviewBeforeCoding ?? false);
+        setPostQaAction(draft.postQaAction ?? 'do_nothing');
         setIsDraftRestored(true);
 
         if (draft.category || draft.priority || draft.complexity || draft.impact) {
@@ -259,8 +263,9 @@ export function TaskCreationWizard({
     images,
     referencedFiles,
     requireReviewBeforeCoding,
+    postQaAction,
     savedAt: new Date()
-  }), [projectId, title, description, category, priority, complexity, impact, profileId, model, thinkingLevel, phaseModels, phaseThinking, images, referencedFiles, requireReviewBeforeCoding]);
+  }), [projectId, title, description, category, priority, complexity, impact, profileId, model, thinkingLevel, phaseModels, phaseThinking, images, referencedFiles, requireReviewBeforeCoding, postQaAction]);
 
   /**
    * Detect @ mention being typed and show autocomplete
@@ -429,6 +434,7 @@ export function TaskCreationWizard({
       if (images.length > 0) metadata.attachedImages = images;
       if (allReferencedFiles.length > 0) metadata.referencedFiles = allReferencedFiles;
       if (requireReviewBeforeCoding) metadata.requireReviewBeforeCoding = true;
+      if (postQaAction !== 'do_nothing') metadata.postQaAction = postQaAction;
       // Always include baseBranch - resolve PROJECT_DEFAULT_BRANCH to actual branch name
       // This ensures the backend always knows which branch to use for worktree creation
       if (baseBranch === PROJECT_DEFAULT_BRANCH) {
@@ -473,6 +479,7 @@ export function TaskCreationWizard({
     setImages([]);
     setReferencedFiles([]);
     setRequireReviewBeforeCoding(false);
+    setPostQaAction('do_nothing');
     setBaseBranch(PROJECT_DEFAULT_BRANCH);
     setUseWorktree(true);
     setError(null);
@@ -655,6 +662,8 @@ export function TaskCreationWizard({
           onImagesChange={setImages}
           requireReviewBeforeCoding={requireReviewBeforeCoding}
           onRequireReviewChange={setRequireReviewBeforeCoding}
+          postQaAction={postQaAction}
+          onPostQaActionChange={setPostQaAction}
           disabled={isCreating}
           error={error}
           onError={setError}

--- a/apps/frontend/src/renderer/components/TaskEditDialog.tsx
+++ b/apps/frontend/src/renderer/components/TaskEditDialog.tsx
@@ -120,6 +120,11 @@ export function TaskEditDialog({ task, open, onOpenChange, onSaved }: TaskEditDi
     task.metadata?.requireReviewBeforeCoding ?? false
   );
 
+  // Post-QA action setting
+  const [postQaAction, setPostQaAction] = useState<'do_nothing' | 'auto_create_pr' | 'auto_merge'>(
+    task.metadata?.postQaAction ?? 'do_nothing'
+  );
+
   // Reset form when task changes or dialog opens
   useEffect(() => {
     if (open) {
@@ -160,6 +165,7 @@ export function TaskEditDialog({ task, open, onOpenChange, onSaved }: TaskEditDi
 
       setImages(task.metadata?.attachedImages || []);
       setRequireReviewBeforeCoding(task.metadata?.requireReviewBeforeCoding ?? false);
+      setPostQaAction(task.metadata?.postQaAction ?? 'do_nothing');
       setError(null);
 
       // Auto-expand classification if it has content
@@ -232,6 +238,10 @@ export function TaskEditDialog({ task, open, onOpenChange, onSaved }: TaskEditDi
     // Always set attachedImages to persist removal when all images are deleted
     metadataUpdates.attachedImages = images.length > 0 ? images : [];
     metadataUpdates.requireReviewBeforeCoding = requireReviewBeforeCoding;
+    // Only set postQaAction if not the default
+    if (postQaAction !== 'do_nothing') {
+      metadataUpdates.postQaAction = postQaAction;
+    }
 
     const success = await persistUpdateTask(task.id, {
       title: trimmedTitle,
@@ -311,6 +321,8 @@ export function TaskEditDialog({ task, open, onOpenChange, onSaved }: TaskEditDi
         onImagesChange={setImages}
         requireReviewBeforeCoding={requireReviewBeforeCoding}
         onRequireReviewChange={setRequireReviewBeforeCoding}
+        postQaAction={postQaAction}
+        onPostQaActionChange={setPostQaAction}
         disabled={isSaving}
         error={error}
         onError={setError}

--- a/apps/frontend/src/renderer/components/TaskEditDialog.tsx
+++ b/apps/frontend/src/renderer/components/TaskEditDialog.tsx
@@ -212,7 +212,8 @@ export function TaskEditDialog({ task, open, onOpenChange, onSaved }: TaskEditDi
       requireReviewBeforeCoding !== (task.metadata?.requireReviewBeforeCoding ?? false) ||
       JSON.stringify(images) !== JSON.stringify(task.metadata?.attachedImages || []) ||
       JSON.stringify(phaseModels) !== JSON.stringify(task.metadata?.phaseModels || DEFAULT_PHASE_MODELS) ||
-      JSON.stringify(phaseThinking) !== JSON.stringify(task.metadata?.phaseThinking || DEFAULT_PHASE_THINKING);
+      JSON.stringify(phaseThinking) !== JSON.stringify(task.metadata?.phaseThinking || DEFAULT_PHASE_THINKING) ||
+      postQaAction !== (task.metadata?.postQaAction ?? 'do_nothing');
 
     if (!hasChanges) {
       onOpenChange(false);

--- a/apps/frontend/src/renderer/components/TaskEditDialog.tsx
+++ b/apps/frontend/src/renderer/components/TaskEditDialog.tsx
@@ -239,10 +239,8 @@ export function TaskEditDialog({ task, open, onOpenChange, onSaved }: TaskEditDi
     // Always set attachedImages to persist removal when all images are deleted
     metadataUpdates.attachedImages = images.length > 0 ? images : [];
     metadataUpdates.requireReviewBeforeCoding = requireReviewBeforeCoding;
-    // Only set postQaAction if not the default
-    if (postQaAction !== 'do_nothing') {
-      metadataUpdates.postQaAction = postQaAction;
-    }
+    // Always set postQaAction to ensure we can clear it when set to 'do_nothing'
+    metadataUpdates.postQaAction = postQaAction;
 
     const success = await persistUpdateTask(task.id, {
       title: trimmedTitle,

--- a/apps/frontend/src/renderer/components/task-form/TaskFormFields.tsx
+++ b/apps/frontend/src/renderer/components/task-form/TaskFormFields.tsx
@@ -17,6 +17,13 @@ import { Input } from '../ui/input';
 import { Textarea } from '../ui/textarea';
 import { Checkbox } from '../ui/checkbox';
 import { Button } from '../ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
 import { AgentProfileSelector } from '../AgentProfileSelector';
 import { ClassificationFields } from './ClassificationFields';
 import { useImageUpload, type FileReferenceData } from './useImageUpload';
@@ -86,6 +93,10 @@ interface TaskFormFieldsProps {
   requireReviewBeforeCoding: boolean;
   onRequireReviewChange: (require: boolean) => void;
 
+  // Post-QA action
+  postQaAction: 'do_nothing' | 'auto_create_pr' | 'auto_merge';
+  onPostQaActionChange: (action: 'do_nothing' | 'auto_create_pr' | 'auto_merge') => void;
+
   // Form state
   disabled?: boolean;
   error?: string | null;
@@ -135,6 +146,8 @@ export function TaskFormFields({
   onImagesChange,
   requireReviewBeforeCoding,
   onRequireReviewChange,
+  postQaAction,
+  onPostQaActionChange,
   disabled = false,
   error,
   onError,
@@ -531,6 +544,36 @@ export function TaskFormFields({
               {t('tasks:form.requireReviewDescription')}
             </p>
           </div>
+        </div>
+
+        {/* Post-QA Action Dropdown */}
+        <div className="space-y-2">
+          <Label htmlFor={`${prefix}post-qa-action`} className="text-sm font-medium text-foreground">
+            {t('tasks:form.postQaActionLabel')}
+          </Label>
+          <Select
+            value={postQaAction}
+            onValueChange={(value) => onPostQaActionChange(value as 'do_nothing' | 'auto_create_pr' | 'auto_merge')}
+            disabled={disabled}
+          >
+            <SelectTrigger id={`${prefix}post-qa-action`}>
+              <SelectValue placeholder={t('tasks:form.postQaAction.do_nothing')} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="do_nothing">
+                {t('tasks:form.postQaAction.do_nothing')}
+              </SelectItem>
+              <SelectItem value="auto_create_pr">
+                {t('tasks:form.postQaAction.auto_create_pr')}
+              </SelectItem>
+              <SelectItem value="auto_merge">
+                {t('tasks:form.postQaAction.auto_merge')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {t('tasks:form.postQaActionDescription')}
+          </p>
         </div>
 
         {/* Error Display */}

--- a/apps/frontend/src/renderer/hooks/index.ts
+++ b/apps/frontend/src/renderer/hooks/index.ts
@@ -8,3 +8,4 @@ export {
 } from './useResolvedAgentSettings';
 export { useVirtualizedTree } from './useVirtualizedTree';
 export { useTerminalProfileChange } from './useTerminalProfileChange';
+export { usePostQaAutomation } from './usePostQaAutomation';

--- a/apps/frontend/src/renderer/hooks/usePostQaAutomation.ts
+++ b/apps/frontend/src/renderer/hooks/usePostQaAutomation.ts
@@ -6,13 +6,17 @@
 import { useEffect, useRef } from 'react';
 import { useTaskStore } from '../stores/task-store';
 import { useProjectStore } from '../stores/project-store';
-import type { Task } from '../../shared/types';
+import type { IPCResult, PostQaAction, Task } from '../../shared/types';
+
+const STATE_SETTLE_DELAY_MS = 1000; // Allow UI state to settle after status change
 
 interface PostQaAutomationOptions {
   /** Callback when automation is triggered */
-  onAutomationTriggered?: (taskId: string, action: 'auto_create_pr' | 'auto_merge') => void;
+  onAutomationTriggered?: (taskId: string, action: PostQaAction) => void;
   /** Callback when automation fails */
   onAutomationFailed?: (taskId: string, error: string) => void;
+  /** Callback for automation progress updates */
+  onAutomationProgress?: (taskId: string, status: 'starting' | 'success' | 'failed', message: string) => void;
 }
 
 /**
@@ -25,14 +29,25 @@ interface PostQaAutomationOptions {
  * - Archives the task after successful action
  */
 export function usePostQaAutomation(options: PostQaAutomationOptions = {}) {
-  const { onAutomationTriggered, onAutomationFailed } = options;
+  const { onAutomationTriggered, onAutomationFailed, onAutomationProgress } = options;
   const tasks = useTaskStore((state) => state.tasks);
   const projects = useProjectStore((state) => state.projects);
 
   // Track processed task IDs to avoid duplicate automation
   const processedTasks = useRef<Set<string>>(new Set());
+  // Track timeout IDs for cleanup on unmount
+  const timeoutIds = useRef<Set<NodeJS.Timeout>>(new Set());
 
   useEffect(() => {
+    // Cleanup: remove processed tasks that are archived or completed
+    for (const task of tasks) {
+      if (processedTasks.current.has(task.id)) {
+        if (task.status === 'done' || task.status === 'pr_created') {
+          processedTasks.current.delete(task.id);
+        }
+      }
+    }
+
     for (const task of tasks) {
       // Skip if already processed
       if (processedTasks.current.has(task.id)) {
@@ -61,74 +76,108 @@ export function usePostQaAutomation(options: PostQaAutomationOptions = {}) {
         }
 
         // Trigger automation after a short delay to ensure state is settled
-        setTimeout(async () => {
+        const timeoutId = setTimeout(async () => {
           try {
             if (postQaAction === 'auto_create_pr') {
-              await handleAutoCreatePR(task, project);
+              await handleAutoCreatePR(task, project, onAutomationProgress);
               onAutomationTriggered?.(task.id, 'auto_create_pr');
             } else if (postQaAction === 'auto_merge') {
-              await handleAutoMerge(task, project);
+              await handleAutoMerge(task, project, onAutomationProgress);
               onAutomationTriggered?.(task.id, 'auto_merge');
             }
           } catch (error) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error';
             console.error(`[PostQaAutomation] Failed to execute ${postQaAction} for task ${task.id}:`, error);
+            onAutomationProgress?.(task.id, 'failed', errorMessage);
             onAutomationFailed?.(task.id, errorMessage);
 
             // Remove from processed set so it can be retried
             processedTasks.current.delete(task.id);
           }
-        }, 1000);
+        }, STATE_SETTLE_DELAY_MS);
+
+        // Store timeout ID for cleanup
+        timeoutIds.current.add(timeoutId);
       }
     }
-  }, [tasks, projects, onAutomationTriggered, onAutomationFailed]);
+
+    // Cleanup function: clear all pending timeouts on unmount
+    return () => {
+      timeoutIds.current.forEach(id => clearTimeout(id));
+      timeoutIds.current.clear();
+    };
+  }, [tasks, projects, onAutomationTriggered, onAutomationFailed, onAutomationProgress]);
+}
+
+/**
+ * Execute an automation action with common error handling and progress reporting
+ */
+async function executeAutomationAction(
+  action: 'auto_create_pr' | 'auto_merge',
+  task: Task,
+  project: { id: string },
+  executeApi: () => Promise<IPCResult>,
+  onAutomationProgress?: (taskId: string, status: 'starting' | 'success' | 'failed', message: string) => void
+): Promise<void> {
+  console.log(`[PostQaAutomation] Executing ${action} for task ${task.id}`);
+
+  onAutomationProgress?.(task.id, 'starting', `Starting ${action.replace(/_/g, ' ')}...`);
+
+  if (!window.electronAPI) {
+    const error = 'ElectronAPI not available';
+    onAutomationProgress?.(task.id, 'failed', error);
+    throw new Error(error);
+  }
+
+  const result = await executeApi();
+
+  if (!result.success) {
+    const error = result.error || (result.data as { message?: string } | undefined)?.message || `${action} failed`;
+    onAutomationProgress?.(task.id, 'failed', error);
+    throw new Error(error);
+  }
+
+  console.log(`[PostQaAutomation] ${action} completed successfully for task ${task.id}`);
+  onAutomationProgress?.(task.id, 'success', `${action.replace(/_/g, ' ')} completed successfully`);
+
+  await archiveTask(task.id, project.id);
 }
 
 /**
  * Handle auto-create PR action
  */
-async function handleAutoCreatePR(task: Task, project: { id: string }): Promise<void> {
-  console.log(`[PostQaAutomation] Creating PR for task ${task.id}`);
-
-  if (!window.electronAPI?.createWorktreePR) {
-    throw new Error('createWorktreePR API not available');
-  }
-
-  const result = await window.electronAPI.createWorktreePR(task.id, {
-    title: task.title,
-    draft: false
-  });
-
-  if (!result.success) {
-    throw new Error(result.error || 'Failed to create PR');
-  }
-
-  console.log(`[PostQaAutomation] PR created successfully: ${result.data?.prUrl}`);
-
-  // Archive the task after successful PR creation
-  await archiveTask(task.id, project.id);
+async function handleAutoCreatePR(
+  task: Task,
+  project: { id: string },
+  onAutomationProgress?: (taskId: string, status: 'starting' | 'success' | 'failed', message: string) => void
+): Promise<void> {
+  return executeAutomationAction(
+    'auto_create_pr',
+    task,
+    project,
+    async () => window.electronAPI?.createWorktreePR?.(task.id, {
+      title: task.title,
+      draft: false
+    }) ?? { success: false, error: 'createWorktreePR API not available' },
+    onAutomationProgress
+  );
 }
 
 /**
  * Handle auto-merge action
  */
-async function handleAutoMerge(task: Task, project: { id: string }): Promise<void> {
-  console.log(`[PostQaAutomation] Merging task ${task.id}`);
-
-  if (!window.electronAPI?.mergeWorktree) {
-    throw new Error('mergeWorktree API not available');
-  }
-
-  const result = await window.electronAPI.mergeWorktree(task.id);
-
-  if (!result.success) {
-    throw new Error(result.data?.message || 'Failed to merge');
-  }
-
-  console.log(`[PostQaAutomation] Task ${task.id} merged successfully`);
-
-  // Archive the task after successful merge
-  await archiveTask(task.id, project.id);
+async function handleAutoMerge(
+  task: Task,
+  project: { id: string },
+  onAutomationProgress?: (taskId: string, status: 'starting' | 'success' | 'failed', message: string) => void
+): Promise<void> {
+  return executeAutomationAction(
+    'auto_merge',
+    task,
+    project,
+    async () => window.electronAPI?.mergeWorktree?.(task.id) ?? { success: false, error: 'mergeWorktree API not available' },
+    onAutomationProgress
+  );
 }
 
 /**

--- a/apps/frontend/src/renderer/hooks/usePostQaAutomation.ts
+++ b/apps/frontend/src/renderer/hooks/usePostQaAutomation.ts
@@ -1,0 +1,151 @@
+/**
+ * Hook for handling post-QA automation
+ * Automatically triggers actions (create PR, merge) after successful QA review
+ */
+
+import { useEffect, useRef } from 'react';
+import { useTaskStore } from '../stores/task-store';
+import { useProjectStore } from '../stores/project-store';
+import type { Task } from '../../shared/types';
+
+interface PostQaAutomationOptions {
+  /** Callback when automation is triggered */
+  onAutomationTriggered?: (taskId: string, action: 'auto_create_pr' | 'auto_merge') => void;
+  /** Callback when automation fails */
+  onAutomationFailed?: (taskId: string, error: string) => void;
+}
+
+/**
+ * Hook that listens for task status changes and triggers post-QA automation
+ *
+ * When a task transitions to 'human_review' with reviewReason='completed'
+ * and has postQaAction set in metadata, it automatically:
+ * - Creates a PR (for 'auto_create_pr')
+ * - Merges the worktree (for 'auto_merge')
+ * - Archives the task after successful action
+ */
+export function usePostQaAutomation(options: PostQaAutomationOptions = {}) {
+  const { onAutomationTriggered, onAutomationFailed } = options;
+  const tasks = useTaskStore((state) => state.tasks);
+  const projects = useProjectStore((state) => state.projects);
+
+  // Track processed task IDs to avoid duplicate automation
+  const processedTasks = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    for (const task of tasks) {
+      // Skip if already processed
+      if (processedTasks.current.has(task.id)) {
+        continue;
+      }
+
+      // Check if task is in human_review with completed review reason
+      if (
+        task.status === 'human_review' &&
+        task.reviewReason === 'completed' &&
+        task.metadata?.postQaAction &&
+        task.metadata.postQaAction !== 'do_nothing'
+      ) {
+        const postQaAction = task.metadata.postQaAction;
+        console.log(`[PostQaAutomation] Task ${task.id} completed QA, triggering action: ${postQaAction}`);
+
+        // Mark as processed to avoid duplicate automation
+        processedTasks.current.add(task.id);
+
+        // Find the project for this task
+        const project = projects.find(p => p.id === task.projectId);
+        if (!project) {
+          console.error(`[PostQaAutomation] Project not found for task ${task.id}`);
+          onAutomationFailed?.(task.id, 'Project not found');
+          continue;
+        }
+
+        // Trigger automation after a short delay to ensure state is settled
+        setTimeout(async () => {
+          try {
+            if (postQaAction === 'auto_create_pr') {
+              await handleAutoCreatePR(task, project);
+              onAutomationTriggered?.(task.id, 'auto_create_pr');
+            } else if (postQaAction === 'auto_merge') {
+              await handleAutoMerge(task, project);
+              onAutomationTriggered?.(task.id, 'auto_merge');
+            }
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            console.error(`[PostQaAutomation] Failed to execute ${postQaAction} for task ${task.id}:`, error);
+            onAutomationFailed?.(task.id, errorMessage);
+
+            // Remove from processed set so it can be retried
+            processedTasks.current.delete(task.id);
+          }
+        }, 1000);
+      }
+    }
+  }, [tasks, projects, onAutomationTriggered, onAutomationFailed]);
+}
+
+/**
+ * Handle auto-create PR action
+ */
+async function handleAutoCreatePR(task: Task, project: { id: string }): Promise<void> {
+  console.log(`[PostQaAutomation] Creating PR for task ${task.id}`);
+
+  if (!window.electronAPI?.createWorktreePR) {
+    throw new Error('createWorktreePR API not available');
+  }
+
+  const result = await window.electronAPI.createWorktreePR(task.id, {
+    title: task.title,
+    draft: false
+  });
+
+  if (!result.success) {
+    throw new Error(result.error || 'Failed to create PR');
+  }
+
+  console.log(`[PostQaAutomation] PR created successfully: ${result.data?.prUrl}`);
+
+  // Archive the task after successful PR creation
+  await archiveTask(task.id, project.id);
+}
+
+/**
+ * Handle auto-merge action
+ */
+async function handleAutoMerge(task: Task, project: { id: string }): Promise<void> {
+  console.log(`[PostQaAutomation] Merging task ${task.id}`);
+
+  if (!window.electronAPI?.mergeWorktree) {
+    throw new Error('mergeWorktree API not available');
+  }
+
+  const result = await window.electronAPI.mergeWorktree(task.id);
+
+  if (!result.success) {
+    throw new Error(result.data?.message || 'Failed to merge');
+  }
+
+  console.log(`[PostQaAutomation] Task ${task.id} merged successfully`);
+
+  // Archive the task after successful merge
+  await archiveTask(task.id, project.id);
+}
+
+/**
+ * Archive task after successful automation
+ */
+async function archiveTask(taskId: string, projectId: string): Promise<void> {
+  console.log(`[PostQaAutomation] Archiving task ${taskId}`);
+
+  if (!window.electronAPI?.archiveTasks) {
+    throw new Error('archiveTasks API not available');
+  }
+
+  const result = await window.electronAPI.archiveTasks(projectId, [taskId]);
+
+  if (!result.success) {
+    console.error(`[PostQaAutomation] Failed to archive task ${taskId}:`, result.error);
+  } else {
+    console.log(`[PostQaAutomation] Task ${taskId} archived successfully`);
+  }
+}

--- a/apps/frontend/src/renderer/hooks/usePostQaAutomation.ts
+++ b/apps/frontend/src/renderer/hooks/usePostQaAutomation.ts
@@ -77,6 +77,17 @@ export function usePostQaAutomation(options: PostQaAutomationOptions = {}) {
 
         // Trigger automation after a short delay to ensure state is settled
         const timeoutId = setTimeout(async () => {
+          // Re-validate task state before executing to prevent race conditions
+          const currentTask = tasks.find(t => t.id === task.id);
+          if (!currentTask ||
+              currentTask.status !== 'human_review' ||
+              currentTask.reviewReason !== 'completed' ||
+              currentTask.metadata?.postQaAction !== postQaAction) {
+            console.log(`[PostQaAutomation] Task ${task.id} state changed, skipping automation`);
+            processedTasks.current.delete(task.id);
+            return;
+          }
+
           try {
             if (postQaAction === 'auto_create_pr') {
               await handleAutoCreatePR(task, project, onAutomationProgress);

--- a/apps/frontend/src/renderer/hooks/usePostQaAutomation.ts
+++ b/apps/frontend/src/renderer/hooks/usePostQaAutomation.ts
@@ -78,7 +78,9 @@ export function usePostQaAutomation(options: PostQaAutomationOptions = {}) {
         // Trigger automation after a short delay to ensure state is settled
         const timeoutId = setTimeout(async () => {
           // Re-validate task state before executing to prevent race conditions
-          const currentTask = tasks.find(t => t.id === task.id);
+          // Access store directly to get fresh state, not the stale closure value
+          const currentTasks = useTaskStore.getState().tasks;
+          const currentTask = currentTasks.find(t => t.id === task.id);
           if (!currentTask ||
               currentTask.status !== 'human_review' ||
               currentTask.reviewReason !== 'completed' ||
@@ -204,8 +206,9 @@ async function archiveTask(taskId: string, projectId: string): Promise<void> {
   const result = await window.electronAPI.archiveTasks(projectId, [taskId]);
 
   if (!result.success) {
-    console.error(`[PostQaAutomation] Failed to archive task ${taskId}:`, result.error);
-  } else {
-    console.log(`[PostQaAutomation] Task ${taskId} archived successfully`);
+    const error = result.error || 'Unknown error';
+    console.error(`[PostQaAutomation] Failed to archive task ${taskId}:`, error);
+    throw new Error(`Failed to archive task: ${error}`);
   }
+  console.log(`[PostQaAutomation] Task ${taskId} archived successfully`);
 }

--- a/apps/frontend/src/shared/i18n/locales/en/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/en/tasks.json
@@ -253,6 +253,13 @@
     "classificationOptional": "Classification (optional)",
     "requireReviewLabel": "Require human review before coding",
     "requireReviewDescription": "When enabled, you'll be prompted to review the spec and implementation plan before the coding phase begins. This allows you to approve, request changes, or provide feedback.",
+    "postQaActionLabel": "After successful AI review",
+    "postQaActionDescription": "Choose what happens automatically after AI review passes. Tasks will be auto-archived when using auto options.",
+    "postQaAction": {
+      "do_nothing": "Do nothing - Manual review required",
+      "auto_create_pr": "Auto-create PR",
+      "auto_merge": "Auto-merge to base branch"
+    },
     "errors": {
       "descriptionRequired": "Please provide a description",
       "maxImagesReached": "Maximum of 5 images allowed",

--- a/apps/frontend/src/shared/i18n/locales/en/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/en/tasks.json
@@ -340,5 +340,9 @@
   "referenceImages": {
     "title": "Reference Images (optional)",
     "description": "Add visual references like screenshots or designs to help the AI understand your requirements."
+  },
+  "automation": {
+    "failedTitle": "Post-QA Automation Failed",
+    "failedDescription": "Task \"{{taskId}}\" automation failed: {{error}}"
   }
 }

--- a/apps/frontend/src/shared/i18n/locales/fr/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/tasks.json
@@ -252,6 +252,13 @@
     "classificationOptional": "Classification (optionnel)",
     "requireReviewLabel": "Exiger une révision humaine avant le codage",
     "requireReviewDescription": "Lorsque activé, vous serez invité à réviser la spécification et le plan d'implémentation avant le début de la phase de codage. Cela vous permet d'approuver, de demander des modifications ou de fournir des commentaires.",
+    "postQaActionLabel": "Après révision IA réussie",
+    "postQaActionDescription": "Choisissez ce qui se passe automatiquement après que la révision IA a réussi. Les tâches seront automatiquement archivées lors de l'utilisation des options automatiques.",
+    "postQaAction": {
+      "do_nothing": "Ne rien faire - Révision manuelle requise",
+      "auto_create_pr": "Créer automatiquement une PR",
+      "auto_merge": "Fusionner automatiquement vers la branche de base"
+    },
     "errors": {
       "descriptionRequired": "Veuillez fournir une description",
       "maxImagesReached": "Maximum de 5 images autorisé",

--- a/apps/frontend/src/shared/i18n/locales/fr/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/tasks.json
@@ -339,5 +339,9 @@
   "referenceImages": {
     "title": "Images de référence (facultatif)",
     "description": "Ajoutez des références visuelles comme des captures d'écran ou des conceptions pour aider l'IA à comprendre vos exigences."
+  },
+  "automation": {
+    "failedTitle": "Échec de l'automatisation post-QA",
+    "failedDescription": "L'automatisation de la tâche « {{taskId}} » a échoué : {{error}}"
   }
 }

--- a/apps/frontend/src/shared/types/task.ts
+++ b/apps/frontend/src/shared/types/task.ts
@@ -7,6 +7,9 @@ import type { ExecutionPhase as ExecutionPhaseType, CompletablePhase } from '../
 
 export type TaskStatus = 'backlog' | 'queue' | 'in_progress' | 'ai_review' | 'human_review' | 'done' | 'pr_created' | 'error';
 
+// Post-QA automation actions
+export type PostQaAction = 'do_nothing' | 'auto_create_pr' | 'auto_merge';
+
 // Maps task status columns to ordered task IDs for kanban board reordering
 export type TaskOrderState = Record<TaskStatus, string[]>;
 
@@ -154,7 +157,7 @@ export interface TaskDraft {
   images: ImageAttachment[];
   referencedFiles: ReferencedFile[];
   requireReviewBeforeCoding?: boolean;
-  postQaAction?: 'do_nothing' | 'auto_create_pr' | 'auto_merge';
+  postQaAction?: PostQaAction;
   savedAt: Date;
 }
 
@@ -225,7 +228,7 @@ export interface TaskMetadata {
 
   // Review settings
   requireReviewBeforeCoding?: boolean;  // Require human review of spec/plan before coding starts
-  postQaAction?: 'do_nothing' | 'auto_create_pr' | 'auto_merge';  // What to do after successful AI review
+  postQaAction?: PostQaAction;  // What to do after successful AI review
 
   // Agent configuration (from agent profile or manual selection)
   model?: ModelType;  // Claude model to use (haiku, sonnet, opus) - used when not auto profile

--- a/apps/frontend/src/shared/types/task.ts
+++ b/apps/frontend/src/shared/types/task.ts
@@ -154,6 +154,7 @@ export interface TaskDraft {
   images: ImageAttachment[];
   referencedFiles: ReferencedFile[];
   requireReviewBeforeCoding?: boolean;
+  postQaAction?: 'do_nothing' | 'auto_create_pr' | 'auto_merge';
   savedAt: Date;
 }
 
@@ -224,6 +225,7 @@ export interface TaskMetadata {
 
   // Review settings
   requireReviewBeforeCoding?: boolean;  // Require human review of spec/plan before coding starts
+  postQaAction?: 'do_nothing' | 'auto_create_pr' | 'auto_merge';  // What to do after successful AI review
 
   // Agent configuration (from agent profile or manual selection)
   model?: ModelType;  // Claude model to use (haiku, sonnet, opus) - used when not auto profile

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
     },
     "apps/frontend": {
       "name": "auto-claude-ui",
-      "version": "2.7.4",
+      "version": "2.7.6-beta.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {


### PR DESCRIPTION
## Summary
- ✅ Added "Post-QA Action" dropdown to task creation/edit dialog
- ✅ Three automation options: Do nothing (default), Auto-create PR, Auto-merge
- ✅ Auto options automatically archive tasks after successful completion
- ✅ New `usePostQaAutomation` hook monitors task status changes
- ✅ Comprehensive pre-PR validation with 9 parallel code reviews passed
- ✅ All auto-fixes applied and verified (memory leaks, race conditions, code quality)

## What it does
When creating a task, users can now choose what happens automatically after AI review succeeds:
- **Do nothing** (default) - Manual review and merge required
- **Auto-create PR** - Automatically creates a PR and archives the task
- **Auto-merge** - Automatically merges to base branch and archives the task

The automation triggers when a task transitions to `human_review` status with `reviewReason='completed'`.

## Changes
- Added `postQaAction` to TaskMetadata type definition
- Added Post-QA Action dropdown to TaskFormFields component
- Integrated state management in TaskCreationWizard and TaskEditDialog
- Created `usePostQaAutomation` hook with proper cleanup and error handling
- Added i18n translations for en/fr locales

## Test plan
- [x] Lint passes (Biome)
- [x] TypeScript types pass for modified files
- [x] Pre-PR validation passed (9 parallel code reviews)
- [x] Auto-fixes applied: memory leaks, race conditions, code quality improvements
- [x] Manual testing: Dropdown appears and saves correctly in task metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Post‑QA automation: users can choose what happens after a successful AI review — Do nothing, Auto‑create PR, or Auto‑merge. Selected action is saved with task drafts and preserved when editing.
* **Notifications**
  * Failures in post‑QA automation show localized error toasts to inform users when an automatic action fails.
* **Localization**
  * Added UI text for the new Post‑QA options and automation failure messages (en + fr).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->