### PR TITLE
feat: add error feedback and unstick functionality for stuck tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,18 @@
 > ⚠️ Beta releases may contain bugs and breaking changes. [View all releases](https://github.com/AndyMik90/Auto-Claude/releases)
 
 <!-- BETA_VERSION_BADGE -->
-[![Beta](https://img.shields.io/badge/beta-2.7.2--beta.10-orange?style=flat-square)](https://github.com/AndyMik90/Auto-Claude/releases/tag/v2.7.2-beta.10)
+[![Beta](https://img.shields.io/badge/beta-2.7.6--beta.1-orange?style=flat-square)](https://github.com/AndyMik90/Auto-Claude/releases/tag/v2.7.6-beta.1)
 <!-- BETA_VERSION_BADGE_END -->
 
 <!-- BETA_DOWNLOADS -->
 | Platform | Download |
 |----------|----------|
-| **Windows** | [Auto-Claude-2.7.2-beta.10-win32-x64.exe](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.2-beta.10/Auto-Claude-2.7.2-beta.10-win32-x64.exe) |
-| **macOS (Apple Silicon)** | [Auto-Claude-2.7.2-beta.10-darwin-arm64.dmg](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.2-beta.10/Auto-Claude-2.7.2-beta.10-darwin-arm64.dmg) |
-| **macOS (Intel)** | [Auto-Claude-2.7.2-beta.10-darwin-x64.dmg](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.2-beta.10/Auto-Claude-2.7.2-beta.10-darwin-x64.dmg) |
-| **Linux** | [Auto-Claude-2.7.2-beta.10-linux-x86_64.AppImage](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.2-beta.10/Auto-Claude-2.7.2-beta.10-linux-x86_64.AppImage) |
-| **Linux (Debian)** | [Auto-Claude-2.7.2-beta.10-linux-amd64.deb](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.2-beta.10/Auto-Claude-2.7.2-beta.10-linux-amd64.deb) |
-| **Linux (Flatpak)** | [Auto-Claude-2.7.2-beta.10-linux-x86_64.flatpak](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.2-beta.10/Auto-Claude-2.7.2-beta.10-linux-x86_64.flatpak) |
+| **Windows** | [Auto-Claude-2.7.6-beta.1-win32-x64.exe](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.6-beta.1/Auto-Claude-2.7.6-beta.1-win32-x64.exe) |
+| **macOS (Apple Silicon)** | [Auto-Claude-2.7.6-beta.1-darwin-arm64.dmg](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.6-beta.1/Auto-Claude-2.7.6-beta.1-darwin-arm64.dmg) |
+| **macOS (Intel)** | [Auto-Claude-2.7.6-beta.1-darwin-x64.dmg](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.6-beta.1/Auto-Claude-2.7.6-beta.1-darwin-x64.dmg) |
+| **Linux** | [Auto-Claude-2.7.6-beta.1-linux-x86_64.AppImage](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.6-beta.1/Auto-Claude-2.7.6-beta.1-linux-x86_64.AppImage) |
+| **Linux (Debian)** | [Auto-Claude-2.7.6-beta.1-linux-amd64.deb](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.6-beta.1/Auto-Claude-2.7.6-beta.1-linux-amd64.deb) |
+| **Linux (Flatpak)** | [Auto-Claude-2.7.6-beta.1-linux-x86_64.flatpak](https://github.com/AndyMik90/Auto-Claude/releases/download/v2.7.6-beta.1/Auto-Claude-2.7.6-beta.1-linux-x86_64.flatpak) |
 <!-- BETA_DOWNLOADS_END -->
 
 > All releases include SHA256 checksums and VirusTotal scan results for security verification.

--- a/apps/backend/cli/main.py
+++ b/apps/backend/cli/main.py
@@ -473,20 +473,20 @@ def _run_cli() -> None:
     if args.unstick:
         from services.recovery import clear_stuck_subtasks, get_stuck_subtasks
 
-        stuck = get_stuck_subtasks(spec_dir, project_dir)
-        if stuck:
-            try:
+        try:
+            stuck = get_stuck_subtasks(spec_dir, project_dir)
+            if stuck:
                 clear_stuck_subtasks(spec_dir, project_dir)
                 print(f"Cleared {len(stuck)} stuck subtasks for {args.spec}")
                 for s in stuck:
                     print(
                         f"  - {s.get('subtask_id', 'unknown')}: {s.get('reason', 'no reason')[:80]}"
                     )
-            except Exception as e:
-                print(f"Failed to clear stuck subtasks: {e}")
-                sys.exit(1)
-        else:
-            print(f"No stuck subtasks found for {args.spec}")
+            else:
+                print(f"No stuck subtasks found for {args.spec}")
+        except Exception as e:
+            print(f"Failed to clear stuck subtasks: {e}")
+            sys.exit(1)
         return
 
     # Normal build flow

--- a/apps/backend/cli/main.py
+++ b/apps/backend/cli/main.py
@@ -473,12 +473,11 @@ def _run_cli() -> None:
 
     # Handle --unstick command
     if args.unstick:
-        from services.recovery import get_stuck_subtasks as get_stuck
-        from services.recovery import clear_stuck_subtasks as clear_stuck
+        from services.recovery import clear_stuck_subtasks, get_stuck_subtasks
 
-        stuck = get_stuck(spec_dir, project_dir)
+        stuck = get_stuck_subtasks(spec_dir, project_dir)
         if stuck:
-            clear_stuck(spec_dir, project_dir)
+            clear_stuck_subtasks(spec_dir, project_dir)
             print(f"Cleared {len(stuck)} stuck subtasks for {args.spec}")
             for s in stuck:
                 print(f"  - {s.get('subtask_id', 'unknown')}: {s.get('reason', 'no reason')[:80]}")

--- a/apps/backend/cli/main.py
+++ b/apps/backend/cli/main.py
@@ -475,12 +475,16 @@ def _run_cli() -> None:
 
         stuck = get_stuck_subtasks(spec_dir, project_dir)
         if stuck:
-            clear_stuck_subtasks(spec_dir, project_dir)
-            print(f"Cleared {len(stuck)} stuck subtasks for {args.spec}")
-            for s in stuck:
-                print(
-                    f"  - {s.get('subtask_id', 'unknown')}: {s.get('reason', 'no reason')[:80]}"
-                )
+            try:
+                clear_stuck_subtasks(spec_dir, project_dir)
+                print(f"Cleared {len(stuck)} stuck subtasks for {args.spec}")
+                for s in stuck:
+                    print(
+                        f"  - {s.get('subtask_id', 'unknown')}: {s.get('reason', 'no reason')[:80]}"
+                    )
+            except Exception as e:
+                print(f"Failed to clear stuck subtasks: {e}")
+                sys.exit(1)
         else:
             print(f"No stuck subtasks found for {args.spec}")
         return

--- a/apps/backend/cli/main.py
+++ b/apps/backend/cli/main.py
@@ -159,6 +159,11 @@ Environment Variables:
         action="store_true",
         help="Push branch and create a GitHub Pull Request",
     )
+    build_group.add_argument(
+        "--unstick",
+        action="store_true",
+        help="Clear all stuck subtasks for a spec (allows task to continue after file validation failures)",
+    )
 
     # PR options
     parser.add_argument(
@@ -213,13 +218,6 @@ Environment Variables:
         "--followup",
         action="store_true",
         help="Add follow-up tasks to a completed spec (extends existing implementation plan)",
-    )
-
-    # Stuck subtask recovery
-    parser.add_argument(
-        "--unstick",
-        action="store_true",
-        help="Clear all stuck subtasks for a spec (allows task to continue after file validation failures)",
     )
 
     # Review options

--- a/apps/backend/cli/main.py
+++ b/apps/backend/cli/main.py
@@ -480,7 +480,9 @@ def _run_cli() -> None:
             clear_stuck_subtasks(spec_dir, project_dir)
             print(f"Cleared {len(stuck)} stuck subtasks for {args.spec}")
             for s in stuck:
-                print(f"  - {s.get('subtask_id', 'unknown')}: {s.get('reason', 'no reason')[:80]}")
+                print(
+                    f"  - {s.get('subtask_id', 'unknown')}: {s.get('reason', 'no reason')[:80]}"
+                )
         else:
             print(f"No stuck subtasks found for {args.spec}")
         return

--- a/apps/backend/cli/main.py
+++ b/apps/backend/cli/main.py
@@ -215,6 +215,13 @@ Environment Variables:
         help="Add follow-up tasks to a completed spec (extends existing implementation plan)",
     )
 
+    # Stuck subtask recovery
+    parser.add_argument(
+        "--unstick",
+        action="store_true",
+        help="Clear all stuck subtasks for a spec (allows task to continue after file validation failures)",
+    )
+
     # Review options
     parser.add_argument(
         "--review-status",
@@ -462,6 +469,21 @@ def _run_cli() -> None:
             model=model,
             verbose=args.verbose,
         )
+        return
+
+    # Handle --unstick command
+    if args.unstick:
+        from services.recovery import get_stuck_subtasks as get_stuck
+        from services.recovery import clear_stuck_subtasks as clear_stuck
+
+        stuck = get_stuck(spec_dir, project_dir)
+        if stuck:
+            clear_stuck(spec_dir, project_dir)
+            print(f"Cleared {len(stuck)} stuck subtasks for {args.spec}")
+            for s in stuck:
+                print(f"  - {s.get('subtask_id', 'unknown')}: {s.get('reason', 'no reason')[:80]}")
+        else:
+            print(f"No stuck subtasks found for {args.spec}")
         return
 
     # Normal build flow

--- a/apps/backend/recovery.py
+++ b/apps/backend/recovery.py
@@ -7,6 +7,7 @@ from services.recovery import (
     check_and_recover,
     clear_stuck_subtasks,
     get_recovery_context,
+    get_stuck_subtasks,
     reset_subtask,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "check_and_recover",
     "clear_stuck_subtasks",
     "get_recovery_context",
+    "get_stuck_subtasks",
     "reset_subtask",
 ]

--- a/apps/backend/services/recovery.py
+++ b/apps/backend/services/recovery.py
@@ -577,6 +577,16 @@ class RecoveryManager:
 
         return hints
 
+    def get_stuck_subtasks(self) -> list[dict]:
+        """
+        Return list of stuck subtasks with reasons.
+
+        Returns:
+            List of stuck subtask dicts with subtask_id, reason, escalated_at, attempt_count
+        """
+        history = self._load_attempt_history()
+        return history.get("stuck_subtasks", [])
+
     def clear_stuck_subtasks(self) -> None:
         """Clear all stuck subtasks (for manual resolution)."""
         history = self._load_attempt_history()
@@ -676,3 +686,18 @@ def clear_stuck_subtasks(spec_dir: Path, project_dir: Path) -> None:
     """
     manager = RecoveryManager(spec_dir, project_dir)
     manager.clear_stuck_subtasks()
+
+
+def get_stuck_subtasks(spec_dir: Path, project_dir: Path) -> list[dict]:
+    """
+    Get list of stuck subtasks (module-level wrapper).
+
+    Args:
+        spec_dir: Spec directory
+        project_dir: Project directory
+
+    Returns:
+        List of stuck subtask dicts
+    """
+    manager = RecoveryManager(spec_dir, project_dir)
+    return manager.get_stuck_subtasks()

--- a/apps/backend/services/recovery.py
+++ b/apps/backend/services/recovery.py
@@ -514,16 +514,6 @@ class RecoveryManager:
 
         self._save_attempt_history(history)
 
-    def get_stuck_subtasks(self) -> list[dict]:
-        """
-        Get all subtasks marked as stuck.
-
-        Returns:
-            List of stuck subtask entries
-        """
-        history = self._load_attempt_history()
-        return history.get("stuck_subtasks", [])
-
     def get_subtask_history(self, subtask_id: str) -> dict:
         """
         Get the attempt history for a specific subtask.

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1221,4 +1221,100 @@ export function registerTaskExecutionHandlers(
       }
     }
   );
+
+  /**
+   * Get stuck subtask information for a spec
+   */
+  ipcMain.handle(
+    IPC_CHANNELS.TASK_GET_STUCK_INFO,
+    async (_, projectId: string, specId: string): Promise<IPCResult<{ stuckSubtasks: Array<{ subtask_id: string; reason: string; escalated_at: string; attempt_count: number }> }>> => {
+      try {
+        const project = projectStore.getProject(projectId);
+        if (!project) {
+          return { success: false, error: 'Project not found' };
+        }
+
+        const specsBaseDir = getSpecsDir(project.autoBuildPath);
+        const specDir = path.join(project.path, specsBaseDir, specId);
+        const attemptHistoryPath = path.join(specDir, 'memory', 'attempt_history.json');
+
+        if (!existsSync(attemptHistoryPath)) {
+          return { success: true, data: { stuckSubtasks: [] } };
+        }
+
+        const historyContent = safeReadFileSync(attemptHistoryPath);
+        if (!historyContent) {
+          return { success: true, data: { stuckSubtasks: [] } };
+        }
+
+        const history = JSON.parse(historyContent);
+        return { success: true, data: { stuckSubtasks: history.stuck_subtasks || [] } };
+      } catch (error) {
+        console.error('Failed to get stuck info:', error);
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to get stuck info' };
+      }
+    }
+  );
+
+  /**
+   * Clear stuck subtasks for a spec
+   */
+  ipcMain.handle(
+    IPC_CHANNELS.TASK_UNSTICK_SUBTASKS,
+    async (_, projectId: string, specId: string): Promise<IPCResult<{ cleared: number }>> => {
+      try {
+        const project = projectStore.getProject(projectId);
+        if (!project) {
+          return { success: false, error: 'Project not found' };
+        }
+
+        const specsBaseDir = getSpecsDir(project.autoBuildPath);
+        const specDir = path.join(project.path, specsBaseDir, specId);
+        const attemptHistoryPath = path.join(specDir, 'memory', 'attempt_history.json');
+
+        if (!existsSync(attemptHistoryPath)) {
+          return { success: true, data: { cleared: 0 } };
+        }
+
+        const historyContent = safeReadFileSync(attemptHistoryPath);
+        if (!historyContent) {
+          return { success: true, data: { cleared: 0 } };
+        }
+
+        const history = JSON.parse(historyContent);
+        const count = (history.stuck_subtasks || []).length;
+
+        // Clear stuck subtasks list
+        history.stuck_subtasks = [];
+
+        // Reset any subtasks marked as 'stuck' to 'pending'
+        if (history.subtasks) {
+          for (const subtaskId in history.subtasks) {
+            if (history.subtasks[subtaskId].status === 'stuck') {
+              history.subtasks[subtaskId].status = 'pending';
+            }
+          }
+        }
+
+        // Save updated history
+        writeFileAtomicSync(attemptHistoryPath, JSON.stringify(history, null, 2));
+
+        // Also update worktree copy if it exists
+        const worktreePath = findTaskWorktree(project.path, specId);
+        if (worktreePath) {
+          const worktreeSpecDir = path.join(worktreePath, specsBaseDir, specId);
+          const worktreeHistoryPath = path.join(worktreeSpecDir, 'memory', 'attempt_history.json');
+          if (existsSync(worktreeHistoryPath)) {
+            writeFileAtomicSync(worktreeHistoryPath, JSON.stringify(history, null, 2));
+          }
+        }
+
+        console.log(`[Unstick] Cleared ${count} stuck subtasks for ${specId}`);
+        return { success: true, data: { cleared: count } };
+      } catch (error) {
+        console.error('Failed to unstick subtasks:', error);
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to unstick subtasks' };
+      }
+    }
+  );
 }

--- a/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/task/execution-handlers.ts
@@ -1238,10 +1238,6 @@ export function registerTaskExecutionHandlers(
         const specDir = path.join(project.path, specsBaseDir, specId);
         const attemptHistoryPath = path.join(specDir, 'memory', 'attempt_history.json');
 
-        if (!existsSync(attemptHistoryPath)) {
-          return { success: true, data: { stuckSubtasks: [] } };
-        }
-
         const historyContent = safeReadFileSync(attemptHistoryPath);
         if (!historyContent) {
           return { success: true, data: { stuckSubtasks: [] } };
@@ -1272,10 +1268,6 @@ export function registerTaskExecutionHandlers(
         const specDir = path.join(project.path, specsBaseDir, specId);
         const attemptHistoryPath = path.join(specDir, 'memory', 'attempt_history.json');
 
-        if (!existsSync(attemptHistoryPath)) {
-          return { success: true, data: { cleared: 0 } };
-        }
-
         const historyContent = safeReadFileSync(attemptHistoryPath);
         if (!historyContent) {
           return { success: true, data: { cleared: 0 } };
@@ -1288,9 +1280,9 @@ export function registerTaskExecutionHandlers(
         history.stuck_subtasks = [];
 
         // Reset any subtasks marked as 'stuck' to 'pending'
-        if (history.subtasks) {
-          for (const subtaskId in history.subtasks) {
-            if (history.subtasks[subtaskId].status === 'stuck') {
+        if (history.subtasks && typeof history.subtasks === 'object') {
+          for (const subtaskId of Object.keys(history.subtasks)) {
+            if (history.subtasks[subtaskId]?.status === 'stuck') {
               history.subtasks[subtaskId].status = 'pending';
             }
           }

--- a/apps/frontend/src/preload/api/task-api.ts
+++ b/apps/frontend/src/preload/api/task-api.ts
@@ -52,6 +52,11 @@ export interface TaskAPI {
   ) => Promise<IPCResult<TaskRecoveryResult>>;
   checkTaskRunning: (taskId: string) => Promise<IPCResult<boolean>>;
   resumePausedTask: (taskId: string) => Promise<IPCResult>;
+  getStuckInfo: (
+    projectId: string,
+    specId: string
+  ) => Promise<IPCResult<{ stuckSubtasks: Array<{ subtask_id: string; reason: string; escalated_at: string; attempt_count: number }> }>>;
+  unstickSubtasks: (projectId: string, specId: string) => Promise<IPCResult<{ cleared: number }>>;
 
   // Worktree Change Detection
   checkWorktreeChanges: (taskId: string) => Promise<IPCResult<{ hasChanges: boolean; worktreePath?: string; changedFileCount?: number }>>;
@@ -150,6 +155,15 @@ export const createTaskAPI = (): TaskAPI => ({
 
   resumePausedTask: (taskId: string): Promise<IPCResult> =>
     ipcRenderer.invoke(IPC_CHANNELS.TASK_RESUME_PAUSED, taskId),
+
+  getStuckInfo: (
+    projectId: string,
+    specId: string
+  ): Promise<IPCResult<{ stuckSubtasks: Array<{ subtask_id: string; reason: string; escalated_at: string; attempt_count: number }> }>> =>
+    ipcRenderer.invoke(IPC_CHANNELS.TASK_GET_STUCK_INFO, projectId, specId),
+
+  unstickSubtasks: (projectId: string, specId: string): Promise<IPCResult<{ cleared: number }>> =>
+    ipcRenderer.invoke(IPC_CHANNELS.TASK_UNSTICK_SUBTASKS, projectId, specId),
 
   // Worktree Change Detection
   checkWorktreeChanges: (taskId: string): Promise<IPCResult<{ hasChanges: boolean; worktreePath?: string; changedFileCount?: number }>> =>

--- a/apps/frontend/src/renderer/components/TaskCard.tsx
+++ b/apps/frontend/src/renderer/components/TaskCard.tsx
@@ -31,7 +31,7 @@ import {
   JSON_ERROR_PREFIX,
   JSON_ERROR_TITLE_SUFFIX
 } from '../../shared/constants';
-import { stopTask, checkTaskRunning, recoverStuckTask, isIncompleteHumanReview, archiveTasks, hasRecentActivity, startTaskOrQueue } from '../stores/task-store';
+import { stopTask, checkTaskRunning, recoverStuckTask, getStuckInfo, isIncompleteHumanReview, archiveTasks, hasRecentActivity, startTaskOrQueue } from '../stores/task-store';
 import { useToast } from '../hooks/use-toast';
 import type { Task, TaskCategory, ReviewReason, TaskStatus } from '../../shared/types';
 
@@ -251,6 +251,18 @@ export const TaskCard = memo(function TaskCard({
     const result = await recoverStuckTask(task.id, { autoRestart: true });
     if (result.success) {
       setIsStuck(false);
+    } else {
+      // Check for stuck subtasks that might be blocking
+      const stuckResult = await getStuckInfo(task.projectId, task.specId);
+      const hasStuckSubtasks = stuckResult.success && stuckResult.stuckSubtasks && stuckResult.stuckSubtasks.length > 0;
+
+      toast({
+        title: t('tasks:errors.recoveryFailed'),
+        description: hasStuckSubtasks
+          ? t('tasks:errors.stuckSubtasksBlocking', { count: stuckResult.stuckSubtasks?.length ?? 0 })
+          : result.message,
+        variant: 'destructive',
+      });
     }
     setIsRecovering(false);
   };

--- a/apps/frontend/src/renderer/components/task-detail/TaskDetailModal.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskDetailModal.tsx
@@ -467,6 +467,8 @@ function TaskDetailModalContent({ open, task, onOpenChange, onSwitchToTerminals,
                     isIncomplete={state.isIncomplete}
                     isRecovering={state.isRecovering}
                     taskProgress={state.taskProgress}
+                    projectId={task.projectId}
+                    specId={task.specId}
                     onRecover={handleRecover}
                     onResume={handleStartStop}
                   />

--- a/apps/frontend/src/renderer/components/task-detail/TaskWarnings.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskWarnings.tsx
@@ -1,11 +1,24 @@
-import { AlertTriangle, Play, RotateCcw, Loader2 } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, Play, RotateCcw, Loader2, Unlock } from 'lucide-react';
 import { Button } from '../ui/button';
+import { getStuckInfo, unstickSubtasks } from '../../stores/task-store';
+import { useToast } from '../../hooks/use-toast';
+
+interface StuckSubtask {
+  subtask_id: string;
+  reason: string;
+  escalated_at: string;
+  attempt_count: number;
+}
 
 interface TaskWarningsProps {
   isStuck: boolean;
   isIncomplete: boolean;
   isRecovering: boolean;
   taskProgress: { completed: number; total: number };
+  projectId?: string;
+  specId?: string;
   onRecover: () => void;
   onResume: () => void;
 }
@@ -15,9 +28,49 @@ export function TaskWarnings({
   isIncomplete,
   isRecovering,
   taskProgress,
+  projectId,
+  specId,
   onRecover,
   onResume
 }: TaskWarningsProps) {
+  const { t } = useTranslation('tasks');
+  const { toast } = useToast();
+  const [stuckSubtasks, setStuckSubtasks] = useState<StuckSubtask[]>([]);
+  const [isLoadingStuck, setIsLoadingStuck] = useState(false);
+  const [isUnsticking, setIsUnsticking] = useState(false);
+
+  // Load stuck subtask info when stuck
+  useEffect(() => {
+    if (isStuck && projectId && specId) {
+      setIsLoadingStuck(true);
+      getStuckInfo(projectId, specId)
+        .then(result => {
+          if (result.success && result.stuckSubtasks) {
+            setStuckSubtasks(result.stuckSubtasks);
+          }
+        })
+        .finally(() => setIsLoadingStuck(false));
+    } else {
+      setStuckSubtasks([]);
+    }
+  }, [isStuck, projectId, specId]);
+
+  const handleUnstick = async () => {
+    if (!projectId || !specId) return;
+    setIsUnsticking(true);
+    try {
+      const result = await unstickSubtasks(projectId, specId);
+      if (result.success && result.cleared && result.cleared > 0) {
+        toast({ title: t('messages.subtasksUnstuck', { count: result.cleared }) });
+        setStuckSubtasks([]);
+      } else if (result.error) {
+        toast({ title: t('errors.unstickFailed'), description: result.error, variant: 'destructive' });
+      }
+    } finally {
+      setIsUnsticking(false);
+    }
+  };
+
   if (!isStuck && !isIncomplete) return null;
 
   return (
@@ -29,12 +82,58 @@ export function TaskWarnings({
             <AlertTriangle className="h-5 w-5 text-warning shrink-0 mt-0.5" />
             <div className="flex-1">
               <h3 className="font-medium text-sm text-foreground mb-1">
-                Task Appears Stuck
+                {t('warnings.taskStuck')}
               </h3>
               <p className="text-sm text-muted-foreground mb-3">
-                This task is marked as running but no active process was found.
-                This can happen if the app crashed or the process was terminated unexpectedly.
+                {t('warnings.taskStuckDescription')}
               </p>
+
+              {/* Stuck Subtasks Info */}
+              {stuckSubtasks.length > 0 && (
+                <div className="mb-3 p-2 bg-destructive/10 rounded text-sm">
+                  <p className="font-medium text-destructive mb-1">
+                    {t('labels.stuckSubtasks')} ({stuckSubtasks.length})
+                  </p>
+                  <ul className="space-y-1 max-h-32 overflow-y-auto">
+                    {stuckSubtasks.map((stuck) => (
+                      <li key={stuck.subtask_id} className="text-xs text-muted-foreground">
+                        <span className="font-mono">{stuck.subtask_id}</span>:{' '}
+                        <span className="truncate" title={stuck.reason}>
+                          {stuck.reason.length > 80 ? `${stuck.reason.slice(0, 80)}...` : stuck.reason}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="mt-2"
+                    onClick={handleUnstick}
+                    disabled={isUnsticking}
+                  >
+                    {isUnsticking ? (
+                      <>
+                        <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+                        {t('actions.unsticking')}
+                      </>
+                    ) : (
+                      <>
+                        <Unlock className="mr-1.5 h-3 w-3" />
+                        {t('actions.unstickSubtasks')}
+                      </>
+                    )}
+                  </Button>
+                </div>
+              )}
+
+              {/* Loading state for stuck info */}
+              {isLoadingStuck && stuckSubtasks.length === 0 && (
+                <div className="mb-3 flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  {t('labels.checkingStuck')}
+                </div>
+              )}
+
               <Button
                 variant="warning"
                 size="sm"
@@ -45,12 +144,12 @@ export function TaskWarnings({
                 {isRecovering ? (
                   <>
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Recovering...
+                    {t('actions.recovering')}
                   </>
                 ) : (
                   <>
                     <RotateCcw className="mr-2 h-4 w-4" />
-                    Recover & Restart Task
+                    {t('actions.recoverRestart')}
                   </>
                 )}
               </Button>
@@ -66,11 +165,10 @@ export function TaskWarnings({
             <AlertTriangle className="h-5 w-5 text-orange-400 shrink-0 mt-0.5" />
             <div className="flex-1">
               <h3 className="font-medium text-sm text-foreground mb-1">
-                Task Incomplete
+                {t('warnings.taskIncomplete')}
               </h3>
               <p className="text-sm text-muted-foreground mb-3">
-                This task has a spec and implementation plan but never completed any subtasks ({taskProgress.completed}/{taskProgress.total}).
-                The process likely crashed during spec creation. Click Resume to continue implementation.
+                {t('warnings.taskIncompleteDescription', { completed: taskProgress.completed, total: taskProgress.total })}
               </p>
               <Button
                 variant="default"
@@ -79,7 +177,7 @@ export function TaskWarnings({
                 className="w-full"
               >
                 <Play className="mr-2 h-4 w-4" />
-                Resume Task
+                {t('actions.resumeTask')}
               </Button>
             </div>
           </div>

--- a/apps/frontend/src/renderer/components/task-detail/TaskWarnings.tsx
+++ b/apps/frontend/src/renderer/components/task-detail/TaskWarnings.tsx
@@ -2,15 +2,9 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AlertTriangle, Play, RotateCcw, Loader2, Unlock } from 'lucide-react';
 import { Button } from '../ui/button';
-import { getStuckInfo, unstickSubtasks } from '../../stores/task-store';
-import { useToast } from '../../hooks/use-toast';
-
-interface StuckSubtask {
-  subtask_id: string;
-  reason: string;
-  escalated_at: string;
-  attempt_count: number;
-}
+import { getStuckInfo, unstickSubtasks } from '@/stores/task-store';
+import { useToast } from '@/hooks/use-toast';
+import type { StuckSubtaskInfo } from '@shared/types/task';
 
 interface TaskWarningsProps {
   isStuck: boolean;
@@ -35,24 +29,26 @@ export function TaskWarnings({
 }: TaskWarningsProps) {
   const { t } = useTranslation('tasks');
   const { toast } = useToast();
-  const [stuckSubtasks, setStuckSubtasks] = useState<StuckSubtask[]>([]);
+  const [stuckSubtasks, setStuckSubtasks] = useState<StuckSubtaskInfo[]>([]);
   const [isLoadingStuck, setIsLoadingStuck] = useState(false);
   const [isUnsticking, setIsUnsticking] = useState(false);
 
   // Load stuck subtask info when stuck
   useEffect(() => {
+    let ignore = false;
     if (isStuck && projectId && specId) {
       setIsLoadingStuck(true);
       getStuckInfo(projectId, specId)
         .then(result => {
-          if (result.success && result.stuckSubtasks) {
+          if (!ignore && result.success && result.stuckSubtasks) {
             setStuckSubtasks(result.stuckSubtasks);
           }
         })
-        .finally(() => setIsLoadingStuck(false));
+        .finally(() => { if (!ignore) setIsLoadingStuck(false); });
     } else {
       setStuckSubtasks([]);
     }
+    return () => { ignore = true; };
   }, [isStuck, projectId, specId]);
 
   const handleUnstick = async () => {

--- a/apps/frontend/src/renderer/lib/mocks/task-mock.ts
+++ b/apps/frontend/src/renderer/lib/mocks/task-mock.ts
@@ -76,6 +76,10 @@ export const taskMock = {
 
   resumePausedTask: async () => ({ success: true }),
 
+  getStuckInfo: async () => ({ success: true, data: { stuckSubtasks: [] } }),
+
+  unstickSubtasks: async () => ({ success: true, data: { cleared: 0 } }),
+
   // Worktree change detection
   checkWorktreeChanges: async (_taskId: string) => ({
     success: true as const,

--- a/apps/frontend/src/renderer/stores/task-store.ts
+++ b/apps/frontend/src/renderer/stores/task-store.ts
@@ -960,6 +960,45 @@ export async function recoverStuckTask(
 }
 
 /**
+ * Get stuck subtask information for a spec
+ * @param projectId - The project ID
+ * @param specId - The spec ID to check
+ */
+export async function getStuckInfo(
+  projectId: string,
+  specId: string
+): Promise<{ success: boolean; stuckSubtasks?: Array<{ subtask_id: string; reason: string; escalated_at: string; attempt_count: number }>; error?: string }> {
+  try {
+    const result = await window.electronAPI.getStuckInfo(projectId, specId);
+    if (result.success && result.data) {
+      return { success: true, stuckSubtasks: result.data.stuckSubtasks };
+    }
+    return { success: false, error: result.error };
+  } catch (error) {
+    console.error('Error getting stuck info:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+}
+
+/**
+ * Clear stuck subtasks for a spec
+ * @param projectId - The project ID
+ * @param specId - The spec ID to unstick
+ */
+export async function unstickSubtasks(
+  projectId: string,
+  specId: string
+): Promise<{ success: boolean; cleared?: number; error?: string }> {
+  try {
+    const result = await window.electronAPI.unstickSubtasks(projectId, specId);
+    return result;
+  } catch (error) {
+    console.error('Error unsticking subtasks:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+}
+
+/**
  * Delete a task and its spec directory
  */
 export async function deleteTask(

--- a/apps/frontend/src/renderer/stores/task-store.ts
+++ b/apps/frontend/src/renderer/stores/task-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { arrayMove } from '@dnd-kit/sortable';
-import type { Task, TaskStatus, SubtaskStatus, ImplementationPlan, Subtask, TaskMetadata, ExecutionProgress, ExecutionPhase, ReviewReason, TaskDraft, ImageAttachment, TaskOrderState } from '../../shared/types';
+import type { Task, TaskStatus, SubtaskStatus, ImplementationPlan, Subtask, TaskMetadata, ExecutionProgress, ExecutionPhase, ReviewReason, TaskDraft, ImageAttachment, TaskOrderState, StuckSubtaskInfo } from '../../shared/types';
 import { debugLog, debugWarn } from '../../shared/utils/debug-logger';
 import { useProjectStore } from './project-store';
 
@@ -967,7 +967,7 @@ export async function recoverStuckTask(
 export async function getStuckInfo(
   projectId: string,
   specId: string
-): Promise<{ success: boolean; stuckSubtasks?: Array<{ subtask_id: string; reason: string; escalated_at: string; attempt_count: number }>; error?: string }> {
+): Promise<{ success: boolean; stuckSubtasks?: StuckSubtaskInfo[]; error?: string }> {
   try {
     const result = await window.electronAPI.getStuckInfo(projectId, specId);
     if (result.success && result.data) {
@@ -991,7 +991,10 @@ export async function unstickSubtasks(
 ): Promise<{ success: boolean; cleared?: number; error?: string }> {
   try {
     const result = await window.electronAPI.unstickSubtasks(projectId, specId);
-    return result;
+    if (result.success && result.data) {
+      return { success: true, cleared: result.data.cleared };
+    }
+    return { success: false, error: result.error };
   } catch (error) {
     console.error('Error unsticking subtasks:', error);
     return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };

--- a/apps/frontend/src/shared/constants/ipc.ts
+++ b/apps/frontend/src/shared/constants/ipc.ts
@@ -30,6 +30,8 @@ export const IPC_CHANNELS = {
   TASK_REVIEW: 'task:review',
   TASK_UPDATE_STATUS: 'task:updateStatus',
   TASK_RECOVER_STUCK: 'task:recoverStuck',
+  TASK_GET_STUCK_INFO: 'task:getStuckInfo',       // Get stuck subtask details
+  TASK_UNSTICK_SUBTASKS: 'task:unstickSubtasks',  // Clear stuck subtasks
   TASK_CHECK_RUNNING: 'task:checkRunning',
   TASK_RESUME_PAUSED: 'task:resumePaused',  // Resume a rate-limited or auth-paused task
   TASK_LOAD_IMAGE_THUMBNAIL: 'task:loadImageThumbnail',

--- a/apps/frontend/src/shared/i18n/locales/en/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/en/tasks.json
@@ -21,7 +21,12 @@
     "viewPR": "View PR",
     "moveTo": "Move to",
     "taskActions": "Task actions",
-    "selectTask": "Select task: {{title}}"
+    "selectTask": "Select task: {{title}}",
+    "unstickSubtasks": "Unstick Subtasks",
+    "unsticking": "Unsticking...",
+    "recovering": "Recovering...",
+    "recoverRestart": "Recover & Restart Task",
+    "resumeTask": "Resume Task"
   },
   "labels": {
     "running": "Running",
@@ -32,7 +37,23 @@
     "incomplete": "Incomplete",
     "recovering": "Recovering...",
     "needsRecovery": "Needs Recovery",
-    "needsResume": "Needs Resume"
+    "needsResume": "Needs Resume",
+    "stuckSubtasks": "Stuck Subtasks",
+    "checkingStuck": "Checking stuck subtasks..."
+  },
+  "errors": {
+    "recoveryFailed": "Recovery failed",
+    "stuckSubtasksBlocking": "{{count}} stuck subtasks blocking progress",
+    "unstickFailed": "Failed to unstick subtasks"
+  },
+  "messages": {
+    "subtasksUnstuck": "{{count}} subtasks unstuck"
+  },
+  "warnings": {
+    "taskStuck": "Task Appears Stuck",
+    "taskStuckDescription": "This task is marked as running but no active process was found. This can happen if the app crashed or the process was terminated unexpectedly.",
+    "taskIncomplete": "Task Incomplete",
+    "taskIncompleteDescription": "This task has a spec and implementation plan but never completed any subtasks ({{completed}}/{{total}}). The process likely crashed during spec creation. Click Resume to continue implementation."
   },
   "reviewReason": {
     "completed": "Completed",

--- a/apps/frontend/src/shared/i18n/locales/fr/tasks.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/tasks.json
@@ -21,7 +21,12 @@
     "viewPR": "Voir la PR",
     "moveTo": "Déplacer vers",
     "taskActions": "Actions de la tâche",
-    "selectTask": "Sélectionner la tâche : {{title}}"
+    "selectTask": "Sélectionner la tâche : {{title}}",
+    "unstickSubtasks": "Débloquer les sous-tâches",
+    "unsticking": "Déblocage...",
+    "recovering": "Récupération...",
+    "recoverRestart": "Récupérer et redémarrer",
+    "resumeTask": "Reprendre la tâche"
   },
   "labels": {
     "running": "En cours",
@@ -32,7 +37,23 @@
     "incomplete": "Incomplet",
     "recovering": "Récupération...",
     "needsRecovery": "Récupération requise",
-    "needsResume": "Reprise requise"
+    "needsResume": "Reprise requise",
+    "stuckSubtasks": "Sous-tâches bloquées",
+    "checkingStuck": "Vérification des sous-tâches bloquées..."
+  },
+  "errors": {
+    "recoveryFailed": "Échec de la récupération",
+    "stuckSubtasksBlocking": "{{count}} sous-tâches bloquées empêchent la progression",
+    "unstickFailed": "Échec du déblocage des sous-tâches"
+  },
+  "messages": {
+    "subtasksUnstuck": "{{count}} sous-tâches débloquées"
+  },
+  "warnings": {
+    "taskStuck": "Tâche bloquée",
+    "taskStuckDescription": "Cette tâche est marquée comme en cours mais aucun processus actif n'a été trouvé. Cela peut arriver si l'application a planté ou si le processus a été terminé de manière inattendue.",
+    "taskIncomplete": "Tâche incomplète",
+    "taskIncompleteDescription": "Cette tâche a un spec et un plan d'implémentation mais n'a terminé aucune sous-tâche ({{completed}}/{{total}}). Le processus a probablement planté pendant la création du spec. Cliquez sur Reprendre pour continuer l'implémentation."
   },
   "reviewReason": {
     "completed": "Terminé",

--- a/apps/frontend/src/shared/types/ipc.ts
+++ b/apps/frontend/src/shared/types/ipc.ts
@@ -205,6 +205,8 @@ export interface ElectronAPI {
   recoverStuckTask: (taskId: string, options?: TaskRecoveryOptions) => Promise<IPCResult<TaskRecoveryResult>>;
   checkTaskRunning: (taskId: string) => Promise<IPCResult<boolean>>;
   resumePausedTask: (taskId: string) => Promise<IPCResult>;
+  getStuckInfo: (projectId: string, specId: string) => Promise<IPCResult<{ stuckSubtasks: Array<{ subtask_id: string; reason: string; escalated_at: string; attempt_count: number }> }>>;
+  unstickSubtasks: (projectId: string, specId: string) => Promise<IPCResult<{ cleared: number }>>;
 
   // Image operations
   loadImageThumbnail: (projectPath: string, specId: string, imagePath: string) => Promise<IPCResult<string>>;

--- a/apps/frontend/src/shared/types/ipc.ts
+++ b/apps/frontend/src/shared/types/ipc.ts
@@ -47,7 +47,8 @@ import type {
   TaskLogStreamChunk,
   ImageAttachment,
   ReviewReason,
-  MergeProgress
+  MergeProgress,
+  StuckSubtaskInfo
 } from './task';
 import type {
   TerminalCreateOptions,
@@ -205,7 +206,7 @@ export interface ElectronAPI {
   recoverStuckTask: (taskId: string, options?: TaskRecoveryOptions) => Promise<IPCResult<TaskRecoveryResult>>;
   checkTaskRunning: (taskId: string) => Promise<IPCResult<boolean>>;
   resumePausedTask: (taskId: string) => Promise<IPCResult>;
-  getStuckInfo: (projectId: string, specId: string) => Promise<IPCResult<{ stuckSubtasks: Array<{ subtask_id: string; reason: string; escalated_at: string; attempt_count: number }> }>>;
+  getStuckInfo: (projectId: string, specId: string) => Promise<IPCResult<{ stuckSubtasks: StuckSubtaskInfo[] }>>;
   unstickSubtasks: (projectId: string, specId: string) => Promise<IPCResult<{ cleared: number }>>;
 
   // Image operations

--- a/apps/frontend/src/shared/types/task.ts
+++ b/apps/frontend/src/shared/types/task.ts
@@ -506,6 +506,13 @@ export interface WorktreeListResult {
 }
 
 // Stuck task recovery types
+export interface StuckSubtaskInfo {
+  subtask_id: string;
+  reason: string;
+  escalated_at: string;
+  attempt_count: number;
+}
+
 export interface StuckTaskInfo {
   taskId: string;
   specId: string;


### PR DESCRIPTION
## Summary

When task recovery fails (e.g., stuck subtasks with wrong file paths), the UI now provides clear feedback and an option to unstick subtasks.

- **Error Feedback**: Shows error toast with stuck subtask count when recovery fails
- **Unstick Button**: Adds "Unstick Subtasks" button in TaskWarnings component with stuck reasons displayed
- **CLI Command**: Adds `--unstick` flag for manual recovery from command line

## Changes

### Backend
- `cli/main.py`: Add `--unstick` CLI flag to clear stuck subtasks
- `services/recovery.py`: Add `get_stuck_subtasks()` method

### Frontend Main Process
- `execution-handlers.ts`: Add `TASK_GET_STUCK_INFO` and `TASK_UNSTICK_SUBTASKS` IPC handlers
- `ipc.ts`: Add new IPC channel constants
- `task-api.ts`: Expose `getStuckInfo` and `unstickSubtasks` preload APIs

### Frontend Renderer
- `TaskWarnings.tsx`: Show stuck subtasks with reasons and unstick button
- `TaskCard.tsx`: Show error toast on recovery failure
- `task-store.ts`: Add `getStuckInfo` and `unstickSubtasks` store actions

### i18n
- Add translation strings for error messages and actions in English and French

## Test Plan

1. Create a task with invalid file paths in implementation plan (e.g., non-existent files)
2. Run task until subtasks get stuck
3. Click Recover - should see error toast with stuck subtask count
4. Open Task Detail modal - should see stuck subtasks listed with reasons
5. Click "Unstick Subtasks" - should clear stuck state
6. Click Recover again - should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: new --unstick flag to detect, clear, and report stuck subtasks.
  * UI: view stuck subtasks with reasons, loading/toast feedback, and a manual "Unstick Subtasks" action.
  * Frontend↔backend: new APIs/channels to fetch stuck-subtask info and perform unstick operations.

* **Localization**
  * Added English and French strings for stuck/subtask recovery flows, actions, errors, and messages.

* **Types & Mocks**
  * New stuck-subtask data type and matching mock methods for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->