### PR TITLE
fix: Add support for prepaid billing with primaryApiKey authentication

### DIFF
--- a/apps/backend/core/auth.py
+++ b/apps/backend/core/auth.py
@@ -628,6 +628,14 @@ def _is_valid_primary_api_key(value: str | None) -> bool:
     return bool(value and isinstance(value, str) and value.startswith("sk-ant-"))
 
 
+def _resolve_primary_api_key(config_dir: str | None = None) -> str | None:
+    effective_config_dir = config_dir or os.environ.get("CLAUDE_CONFIG_DIR")
+    if not effective_config_dir:
+        return None
+    return _get_primary_api_key_from_config_dir(
+        os.path.expanduser(effective_config_dir)
+    )
+
 
 def _get_primary_api_key_from_config_dir(expanded_dir: str) -> str | None:
     claude_json_path = os.path.join(expanded_dir, ".claude.json")
@@ -640,7 +648,7 @@ def _get_primary_api_key_from_config_dir(expanded_dir: str) -> str | None:
         if _is_valid_primary_api_key(api_key):
             logger.debug(f"Found primaryApiKey in {claude_json_path}")
             return api_key
-    except (json.JSONDecodeError, KeyError, Exception) as e:
+    except (json.JSONDecodeError, OSError) as e:
         logger.debug(f"Failed to read primaryApiKey from {claude_json_path}: {e}")
     return None
 
@@ -1011,10 +1019,7 @@ def configure_sdk_authentication(config_dir: str | None = None) -> None:
         # Check if profile uses primaryApiKey (prepaid/API billing mode)
         # In this mode, Claude Code stores an API key in .claude.json instead of
         # OAuth tokens in the credential store. Route to ANTHROPIC_AUTH_TOKEN.
-        effective_config_dir = config_dir or os.environ.get("CLAUDE_CONFIG_DIR")
-        primary_api_key = _get_primary_api_key_from_config_dir(
-            os.path.expanduser(effective_config_dir)
-        ) if effective_config_dir else None
+        primary_api_key = _resolve_primary_api_key(config_dir)
 
         if primary_api_key:
             os.environ["ANTHROPIC_AUTH_TOKEN"] = primary_api_key
@@ -1047,10 +1052,7 @@ def ensure_claude_code_oauth_token() -> None:
     if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
         return
 
-    config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
-    primary_api_key = _get_primary_api_key_from_config_dir(
-        os.path.expanduser(config_dir)
-    ) if config_dir else None
+    primary_api_key = _resolve_primary_api_key()
 
     if primary_api_key:
         os.environ["ANTHROPIC_AUTH_TOKEN"] = primary_api_key

--- a/apps/backend/core/auth.py
+++ b/apps/backend/core/auth.py
@@ -624,6 +624,27 @@ def _get_token_from_linux_secret_service(config_dir: str | None = None) -> str |
         return None
 
 
