### PR TITLE
fix(recovery): wire up startup recovery scan to reset stuck tasks after crash

### DIFF
--- a/apps/frontend/src/main/agent/agent-manager.ts
+++ b/apps/frontend/src/main/agent/agent-manager.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import path from 'path';
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { AgentState } from './agent-state';
 import { AgentEvents } from './agent-events';
 import { AgentProcessManager } from './agent-process';
@@ -14,7 +14,7 @@ import {
   RoadmapConfig
 } from './types';
 import type { IdeationConfig } from '../../shared/types';
-import { resetStuckSubtasks } from '../ipc-handlers/task/plan-file-utils';
+import { recoverStuckPlan, resetStuckSubtasks } from '../ipc-handlers/task/plan-file-utils';
 import { AUTO_BUILD_PATHS, getSpecsDir, sanitizeThinkingLevel } from '../../shared/constants';
 import { projectStore } from '../project-store';
 
@@ -156,57 +156,17 @@ export class AgentManager extends EventEmitter {
 
             totalScanned++;
 
-            // 1. Reset stuck subtasks (in_progress/failed -> pending)
-            const { success, resetCount } = await resetStuckSubtasks(planPath, project.id);
+            // Recover stuck subtasks and task-level status in a single atomic operation
+            const result = await recoverStuckPlan(planPath, project.id);
 
-            if (success && resetCount > 0) {
-              totalSubtasksReset += resetCount;
-              console.log(`[AgentManager] Startup recovery: Reset ${resetCount} stuck subtask(s) in ${specDirName}`);
+            if (result.subtasksReset > 0) {
+              totalSubtasksReset += result.subtasksReset;
+              console.log(`[AgentManager] Startup recovery: Reset ${result.subtasksReset} stuck subtask(s) in ${specDirName}`);
             }
 
-            // 2. Reset stuck task-level status
-            // At startup no agents are running, so any task with in_progress status is stuck.
-            // Choose the correct target status based on subtask completion:
-            // - All subtasks completed → human_review (work is done, needs review)
-            // - Some subtasks incomplete → queue (work needs to resume)
-            try {
-              const planContent = readFileSync(planPath, 'utf-8');
-              const plan = JSON.parse(planContent);
-
-              if (plan.status === 'in_progress') {
-                // Check subtask completion state (after stuck subtasks were already reset above)
-                const allSubtasks = (plan.phases || []).flatMap(
-                  (p: { subtasks?: { status: string }[] }) => p.subtasks || []
-                );
-                const allCompleted = allSubtasks.length > 0 &&
-                  allSubtasks.every((s: { status: string }) => s.status === 'completed');
-
-                if (allCompleted) {
-                  // All coding work is done — move to human_review so user can approve or re-run QA
-                  plan.status = 'human_review';
-                  plan.planStatus = 'review';
-                  plan.xstateState = 'human_review';
-                  plan.executionPhase = 'complete';
-                  console.log(`[AgentManager] Startup recovery: Task ${specDirName} has all subtasks completed — setting to human_review`);
-                } else {
-                  // Work is incomplete — set to queue so user can restart
-                  plan.status = 'queue';
-                  plan.planStatus = 'queued';
-                  delete plan.xstateState;
-                  delete plan.executionPhase;
-                  console.log(`[AgentManager] Startup recovery: Reset task status in_progress -> queue in ${specDirName}`);
-                }
-
-                plan.updated_at = new Date().toISOString();
-                writeFileSync(planPath, JSON.stringify(plan, null, 2), 'utf-8');
-                totalTasksReset++;
-
-                if (project.id) {
-                  projectStore.invalidateTasksCache(project.id);
-                }
-              }
-            } catch (planErr) {
-              console.warn(`[AgentManager] Failed to check/reset task status for ${specDirName}:`, planErr);
+            if (result.taskStatusChanged) {
+              totalTasksReset++;
+              console.log(`[AgentManager] Startup recovery: Task ${specDirName} status → ${result.newStatus}`);
             }
           }
         } catch (err) {

--- a/apps/frontend/src/main/agent/agent-manager.ts
+++ b/apps/frontend/src/main/agent/agent-manager.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import path from 'path';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { AgentState } from './agent-state';
 import { AgentEvents } from './agent-events';
 import { AgentProcessManager } from './agent-process';
@@ -111,7 +111,7 @@ export class AgentManager extends EventEmitter {
    * Scans all projects for implementation_plan.json files and resets any stuck subtasks
    */
   async runStartupRecoveryScan(): Promise<void> {
-    console.log('[AgentManager] Running startup recovery scan for stuck subtasks...');
+    console.log('[AgentManager] Running startup recovery scan for stuck tasks...');
 
     try {
       // Get all projects from the store
@@ -123,9 +123,10 @@ export class AgentManager extends EventEmitter {
       }
 
       let totalScanned = 0;
-      let totalReset = 0;
+      let totalSubtasksReset = 0;
+      let totalTasksReset = 0;
 
-      // Scan each project for stuck subtasks
+      // Scan each project for stuck subtasks and task-level status
       for (const project of projects) {
         if (!project.autoBuildPath) {
           continue; // Skip projects that haven't been initialized yet
@@ -155,12 +156,57 @@ export class AgentManager extends EventEmitter {
 
             totalScanned++;
 
-            // Reset stuck subtasks (pass project.id to invalidate tasks cache)
+            // 1. Reset stuck subtasks (in_progress/failed -> pending)
             const { success, resetCount } = await resetStuckSubtasks(planPath, project.id);
 
             if (success && resetCount > 0) {
-              totalReset += resetCount;
+              totalSubtasksReset += resetCount;
               console.log(`[AgentManager] Startup recovery: Reset ${resetCount} stuck subtask(s) in ${specDirName}`);
+            }
+
+            // 2. Reset stuck task-level status
+            // At startup no agents are running, so any task with in_progress status is stuck.
+            // Choose the correct target status based on subtask completion:
+            // - All subtasks completed → human_review (work is done, needs review)
+            // - Some subtasks incomplete → queue (work needs to resume)
+            try {
+              const planContent = readFileSync(planPath, 'utf-8');
+              const plan = JSON.parse(planContent);
+
+              if (plan.status === 'in_progress') {
+                // Check subtask completion state (after stuck subtasks were already reset above)
+                const allSubtasks = (plan.phases || []).flatMap(
+                  (p: { subtasks?: { status: string }[] }) => p.subtasks || []
+                );
+                const allCompleted = allSubtasks.length > 0 &&
+                  allSubtasks.every((s: { status: string }) => s.status === 'completed');
+
+                if (allCompleted) {
+                  // All coding work is done — move to human_review so user can approve or re-run QA
+                  plan.status = 'human_review';
+                  plan.planStatus = 'review';
+                  plan.xstateState = 'human_review';
+                  plan.executionPhase = 'complete';
+                  console.log(`[AgentManager] Startup recovery: Task ${specDirName} has all subtasks completed — setting to human_review`);
+                } else {
+                  // Work is incomplete — set to queue so user can restart
+                  plan.status = 'queue';
+                  plan.planStatus = 'queued';
+                  delete plan.xstateState;
+                  delete plan.executionPhase;
+                  console.log(`[AgentManager] Startup recovery: Reset task status in_progress -> queue in ${specDirName}`);
+                }
+
+                plan.updated_at = new Date().toISOString();
+                writeFileSync(planPath, JSON.stringify(plan, null, 2), 'utf-8');
+                totalTasksReset++;
+
+                if (project.id) {
+                  projectStore.invalidateTasksCache(project.id);
+                }
+              }
+            } catch (planErr) {
+              console.warn(`[AgentManager] Failed to check/reset task status for ${specDirName}:`, planErr);
             }
           }
         } catch (err) {
@@ -168,10 +214,10 @@ export class AgentManager extends EventEmitter {
         }
       }
 
-      if (totalReset > 0) {
-        console.log(`[AgentManager] Startup recovery complete: Reset ${totalReset} stuck subtask(s) across ${totalScanned} task(s)`);
+      if (totalSubtasksReset > 0 || totalTasksReset > 0) {
+        console.log(`[AgentManager] Startup recovery complete: Reset ${totalSubtasksReset} stuck subtask(s) and ${totalTasksReset} stuck task(s) across ${totalScanned} spec(s)`);
       } else {
-        console.log(`[AgentManager] Startup recovery complete: No stuck subtasks found (scanned ${totalScanned} task(s))`);
+        console.log(`[AgentManager] Startup recovery complete: No stuck tasks found (scanned ${totalScanned} spec(s))`);
       }
     } catch (err) {
       console.error('[AgentManager] Startup recovery scan failed:', err);

--- a/apps/frontend/src/main/index.ts
+++ b/apps/frontend/src/main/index.ts
@@ -474,6 +474,16 @@ app.whenReady().then(() => {
   // Create window
   createWindow();
 
+  // Run startup recovery scan to reset any tasks stuck in "in_progress" from a crash/restart.
+  // At startup no agents are running, so any in_progress tasks are stale.
+  // This resets stuck subtasks (in_progress/failed -> pending) and task-level status (in_progress -> queue),
+  // allowing the user to restart tasks cleanly.
+  if (agentManager) {
+    agentManager.runStartupRecoveryScan().catch((error) => {
+      console.error('[main] Startup recovery scan failed:', error);
+    });
+  }
+
   // Pre-warm CLI tool cache in background (non-blocking)
   // This ensures CLI detection is done before user needs it
   // Include all commonly used tools to prevent sync blocking on first use

--- a/apps/frontend/src/main/ipc-handlers/task/plan-file-utils.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/plan-file-utils.ts
@@ -502,6 +502,137 @@ export async function resetStuckSubtasks(planPath: string, projectId?: string): 
 }
 
 /**
+ * Subtask shape used within implementation plan phases.
+ * Phases may use either 'subtasks' or 'chunks' as the property name.
+ */
+interface PlanSubtask {
+  id: string;
+  status: string;
+  started_at?: string | null;
+  completed_at?: string | null;
+}
+
+/**
+ * Minimal shape of a parsed implementation_plan.json for recovery operations.
+ */
+interface RecoveryPlan {
+  status?: string;
+  planStatus?: string;
+  xstateState?: string;
+  executionPhase?: string;
+  updated_at?: string;
+  phases?: Array<{
+    subtasks?: PlanSubtask[];
+    chunks?: PlanSubtask[];
+  }>;
+  [key: string]: unknown;
+}
+
+/** Result of a startup recovery operation on a single plan file. */
+export interface RecoveryResult {
+  success: boolean;
+  subtasksReset: number;
+  taskStatusChanged: boolean;
+  newStatus?: string;
+}
+
+/**
+ * Recover a stuck plan file during startup.
+ *
+ * Performs two recovery actions in a single atomic, locked operation:
+ * 1. Resets stuck subtasks (in_progress/failed → pending)
+ * 2. Corrects task-level status (in_progress/error → queue or human_review)
+ *
+ * Thread-safe via withPlanLock. Uses atomic temp+rename writes to prevent
+ * file corruption if the process is interrupted.
+ *
+ * Handles both 'subtasks' and 'chunks' phase property naming for backward
+ * compatibility with older plan formats.
+ *
+ * @param planPath - Path to the implementation_plan.json file
+ * @param projectId - Optional project ID to invalidate cache
+ * @returns RecoveryResult with details of what was changed
+ */
+export async function recoverStuckPlan(planPath: string, projectId?: string): Promise<RecoveryResult> {
+  return withPlanLock(planPath, async () => {
+    try {
+      // Read file directly without existence check to avoid TOCTOU race condition
+      const planContent = readFileSync(planPath, 'utf-8');
+      const plan: RecoveryPlan = JSON.parse(planContent);
+
+      let subtasksReset = 0;
+      let taskStatusChanged = false;
+      let newStatus: string | undefined;
+
+      // 1. Reset stuck subtasks (in_progress/failed → pending)
+      // Handle both 'subtasks' and 'chunks' naming (older plan format)
+      if (plan.phases && Array.isArray(plan.phases)) {
+        for (const phase of plan.phases) {
+          const items: PlanSubtask[] = phase.subtasks || phase.chunks || [];
+          for (const subtask of items) {
+            if (subtask.status === 'in_progress' || subtask.status === 'failed') {
+              const originalStatus = subtask.status;
+              subtask.status = 'pending';
+              subtask.started_at = null;
+              subtask.completed_at = null;
+              subtasksReset++;
+              console.log(`[plan-file-utils] Reset subtask ${subtask.id} from ${originalStatus} to pending`);
+            }
+          }
+        }
+      }
+
+      // 2. Correct stuck task-level status
+      // At startup no agents are running, so in_progress or error status means the task is stuck.
+      if (plan.status === 'in_progress' || plan.status === 'error') {
+        // Determine target status based on subtask completion
+        // (checked AFTER subtask reset, so in_progress subtasks are now pending)
+        const allSubtasks: PlanSubtask[] = (plan.phases || []).flatMap(
+          (p) => p.subtasks || p.chunks || []
+        );
+        const allCompleted = allSubtasks.length > 0 &&
+          allSubtasks.every((s) => s.status === 'completed');
+
+        if (allCompleted) {
+          // All coding work is done — move to human_review
+          plan.status = 'human_review';
+          plan.planStatus = 'review';
+          plan.xstateState = 'human_review';
+          plan.executionPhase = 'complete';
+          newStatus = 'human_review';
+        } else {
+          // Work is incomplete — set to queue so user can restart
+          plan.status = 'queue';
+          plan.planStatus = 'queued';
+          delete plan.xstateState;
+          delete plan.executionPhase;
+          newStatus = 'queue';
+        }
+        taskStatusChanged = true;
+      }
+
+      // Only write if something changed
+      if (subtasksReset > 0 || taskStatusChanged) {
+        plan.updated_at = new Date().toISOString();
+        writeFileAtomicSync(planPath, JSON.stringify(plan, null, 2));
+
+        if (projectId) {
+          projectStore.invalidateTasksCache(projectId);
+        }
+      }
+
+      return { success: true, subtasksReset, taskStatusChanged, newStatus };
+    } catch (err) {
+      if (isFileNotFoundError(err)) {
+        return { success: false, subtasksReset: 0, taskStatusChanged: false };
+      }
+      console.warn(`[plan-file-utils] Could not recover stuck plan at ${planPath}:`, err);
+      return { success: false, subtasksReset: 0, taskStatusChanged: false };
+    }
+  });
+}
+
+/**
  * Update task_metadata.json to add PR URL.
  * This is a simple JSON file update (no locking needed as it's rarely updated concurrently).
  *


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

`runStartupRecoveryScan()` was fully implemented in `AgentManager` but never called on app startup. When the app crashes or the user force-restarts mid-task, tasks get permanently stuck in `in_progress` with stale XState/executionPhase state persisted in `implementation_plan.json`. The UI reconstructs a "running" state from the persisted data, making it impossible to restart these tasks — there's no start button because the app thinks they're already running, but no agent process actually exists.

This PR wires up the existing recovery scan on app launch and enhances it to also reset task-level status (not just subtasks), choosing the correct target state based on subtask completion.

## Related Issue

Related to PR #1726 (branch `auto-claude/194-bug-rate-limit-during-task-execution-causes-subtas`) which implemented this fix but was never merged to develop.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [x] Frontend
- [ ] Backend
- [ ] Fullstack

## Commit Message Format

`fix(recovery): wire up startup recovery scan to reset stuck tasks after crash`

## AI Disclosure

- [x] This PR includes AI-generated code (Claude, Codex, Copilot, etc.)

**Tool(s) used:** Claude Code (Claude Opus 4.6)
**Testing level:**
- [ ] Untested -- AI output not yet verified
- [ ] Lightly tested -- ran the app / spot-checked key paths
- [x] Fully tested -- all tests pass, manually verified behavior

- [x] I understand what this PR does and how the underlying code works

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)

## Platform Testing Checklist

- [ ] **Windows tested** (either on Windows or via CI)
- [x] **macOS tested** (either on macOS or via CI)
- [ ] **Linux tested** (CI covers this)
- [x] Used centralized `platform/` module instead of direct `process.platform` checks
- [x] No hardcoded paths (used `findExecutable()` or platform abstractions)

**If you only have access to one OS:** CI now tests on all platforms. Ensure all checks pass before submitting.

## CI/Testing Requirements

- [ ] All CI checks pass on **all platforms** (Windows, macOS, Linux)
- [x] All existing tests pass
- [ ] New features include test coverage
- [ ] Bug fixes include regression tests

## What Changed

### `apps/frontend/src/main/index.ts`
- Added call to `agentManager.runStartupRecoveryScan()` after `createWindow()` in the `app.whenReady()` initialization flow
- Runs async, non-blocking, with error handling via `.catch()`

### `apps/frontend/src/main/agent/agent-manager.ts`
- Added `readFileSync`, `writeFileSync` to fs imports
- Enhanced `runStartupRecoveryScan()` to also reset task-level status after resetting stuck subtasks:
  - **All subtasks completed** → sets status to `human_review` with `xstateState: 'human_review'` and `executionPhase: 'complete'` (work is done, user should review)
  - **Incomplete subtasks** → sets status to `queue` and clears `xstateState`/`executionPhase` (user can click Start to resume)
- This prevents `correctStaleTaskStatus()` in `project-store.ts` from fighting the recovery by choosing the correct status upfront

### How it works
1. On app startup (after window creation), `runStartupRecoveryScan()` is called
2. It iterates all projects and their spec directories
3. For each `implementation_plan.json`:
   - Resets stuck subtasks (`in_progress`/`failed` → `pending`) via existing `resetStuckSubtasks()`
   - Reads the plan and checks task-level status
   - If `in_progress` with no agent running (always true at startup), resets to the appropriate state
4. Invalidates the project store task cache so the UI picks up the corrected state

## Feature Toggle

- [ ] Behind localStorage flag: `use_feature_name`
- [ ] Behind settings toggle
- [ ] Behind environment variable/config
- [x] N/A - Feature is complete and ready for all users

## Breaking Changes

**Breaking:** No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup recovery sweep runs after window creation to reset stuck tasks and subtasks, enabling clean restarts.
* **Bug Fixes**
  * Improved recovery that atomically resets in-progress/failed subtasks and updates task statuses to queue/review/completed as appropriate.
* **Chores**
  * Startup logs now report separate counts for subtasks and task-status changes and use “spec(s)” wording for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->