### PR TITLE
feat(terminal): centralized auto-resume queue for terminal recovery

### DIFF
--- a/apps/frontend/src/renderer/components/Terminal.tsx
+++ b/apps/frontend/src/renderer/components/Terminal.tsx
@@ -382,10 +382,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         pendingWorktreeConfigRef.current = null;
       }
       // Auto-resume: enqueue non-active terminals for staggered resume
-      if (!isActive && !hasAttemptedAutoResumeRef.current) {
+      // Read current active state from store to avoid stale closure value
+      const currentActiveId = useTerminalStore.getState().activeTerminalId;
+      const isCurrentlyActive = currentActiveId === id;
+
+      if (!isCurrentlyActive) {
         const currentTerminal = useTerminalStore.getState().terminals.find(t => t.id === id);
         if (currentTerminal?.pendingClaudeResume) {
-          hasAttemptedAutoResumeRef.current = true;
           enqueueAutoResume(id);
         }
       }

--- a/apps/frontend/src/renderer/stores/terminal-store.ts
+++ b/apps/frontend/src/renderer/stores/terminal-store.ts
@@ -116,6 +116,80 @@ export function writeToTerminal(terminalId: string, data: string): void {
   }
 }
 
+// === Auto-Resume Queue Coordinator ===
+// Coordinates staggered auto-resume of non-active terminals after app restart.
+// Each terminal enqueues itself when its PTY is confirmed ready (onCreated).
+// A single coordinator processes the queue with stagger delays.
+
+const AUTO_RESUME_INITIAL_DELAY_MS = 1500;
+const AUTO_RESUME_STAGGER_MS = 500;
+
+let autoResumeQueue: string[] = [];
+let autoResumeTimer: ReturnType<typeof setTimeout> | null = null;
+let autoResumeProcessing = false;
+
+export function enqueueAutoResume(terminalId: string): void {
+  if (autoResumeQueue.includes(terminalId)) return;
+  autoResumeQueue.push(terminalId);
+  debugLog(`[AutoResume] Enqueued terminal: ${terminalId}, queue size: ${autoResumeQueue.length}`);
+
+  // Start initial delay timer on first enqueue only
+  if (autoResumeTimer === null && !autoResumeProcessing) {
+    debugLog(`[AutoResume] Starting initial delay (${AUTO_RESUME_INITIAL_DELAY_MS}ms)`);
+    autoResumeTimer = setTimeout(() => {
+      autoResumeTimer = null;
+      processAutoResumeQueue();
+    }, AUTO_RESUME_INITIAL_DELAY_MS);
+  }
+}
+
+export function dequeueAutoResume(terminalId: string): void {
+  const idx = autoResumeQueue.indexOf(terminalId);
+  if (idx !== -1) {
+    autoResumeQueue.splice(idx, 1);
+    debugLog(`[AutoResume] Dequeued terminal: ${terminalId}, queue size: ${autoResumeQueue.length}`);
+  }
+}
+
+export function clearAutoResumeQueue(): void {
+  autoResumeQueue = [];
+  if (autoResumeTimer !== null) {
+    clearTimeout(autoResumeTimer);
+    autoResumeTimer = null;
+  }
+  autoResumeProcessing = false;
+  debugLog('[AutoResume] Queue cleared');
+}
+
+async function processAutoResumeQueue(): Promise<void> {
+  if (autoResumeProcessing) return;
+  autoResumeProcessing = true;
+  debugLog(`[AutoResume] Processing queue, ${autoResumeQueue.length} terminals`);
+
+  while (autoResumeQueue.length > 0) {
+    const terminalId = autoResumeQueue.shift()!;
+
+    // Check if terminal still needs resume
+    const terminal = useTerminalStore.getState().terminals.find(t => t.id === terminalId);
+    if (!terminal?.pendingClaudeResume) {
+      debugLog(`[AutoResume] Skipping ${terminalId} — no longer pending`);
+      continue;
+    }
+
+    debugLog(`[AutoResume] Resuming terminal: ${terminalId}`);
+    useTerminalStore.getState().setPendingClaudeResume(terminalId, false);
+    window.electronAPI.activateDeferredClaudeResume(terminalId);
+
+    // Stagger delay between resumes
+    if (autoResumeQueue.length > 0) {
+      await new Promise(resolve => setTimeout(resolve, AUTO_RESUME_STAGGER_MS));
+    }
+  }
+
+  autoResumeProcessing = false;
+  debugLog('[AutoResume] Queue processing complete');
+}
+
 export type TerminalStatus = 'idle' | 'running' | 'claude-active' | 'exited';
 
 export interface Terminal {
@@ -628,6 +702,7 @@ export async function restoreTerminalSessions(projectPath: string): Promise<void
     return;
   }
   restoringProjects.add(projectPath);