+def _is_valid_primary_api_key(value: str | None) -> bool:
+    return bool(value and isinstance(value, str) and value.startswith("sk-ant-"))
+
+
+
+def _get_primary_api_key_from_config_dir(expanded_dir: str) -> str | None:
+    claude_json_path = os.path.join(expanded_dir, ".claude.json")
+    if not os.path.exists(claude_json_path):
+        return None
+    try:
+        with open(claude_json_path, encoding="utf-8") as f:
+            data = json.load(f)
+        api_key = data.get("primaryApiKey")
+        if _is_valid_primary_api_key(api_key):
+            logger.debug(f"Found primaryApiKey in {claude_json_path}")
+            return api_key
+    except (json.JSONDecodeError, KeyError, Exception) as e:
+        logger.debug(f"Failed to read primaryApiKey from {claude_json_path}: {e}")
+    return None
+
+
 def _get_token_from_config_dir(config_dir: str) -> str | None:
     """
     Read token from a custom config directory's credentials file.
@@ -665,6 +686,10 @@ def _get_token_from_config_dir(config_dir: str) -> str | None:
             except (json.JSONDecodeError, KeyError, Exception) as e:
                 logger.debug(f"Failed to read {cred_path}: {e}")
                 continue
+
+    primary_api_key = _get_primary_api_key_from_config_dir(expanded_dir)
+    if primary_api_key:
+        return primary_api_key
 
     return None
 
@@ -983,20 +1008,33 @@ def configure_sdk_authentication(config_dir: str | None = None) -> None:
         os.environ.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
         logger.info("Using API profile authentication")
     else:
-        # OAuth mode: require and validate OAuth token
-        # Get OAuth token - uses profile-specific Keychain lookup when config_dir is set
-        # This correctly reads from "Claude Code-credentials-{hash}" for non-default profiles
-        oauth_token = require_auth_token(config_dir)
+        # Check if profile uses primaryApiKey (prepaid/API billing mode)
+        # In this mode, Claude Code stores an API key in .claude.json instead of
+        # OAuth tokens in the credential store. Route to ANTHROPIC_AUTH_TOKEN.
+        effective_config_dir = config_dir or os.environ.get("CLAUDE_CONFIG_DIR")
+        primary_api_key = _get_primary_api_key_from_config_dir(
+            os.path.expanduser(effective_config_dir)
+        ) if effective_config_dir else None
 
-        # Validate token is not encrypted before passing to SDK
-        # Encrypted tokens (enc:...) should have been decrypted by require_auth_token()
-        # If we still have an encrypted token here, it means decryption failed or was skipped
-        validate_token_not_encrypted(oauth_token)
+        if primary_api_key:
+            os.environ["ANTHROPIC_AUTH_TOKEN"] = primary_api_key
+            os.environ.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+            logger.info("Using primaryApiKey authentication (prepaid billing)")
+        else:
+            # OAuth mode: require and validate OAuth token
+            # Get OAuth token - uses profile-specific Keychain lookup when config_dir is set
+            # This correctly reads from "Claude Code-credentials-{hash}" for non-default profiles
+            oauth_token = require_auth_token(config_dir)
 
-        # Ensure SDK can access it via its expected env var
-        # This is required because the SDK doesn't know about per-profile Keychain naming
-        os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
-        logger.info("Using OAuth authentication")
+            # Validate token is not encrypted before passing to SDK
+            # Encrypted tokens (enc:...) should have been decrypted by require_auth_token()
+            # If we still have an encrypted token here, it means decryption failed or was skipped
+            validate_token_not_encrypted(oauth_token)
+
+            # Ensure SDK can access it via its expected env var
+            # This is required because the SDK doesn't know about per-profile Keychain naming
+            os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = oauth_token
+            logger.info("Using OAuth authentication")
 
 
 def ensure_claude_code_oauth_token() -> None:
@@ -1007,6 +1045,16 @@ def ensure_claude_code_oauth_token() -> None:
     to CLAUDE_CODE_OAUTH_TOKEN so the underlying SDK can use it.
     """
     if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN"):
+        return
+
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    primary_api_key = _get_primary_api_key_from_config_dir(
+        os.path.expanduser(config_dir)
+    ) if config_dir else None
+
+    if primary_api_key:
+        os.environ["ANTHROPIC_AUTH_TOKEN"] = primary_api_key
+        os.environ.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
         return
 
     token = get_auth_token()

