### PR TITLE
fix: prevent roadmap.json cross-project contamination on project switch

### DIFF
--- a/apps/frontend/src/renderer/hooks/useIpc.ts
+++ b/apps/frontend/src/renderer/hooks/useIpc.ts
@@ -222,14 +222,18 @@ export function useIpcListeners(): void {
 
         // Sync roadmap feature when task completes
         if (status === 'done' || status === 'pr_created') {
-          useRoadmapStore.getState().markFeatureDoneBySpecId(taskId);
-          // Re-read state after mutation to get updated roadmap
+          // Use event's projectId (from callback param) — NOT the store's activeProjectId.
+          // During project switches, the store may hold a different project's roadmap.
+          const eventProjectId = projectId;
           const rm = useRoadmapStore.getState().roadmap;
-          const currentProjectId = useProjectStore.getState().activeProjectId || useProjectStore.getState().selectedProjectId;
-          if (rm && currentProjectId) {
-            window.electronAPI.saveRoadmap(currentProjectId, rm).catch((err) => {
-              console.error('[useIpc] Failed to persist roadmap after task completion:', err);
-            });
+          if (rm && eventProjectId && rm.projectId === eventProjectId) {
+            useRoadmapStore.getState().markFeatureDoneBySpecId(taskId);
+            const updatedRm = useRoadmapStore.getState().roadmap;
+            if (updatedRm && updatedRm.projectId === eventProjectId) {
+              window.electronAPI.saveRoadmap(eventProjectId, updatedRm).catch((err) => {
+                console.error('[useIpc] Failed to persist roadmap after task completion:', err);
+              });
+            }
           }
         }
       }

--- a/apps/frontend/src/renderer/stores/roadmap-store.ts
+++ b/apps/frontend/src/renderer/stores/roadmap-store.ts
@@ -713,7 +713,9 @@ async function reconcileLinkedFeatures(projectId: string, roadmap: Roadmap): Pro
 
   if (hasChanges) {
     const updatedRoadmap = useRoadmapStore.getState().roadmap;
-    if (updatedRoadmap) {
+    // Guard: only save if the store still holds the same project's roadmap.
+    // A project switch during async reconciliation could replace the roadmap.
+    if (updatedRoadmap && updatedRoadmap.projectId === projectId) {
       console.log('[Roadmap] Reconciled linked features with task states');
       window.electronAPI.saveRoadmap(projectId, updatedRoadmap).catch((err) => {
         console.error('[Roadmap] Failed to save reconciled roadmap:', err);
@@ -729,6 +731,7 @@ export async function loadRoadmap(projectId: string): Promise<void> {
   // Always set current project ID first - this ensures event handlers
   // only process events for the currently viewed project
   store.setCurrentProjectId(projectId);
+  store.setRoadmap(null);  // Clear immediately to prevent stale cross-project saves
 
   // Query if roadmap generation is currently running for this project
   // This restores the generation status when switching back to a project

--- a/apps/frontend/src/renderer/stores/roadmap-store.ts
+++ b/apps/frontend/src/renderer/stores/roadmap-store.ts
@@ -732,6 +732,8 @@ export async function loadRoadmap(projectId: string): Promise<void> {
   // only process events for the currently viewed project
   store.setCurrentProjectId(projectId);
   store.setRoadmap(null);  // Clear immediately to prevent stale cross-project saves
+  store.setCompetitorAnalysis(null);
+  store.setGenerationStatus({ phase: 'idle', progress: 0, message: '' });
 
   // Query if roadmap generation is currently running for this project
   // This restores the generation status when switching back to a project


### PR DESCRIPTION
## Summary
- Fix race condition where switching projects could overwrite one project's `roadmap.json` with another project's data
- Add `roadmap.projectId` validation before every save in `useIpc.ts` and `roadmap-store.ts`
- Clear roadmap store immediately on project switch (`loadRoadmap`) to prevent stale saves during async gap

## Test plan
- [ ] Open two projects (A and B), each with a roadmap
- [ ] On Project A, start a merge for a task; while running, switch to Project B, then back to A
- [ ] Verify Project A's `roadmap.json` still has Project A's features after merge completes
- [ ] Verify Project B's `roadmap.json` is unchanged
- [ ] Run `cd apps/frontend && npm test` — all 3467 tests pass
- [ ] Run `cd apps/frontend && npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Roadmap updates now use the originating event's project ID to prevent cross-project persistence and data corruption.
  * Reconciliation logic avoids saving if the in-memory roadmap no longer belongs to the same project, preventing async cross-project saves.
  * Switching projects immediately clears roadmap and related state to remove stale data and stop inconsistencies from carrying over.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->