+  clearAutoResumeQueue();
 
   try {
     const store = useTerminalStore.getState();

--- a/apps/frontend/src/renderer/stores/terminal-store.ts
+++ b/apps/frontend/src/renderer/stores/terminal-store.ts
@@ -125,6 +125,12 @@ const AUTO_RESUME_INITIAL_DELAY_MS = 1500;
 const AUTO_RESUME_STAGGER_MS = 500;
 
 // Auto-resume queue state (single-threaded JS assumption - see processAutoResumeQueue)
+//
+// Mutex invariant: The active-terminal effect (which triggers enqueueAutoResume) and
+// processAutoResumeQueue / resumeAllPendingClaude are mutually coordinated through
+// clearAutoResumeQueue(). When a project switch or "Resume All" occurs, clearAutoResumeQueue()
+// cancels any pending timer, empties the queue, and bumps autoResumeGeneration to abort
+// any in-flight processing run. This ensures only one resumption path is active at a time.
 let autoResumeQueue: string[] = [];
 let autoResumeTimer: ReturnType<typeof setTimeout> | null = null;
 let autoResumeProcessing = false;
@@ -674,13 +680,14 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     }
     isResumingAll = true;
 
-    // Capture generation BEFORE clearAutoResumeQueue() bumps it, so this call
-    // doesn't immediately invalidate itself, but CAN be cancelled by external calls
-    const generation = autoResumeGeneration;
-
     try {
       // Clear auto-resume queue to prevent redundant processing
       clearAutoResumeQueue();
+
+      // Capture generation AFTER clearAutoResumeQueue() bumps it, so this call
+      // doesn't immediately self-cancel, but CAN be cancelled by subsequent external
+      // calls to clearAutoResumeQueue() (e.g., project switch)
+      const generation = autoResumeGeneration;
 
       const state = get();
 

--- a/apps/frontend/src/renderer/stores/terminal-store.ts
+++ b/apps/frontend/src/renderer/stores/terminal-store.ts
@@ -161,6 +161,15 @@ export function clearAutoResumeQueue(): void {
   debugLog('[AutoResume] Queue cleared');
 }
 
+/**
+ * Shared helper to resume a terminal's Claude session with consistent behavior.
+ * Clears the pending flag and triggers IPC activation.
+ */
+function resumeTerminalClaudeSession(terminalId: string): void {
+  useTerminalStore.getState().setPendingClaudeResume(terminalId, false);
+  window.electronAPI.activateDeferredClaudeResume(terminalId);
+}
+
 async function processAutoResumeQueue(): Promise<void> {
   if (autoResumeProcessing) return;
   autoResumeProcessing = true;
@@ -177,8 +186,7 @@ async function processAutoResumeQueue(): Promise<void> {
     }
 
     debugLog(`[AutoResume] Resuming terminal: ${terminalId}`);
-    useTerminalStore.getState().setPendingClaudeResume(terminalId, false);
-    window.electronAPI.activateDeferredClaudeResume(terminalId);
+    resumeTerminalClaudeSession(terminalId);
 
     // Stagger delay between resumes
     if (autoResumeQueue.length > 0) {
@@ -629,6 +637,9 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   },
 
   resumeAllPendingClaude: async () => {
+    // Clear auto-resume queue to prevent redundant processing
+    clearAutoResumeQueue();
+
     const state = get();
 
     // Filter terminals with pending Claude resume
@@ -639,21 +650,18 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       return;
     }
 
-    debugLog(`[TerminalStore] Resuming ${pendingTerminals.length} pending Claude sessions with 500ms stagger`);
+    debugLog(`[TerminalStore] Resuming ${pendingTerminals.length} pending Claude sessions with ${AUTO_RESUME_STAGGER_MS}ms stagger`);
 
     // Iterate through terminals with staggered delays
     for (let i = 0; i < pendingTerminals.length; i++) {
       const terminal = pendingTerminals[i];
-      // Clear the pending flag BEFORE IPC call to prevent race condition
-      // with auto-resume effect in Terminal.tsx (which checks this flag on a 100ms timeout)
-      get().setPendingClaudeResume(terminal.id, false);
 
       debugLog(`[TerminalStore] Activating deferred Claude resume for terminal: ${terminal.id}`);
-      window.electronAPI.activateDeferredClaudeResume(terminal.id);
+      resumeTerminalClaudeSession(terminal.id);
 
-      // Wait 500ms before processing next terminal (staggered delay)
+      // Wait before processing next terminal (staggered delay)
       if (i < pendingTerminals.length - 1) {
-        await new Promise(resolve => setTimeout(resolve, 500));
+        await new Promise(resolve => setTimeout(resolve, AUTO_RESUME_STAGGER_MS));
       }
     }
 

--- a/apps/frontend/src/renderer/stores/terminal-store.ts
+++ b/apps/frontend/src/renderer/stores/terminal-store.ts
@@ -674,6 +674,10 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     }
     isResumingAll = true;
 
+    // Capture generation BEFORE clearAutoResumeQueue() bumps it, so this call
+    // doesn't immediately invalidate itself, but CAN be cancelled by external calls
+    const generation = autoResumeGeneration;
+
     try {
       // Clear auto-resume queue to prevent redundant processing
       clearAutoResumeQueue();
@@ -688,10 +692,16 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
         return;
       }
 
-      debugLog(`[TerminalStore] Resuming ${pendingTerminals.length} pending Claude sessions with ${AUTO_RESUME_STAGGER_MS}ms stagger`);
+      debugLog(`[TerminalStore] Resuming ${pendingTerminals.length} pending Claude sessions with ${AUTO_RESUME_STAGGER_MS}ms stagger (generation ${generation})`);
 
       // Iterate through terminals with staggered delays
       for (let i = 0; i < pendingTerminals.length; i++) {
+        // Check for cancellation (e.g., project switch triggered clearAutoResumeQueue)
+        if (generation !== autoResumeGeneration) {
+          debugLog(`[TerminalStore] Generation mismatch in resumeAll (${generation} !== ${autoResumeGeneration}) — aborting`);
+          return;
+        }
+
         const terminal = pendingTerminals[i];
 
         // Re-check terminal still needs resume (may have changed during stagger delay)
@@ -712,6 +722,11 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
         // Wait before processing next terminal (staggered delay)
         if (i < pendingTerminals.length - 1) {
           await new Promise(resolve => setTimeout(resolve, AUTO_RESUME_STAGGER_MS));
+          // Re-check generation after await (may have been cancelled during stagger)
+          if (generation !== autoResumeGeneration) {
+            debugLog(`[TerminalStore] Generation mismatch after stagger in resumeAll — aborting`);
+            return;
+          }
         }
       }
 

--- a/apps/frontend/src/renderer/stores/terminal-store.ts
+++ b/apps/frontend/src/renderer/stores/terminal-store.ts
@@ -160,11 +160,11 @@ export function clearAutoResumeQueue(): void {
     clearTimeout(autoResumeTimer);
     autoResumeTimer = null;
   }
-  // Don't reset autoResumeProcessing here - the generation counter is sufficient
-  // to abort stale processing runs. Resetting the flag here creates a race condition
-  // where clearAutoResumeQueue() could allow a new processAutoResumeQueue() to start
-  // before the aborted one has fully exited.
-  autoResumeGeneration++; // Increment generation to abort any in-flight processing
+  // Increment generation first to abort any in-flight processing
+  autoResumeGeneration++;
+  // Reset processing flag so new enqueue attempts can start a fresh processor
+  // Safe to do after generation bump because stale runs check generation on each iteration
+  autoResumeProcessing = false;
   debugLog('[AutoResume] Queue cleared');
 }
 