--- a/apps/frontend/src/main/claude-profile/profile-utils.ts
+++ b/apps/frontend/src/main/claude-profile/profile-utils.ts
@@ -80,6 +80,9 @@ export function isProfileAuthenticated(profile: ClaudeProfile): boolean {
       const data = JSON.parse(content);
       // Check for oauthAccount which indicates successful OAuth authentication
       if (data && typeof data === 'object' && (data.oauthAccount?.accountUuid || data.oauthAccount?.emailAddress)) {
+        if (hasPrimaryApiKeyInConfigDir(configDir)) {
+          return true;
+        }
         // The actual OAuth tokens are stored in platform-specific credential storage:
         // - macOS: Keychain
         // - Windows: Credential Manager
@@ -232,6 +235,31 @@ export function expandHomePath(path: string): string {
     return path.replace(/^~/, home);
   }
   return path;
+}
+
+function isValidPrimaryApiKey(value: unknown): boolean {
+  return typeof value === 'string' && value.startsWith('sk-ant-');
+}
+
+export function hasPrimaryApiKeyInConfigDir(configDir?: string): boolean {
+  if (!configDir) {
+    return false;
+  }
+
+  const expandedConfigDir = expandHomePath(configDir);
+  const claudeJsonPath = join(expandedConfigDir, '.claude.json');
+
+  if (!existsSync(claudeJsonPath)) {
+    return false;
+  }
+
+  try {
+    const content = readFileSync(claudeJsonPath, 'utf-8');
+    const data = JSON.parse(content);
+    return isValidPrimaryApiKey(data?.primaryApiKey);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/apps/frontend/src/main/claude-profile/profile-utils.ts
+++ b/apps/frontend/src/main/claude-profile/profile-utils.ts
@@ -71,6 +71,10 @@ export function isProfileAuthenticated(profile: ClaudeProfile): boolean {
     return false;
   }
 
+  if (hasPrimaryApiKeyInConfigDir(configDir)) {
+    return true;
+  }
+
   // Check for .claude.json with OAuth account info (modern Claude Code CLI)
   // This is how Claude Code CLI stores OAuth authentication since v1.0
   const claudeJsonPath = join(configDir, '.claude.json');
@@ -80,9 +84,6 @@ export function isProfileAuthenticated(profile: ClaudeProfile): boolean {
       const data = JSON.parse(content);
       // Check for oauthAccount which indicates successful OAuth authentication
       if (data && typeof data === 'object' && (data.oauthAccount?.accountUuid || data.oauthAccount?.emailAddress)) {
-        if (hasPrimaryApiKeyInConfigDir(configDir)) {
-          return true;
-        }
         // The actual OAuth tokens are stored in platform-specific credential storage:
         // - macOS: Keychain
         // - Windows: Credential Manager
@@ -257,7 +258,8 @@ export function hasPrimaryApiKeyInConfigDir(configDir?: string): boolean {
     const content = readFileSync(claudeJsonPath, 'utf-8');
     const data = JSON.parse(content);
     return isValidPrimaryApiKey(data?.primaryApiKey);
-  } catch {
+  } catch (error) {
+    console.warn(`[profile-utils] Failed to read or parse ${claudeJsonPath}:`, error);
     return false;
   }
 }

--- a/apps/frontend/src/main/claude-profile/usage-monitor.ts
+++ b/apps/frontend/src/main/claude-profile/usage-monitor.ts
@@ -793,6 +793,8 @@ export class UsageMonitor extends EventEmitter {
     const profileManager = getClaudeProfileManager();
     const activeProfile = profileManager.getActiveProfile();
     if (activeProfile) {
+      const hasPrimaryKey = hasPrimaryApiKeyInConfigDir(activeProfile.configDir);
+
       // Use ensureValidToken to proactively refresh tokens before they expire
       // This prevents 401 errors during overnight autonomous operation
       try {
@@ -836,7 +838,7 @@ export class UsageMonitor extends EventEmitter {
 
           // Check for missing_credentials error - indicates no token in credential store
           // User needs to authenticate via /login
-          if (tokenResult.errorCode === 'missing_credentials' && !hasPrimaryApiKeyInConfigDir(activeProfile.configDir)) {
+          if (tokenResult.errorCode === 'missing_credentials' && !hasPrimaryKey) {
             this.debugLog('[UsageMonitor] Profile needs authentication (no credentials found): ' + activeProfile.name);
             this.needsReauthProfiles.add(activeProfile.id);
           }
@@ -862,7 +864,7 @@ export class UsageMonitor extends EventEmitter {
           ' - user may need to re-authenticate with claude /login');
       }
 
-      if (!hasPrimaryApiKeyInConfigDir(activeProfile.configDir)) {
+      if (!hasPrimaryKey) {
         // Mark profile as needing re-authentication since credentials are missing
         this.needsReauthProfiles.add(activeProfile.id);
       }

--- a/apps/frontend/src/main/claude-profile/usage-monitor.ts
+++ b/apps/frontend/src/main/claude-profile/usage-monitor.ts
@@ -20,6 +20,7 @@ import { getCredentialsFromKeychain, clearKeychainCache } from './credential-uti
 import { reactiveTokenRefresh, ensureValidToken } from './token-refresh';
 import { isProfileRateLimited } from './rate-limit-manager';
 import { getOperationRegistry } from './operation-registry';
+import { hasPrimaryApiKeyInConfigDir } from './profile-utils';
 
 // Re-export for backward compatibility
 export type { ApiProvider };
@@ -380,7 +381,7 @@ export class UsageMonitor extends EventEmitter {
             ? profile.configDir.replace(/^~/, homedir())
             : profile.configDir;
           const creds = getCredentialsFromKeychain(expandedConfigDir);
-          if (!creds.token) {
+          if (!creds.token && !hasPrimaryApiKeyInConfigDir(expandedConfigDir)) {
             // Credentials are missing - mark for re-auth
             this.needsReauthProfiles.add(profile.id);
             this.debugLog('[UsageMonitor:getAllProfilesUsage] Profile needs re-auth (no credentials): ' + profile.name);
@@ -635,8 +636,10 @@ export class UsageMonitor extends EventEmitter {
 
         if (!token) {
           this.debugLog('[UsageMonitor] No keychain credentials for inactive profile: ' + profile.name);
-          // Mark profile as needing re-authentication since credentials are missing
-          this.needsReauthProfiles.add(profile.id);
+          if (!hasPrimaryApiKeyInConfigDir(expandedConfigDir)) {
+            // Mark profile as needing re-authentication since credentials are missing
+            this.needsReauthProfiles.add(profile.id);
+          }
           return null;
         }
       }
@@ -833,7 +836,7 @@ export class UsageMonitor extends EventEmitter {
 
           // Check for missing_credentials error - indicates no token in credential store
           // User needs to authenticate via /login
-          if (tokenResult.errorCode === 'missing_credentials') {
+          if (tokenResult.errorCode === 'missing_credentials' && !hasPrimaryApiKeyInConfigDir(activeProfile.configDir)) {
             this.debugLog('[UsageMonitor] Profile needs authentication (no credentials found): ' + activeProfile.name);
             this.needsReauthProfiles.add(activeProfile.id);
           }
@@ -859,8 +862,10 @@ export class UsageMonitor extends EventEmitter {
           ' - user may need to re-authenticate with claude /login');
       }
 
-      // Mark profile as needing re-authentication since credentials are missing
-      this.needsReauthProfiles.add(activeProfile.id);
+      if (!hasPrimaryApiKeyInConfigDir(activeProfile.configDir)) {
+        // Mark profile as needing re-authentication since credentials are missing
+        this.needsReauthProfiles.add(activeProfile.id);
+      }
     }
 
     // No credential available


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

Fixes authentication detection for prepaid billing accounts (Anthropic Platform API / pay-per-token). These accounts store a `primaryApiKey` in `.claude.json` instead of OAuth tokens in the system credential store. Auto Claude was not recognizing this as valid authentication, causing "Re-authentication required" errors and falling back to simple mode.

## Related Issue

Closes #1768

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [ ] Frontend
- [ ] Backend
- [x] Fullstack

## Changes

### Frontend (`profile-utils.ts`)
- Added `isValidPrimaryApiKey()` helper to validate API key format
- Added `hasPrimaryApiKeyInConfigDir()` to check for `primaryApiKey` in `.claude.json`
- Modified `isProfileAuthenticated()` to recognize `primaryApiKey` as valid authentication

### Frontend (`usage-monitor.ts`)
- Added `hasPrimaryApiKeyInConfigDir()` guard in 4 locations to prevent profiles with `primaryApiKey` from being incorrectly flagged for re-authentication

### Backend (`auth.py`)
- Added `_is_valid_primary_api_key()` helper for consistent key validation
- Added `_get_primary_api_key_from_config_dir()` to read `primaryApiKey` directly from `.claude.json`
- Modified `_get_token_from_config_dir()` to fall back to `primaryApiKey` when no OAuth token is found
- Modified `configure_sdk_authentication()` to read `primaryApiKey` directly (not through the generic token chain) and route it to `ANTHROPIC_AUTH_TOKEN`
- Modified `ensure_claude_code_oauth_token()` with the same direct read approach

## Commit Message Format

Follow conventional commits: `<type>: <subject>`

**Types:** feat, fix, docs, style, refactor, test, chore

**Example:** `feat: add user authentication system`

## AI Disclosure

- [x] This PR includes AI-generated code (Claude, Codex, Copilot, etc.)

**Tool(s) used:** Claude (via Cursor)
**Testing level:**
- [ ] Untested -- AI output not yet verified
- [x] Lightly tested -- ran the app / spot-checked key paths
- [ ] Fully tested -- all tests pass, manually verified behavior

- [x] I understand what this PR does and how the underlying code works

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)

## Platform Testing Checklist

- [x] **Windows tested** (either on Windows or via CI)
- [ ] **macOS tested** (either on macOS or via CI)
- [ ] **Linux tested** (CI covers this)
- [x] Used centralized `platform/` module instead of direct `process.platform` checks
- [x] No hardcoded paths (used `findExecutable()` or platform abstractions)

**If you only have access to one OS:** CI now tests on all platforms. Ensure all checks pass before submitting.

## CI/Testing Requirements

- [ ] All CI checks pass on **all platforms** (Windows, macOS, Linux)
- [x] All existing tests pass
- [ ] New features include test coverage
- [ ] Bug fixes include regression tests

## Feature Toggle

- [x] N/A - Feature is complete and ready for all users

## Breaking Changes

**Breaking:** No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for authenticating with a per-profile primary API key stored in profile config, as an alternative to OAuth.

* **Improvements**
  * Credential handling now detects primary API keys and bypasses unnecessary OAuth flows and re-auth prompts.
  * Usage and credential checks updated to suppress re-auth signals when a valid primary API key exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->