@@ -183,41 +183,49 @@ async function processAutoResumeQueue(): Promise<void> {
   const generation = autoResumeGeneration; // Capture generation to detect cancellation
   debugLog(`[AutoResume] Processing queue (generation ${generation}), ${autoResumeQueue.length} terminals`);
 
-  while (autoResumeQueue.length > 0) {
-    // Check if this processing run has been cancelled
-    if (generation !== autoResumeGeneration) {
-      debugLog(`[AutoResume] Generation mismatch (${generation} !== ${autoResumeGeneration}) — aborting stale processing`);
-      return; // Don't reset autoResumeProcessing — the new run owns it
-    }
-
-    const terminalId = autoResumeQueue.shift()!;
-
-    // Check if terminal still needs resume
-    const terminal = useTerminalStore.getState().terminals.find(t => t.id === terminalId);
-    if (!terminal?.pendingClaudeResume) {
-      debugLog(`[AutoResume] Skipping ${terminalId} — no longer pending`);
-      continue;
-    }
-
-    debugLog(`[AutoResume] Resuming terminal: ${terminalId}`);
-    resumeTerminalClaudeSession(terminalId);
-
-    // Stagger delay between resumes
-    if (autoResumeQueue.length > 0) {
-      await new Promise(resolve => setTimeout(resolve, AUTO_RESUME_STAGGER_MS));
-      // Re-check generation after await (may have been cancelled during stagger delay)
+  try {
+    while (autoResumeQueue.length > 0) {
+      // Check if this processing run has been cancelled
       if (generation !== autoResumeGeneration) {
-        debugLog(`[AutoResume] Generation mismatch after stagger — aborting stale processing`);
+        debugLog(`[AutoResume] Generation mismatch (${generation} !== ${autoResumeGeneration}) — aborting stale processing`);
         return;
       }
+
+      const terminalId = autoResumeQueue.shift()!;
+
+      // Check if terminal still needs resume
+      const terminal = useTerminalStore.getState().terminals.find(t => t.id === terminalId);
+      if (!terminal?.pendingClaudeResume) {
+        debugLog(`[AutoResume] Skipping ${terminalId} — no longer pending`);
+        continue;
+      }
+
+      try {
+        debugLog(`[AutoResume] Resuming terminal: ${terminalId}`);
+        resumeTerminalClaudeSession(terminalId);
+      } catch (error) {
+        // Log error and continue processing remaining terminals
+        debugError(`[AutoResume] Error resuming terminal ${terminalId}:`, error);
+      }
+
+      // Stagger delay between resumes
+      if (autoResumeQueue.length > 0) {
+        await new Promise(resolve => setTimeout(resolve, AUTO_RESUME_STAGGER_MS));
+        // Re-check generation after await (may have been cancelled during stagger delay)
+        if (generation !== autoResumeGeneration) {
+          debugLog(`[AutoResume] Generation mismatch after stagger — aborting stale processing`);
+          return;
+        }
+      }
+    }
+
+    debugLog('[AutoResume] Queue processing complete');
+  } finally {
+    // Only reset processing flag if this is still the current generation
+    if (generation === autoResumeGeneration) {
+      autoResumeProcessing = false;
     }
   }
-
-  // Only reset processing flag if this is still the current generation
-  if (generation === autoResumeGeneration) {
-    autoResumeProcessing = false;
-  }
-  debugLog('[AutoResume] Queue processing complete');
 }
 
 export type TerminalStatus = 'idle' | 'running' | 'claude-active' | 'exited';
@@ -685,6 +693,13 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       // Iterate through terminals with staggered delays
       for (let i = 0; i < pendingTerminals.length; i++) {
         const terminal = pendingTerminals[i];
+
+        // Re-check terminal still needs resume (may have changed during stagger delay)
+        const currentTerminal = get().terminals.find(t => t.id === terminal.id);
+        if (!currentTerminal?.pendingClaudeResume) {
+          debugLog(`[TerminalStore] Skipping ${terminal.id} — no longer pending`);
+          continue;
+        }
 
         try {
           debugLog(`[TerminalStore] Activating deferred Claude resume for terminal: ${terminal.id}`);

--- a/apps/frontend/src/renderer/stores/terminal-store.ts
+++ b/apps/frontend/src/renderer/stores/terminal-store.ts
@@ -160,7 +160,10 @@ export function clearAutoResumeQueue(): void {
     clearTimeout(autoResumeTimer);
     autoResumeTimer = null;
   }
-  autoResumeProcessing = false;
+  // Don't reset autoResumeProcessing here - the generation counter is sufficient
+  // to abort stale processing runs. Resetting the flag here creates a race condition
+  // where clearAutoResumeQueue() could allow a new processAutoResumeQueue() to start
+  // before the aborted one has fully exited.
   autoResumeGeneration++; // Increment generation to abort any in-flight processing
   debugLog('[AutoResume] Queue cleared');
 }
@@ -683,8 +686,13 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       for (let i = 0; i < pendingTerminals.length; i++) {
         const terminal = pendingTerminals[i];
 
-        debugLog(`[TerminalStore] Activating deferred Claude resume for terminal: ${terminal.id}`);
-        resumeTerminalClaudeSession(terminal.id);
+        try {
+          debugLog(`[TerminalStore] Activating deferred Claude resume for terminal: ${terminal.id}`);
+          resumeTerminalClaudeSession(terminal.id);
+        } catch (error) {
+          // Log error and continue processing remaining terminals
+          debugError(`[TerminalStore] Error resuming terminal ${terminal.id}:`, error);
+        }
 
         // Wait before processing next terminal (staggered delay)
         if (i < pendingTerminals.length - 1) {
@@ -813,3 +821,7 @@ export async function restoreTerminalSessions(projectPath: string): Promise<void
     restoringProjects.delete(projectPath);
   }
 }
+
+// NOTE: HMR cleanup for auto-resume queue state would be beneficial during development
+// to clear timers on hot reload, but requires augmenting ImportMeta types in vite-env.d.ts.
+// The generation counter provides sufficient protection against stale processing runs.

--- a/apps/frontend/src/renderer/stores/terminal-store.ts
+++ b/apps/frontend/src/renderer/stores/terminal-store.ts
@@ -124,9 +124,12 @@ export function writeToTerminal(terminalId: string, data: string): void {
 const AUTO_RESUME_INITIAL_DELAY_MS = 1500;
 const AUTO_RESUME_STAGGER_MS = 500;
 
+// Auto-resume queue state (single-threaded JS assumption - see processAutoResumeQueue)
 let autoResumeQueue: string[] = [];
 let autoResumeTimer: ReturnType<typeof setTimeout> | null = null;
 let autoResumeProcessing = false;
+let autoResumeGeneration = 0; // Generation counter to abort stale processing runs
+let isResumingAll = false; // Concurrency guard for resumeAllPendingClaude
 
 export function enqueueAutoResume(terminalId: string): void {
   if (autoResumeQueue.includes(terminalId)) return;
@@ -158,6 +161,7 @@ export function clearAutoResumeQueue(): void {
     autoResumeTimer = null;
   }
   autoResumeProcessing = false;
+  autoResumeGeneration++; // Increment generation to abort any in-flight processing
   debugLog('[AutoResume] Queue cleared');
 }
 
@@ -173,9 +177,16 @@ function resumeTerminalClaudeSession(terminalId: string): void {
 async function processAutoResumeQueue(): Promise<void> {
   if (autoResumeProcessing) return;
   autoResumeProcessing = true;
-  debugLog(`[AutoResume] Processing queue, ${autoResumeQueue.length} terminals`);
+  const generation = autoResumeGeneration; // Capture generation to detect cancellation
+  debugLog(`[AutoResume] Processing queue (generation ${generation}), ${autoResumeQueue.length} terminals`);
 
   while (autoResumeQueue.length > 0) {
+    // Check if this processing run has been cancelled
+    if (generation !== autoResumeGeneration) {
+      debugLog(`[AutoResume] Generation mismatch (${generation} !== ${autoResumeGeneration}) — aborting stale processing`);
+      return; // Don't reset autoResumeProcessing — the new run owns it
+    }
+
     const terminalId = autoResumeQueue.shift()!;
 
     // Check if terminal still needs resume
@@ -191,10 +202,18 @@ async function processAutoResumeQueue(): Promise<void> {
     // Stagger delay between resumes
     if (autoResumeQueue.length > 0) {
       await new Promise(resolve => setTimeout(resolve, AUTO_RESUME_STAGGER_MS));
+      // Re-check generation after await (may have been cancelled during stagger delay)
+      if (generation !== autoResumeGeneration) {
+        debugLog(`[AutoResume] Generation mismatch after stagger — aborting stale processing`);
+        return;
+      }
     }
   }
 
-  autoResumeProcessing = false;
+  // Only reset processing flag if this is still the current generation
+  if (generation === autoResumeGeneration) {
+    autoResumeProcessing = false;
+  }
   debugLog('[AutoResume] Queue processing complete');
 }
 
@@ -637,35 +656,46 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   },
 
   resumeAllPendingClaude: async () => {
-    // Clear auto-resume queue to prevent redundant processing
-    clearAutoResumeQueue();
-
-    const state = get();
-
-    // Filter terminals with pending Claude resume
-    const pendingTerminals = state.terminals.filter(t => t.pendingClaudeResume === true);
-
-    if (pendingTerminals.length === 0) {
-      debugLog('[TerminalStore] No terminals with pending Claude resume');
+    // Concurrency guard - prevent multiple simultaneous executions
+    if (isResumingAll) {
+      debugLog('[TerminalStore] Resume All already in progress — skipping');
       return;
     }
+    isResumingAll = true;
 
-    debugLog(`[TerminalStore] Resuming ${pendingTerminals.length} pending Claude sessions with ${AUTO_RESUME_STAGGER_MS}ms stagger`);
+    try {
+      // Clear auto-resume queue to prevent redundant processing
+      clearAutoResumeQueue();
 
-    // Iterate through terminals with staggered delays
-    for (let i = 0; i < pendingTerminals.length; i++) {
-      const terminal = pendingTerminals[i];
+      const state = get();
 
-      debugLog(`[TerminalStore] Activating deferred Claude resume for terminal: ${terminal.id}`);
-      resumeTerminalClaudeSession(terminal.id);
+      // Filter terminals with pending Claude resume
+      const pendingTerminals = state.terminals.filter(t => t.pendingClaudeResume === true);
 
-      // Wait before processing next terminal (staggered delay)
-      if (i < pendingTerminals.length - 1) {
-        await new Promise(resolve => setTimeout(resolve, AUTO_RESUME_STAGGER_MS));
+      if (pendingTerminals.length === 0) {
+        debugLog('[TerminalStore] No terminals with pending Claude resume');
+        return;
       }
-    }
 
-    debugLog('[TerminalStore] Completed resuming all pending Claude sessions');
+      debugLog(`[TerminalStore] Resuming ${pendingTerminals.length} pending Claude sessions with ${AUTO_RESUME_STAGGER_MS}ms stagger`);
+
+      // Iterate through terminals with staggered delays
+      for (let i = 0; i < pendingTerminals.length; i++) {
+        const terminal = pendingTerminals[i];
+
+        debugLog(`[TerminalStore] Activating deferred Claude resume for terminal: ${terminal.id}`);
+        resumeTerminalClaudeSession(terminal.id);
+
+        // Wait before processing next terminal (staggered delay)
+        if (i < pendingTerminals.length - 1) {
+          await new Promise(resolve => setTimeout(resolve, AUTO_RESUME_STAGGER_MS));
+        }
+      }
+
+      debugLog('[TerminalStore] Completed resuming all pending Claude sessions');
+    } finally {
+      isResumingAll = false;
+    }
   },
 
   getTerminal: (id: string) => {


### PR DESCRIPTION
## Summary
- Adds a centralized auto-resume queue coordinator in `terminal-store.ts` that processes non-active terminals with staggered delays (1.5s initial wait, 500ms between each resume)
- Non-active terminals with pending Claude resume enqueue themselves when their PTY is confirmed ready (`onCreated` callback in `Terminal.tsx`)
- Active terminals dequeue themselves since they handle their own resume via the existing `isActive` useEffect
- Queue is cleared on new restore operations to prevent stale entries from previous sessions

## Problem
When the app restarts, only the first terminal (the one assigned `activeTerminalId`) auto-resumes its Claude session. All other terminals show a pending resume badge and require the user to manually click the tab and press Enter. Root cause: the deferred resume `useEffect` in `Terminal.tsx` gates on `isActive === true`.

## Test plan
- [ ] Restart app with multiple Claude terminals active — verify all terminals auto-resume (not just the active one)
- [ ] Verify active terminal still resumes immediately via the existing isActive path
- [ ] Verify terminals resume in staggered fashion (not all at once)
- [ ] Verify switching projects clears the queue (no stale resumes)
- [ ] Verify closing a terminal before it resumes doesn't cause errors
- [ ] TypeScript typecheck passes
- [ ] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coordinated auto-resume queue for terminals so pending Claude sessions restart in a staggered, controlled sequence after app restart; restoration now resets the queue to avoid conflicts.
* **Bug Fixes**
  * Prevented duplicate or premature resume attempts; terminals are removed from the resume queue on activation, teardown, or cleanup to keep resuming consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->