### PR TITLE
fix: resolve setup wizard flashing on auth screen

### DIFF
--- a/apps/frontend/src/renderer/components/onboarding/OAuthStep.tsx
+++ b/apps/frontend/src/renderer/components/onboarding/OAuthStep.tsx
@@ -79,7 +79,7 @@ export function OAuthStep({ onNext, onBack, onSkip }: OAuthStepProps) {
   );
 
   // Reusable function to load Claude profiles
-  const loadClaudeProfiles = async () => {
+  const loadClaudeProfiles = useCallback(async () => {
     setIsLoadingProfiles(true);
     setError(null);
     try {
@@ -95,7 +95,7 @@ export function OAuthStep({ onNext, onBack, onSkip }: OAuthStepProps) {
     } finally {
       setIsLoadingProfiles(false);
     }
-  };
+  }, []);
 
   // Load Claude profiles on mount
   useEffect(() => {

--- a/apps/frontend/src/renderer/components/onboarding/OAuthStep.tsx
+++ b/apps/frontend/src/renderer/components/onboarding/OAuthStep.tsx
@@ -231,7 +231,7 @@ export function OAuthStep({ onNext, onBack, onSkip }: OAuthStepProps) {
 
   // Handle auth terminal success
   const handleAuthTerminalSuccess = useCallback(async (email?: string) => {
-    console.warn('[OAuthStep] Auth success:', email);
+    console.warn('[OAuthStep] Auth success');
 
     // Close terminal immediately
     setAuthTerminal(null);


### PR DESCRIPTION
## Summary
- Fixes the setup wizard screen flashing/flickering constantly when navigating to the "Configure Claude Authentication" step
- **Root cause:** `loadClaudeProfiles` in `OAuthStep.tsx` was defined as a plain `async` function, creating a new reference every render. Since it was a `useEffect` dependency, this caused an infinite re-render loop (effect fires → state update → re-render → new function ref → effect fires again)
- **Fix:** Wrapped `loadClaudeProfiles` in `useCallback` with `[]` deps to stabilize the function reference

Fixes #1882

## Test plan
- [x] All 3467 frontend unit tests pass
- [ ] Launch app fresh → Setup Wizard → "Sign in with Anthropic" → auth screen should render stably without flashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved profile-loading logic to stabilize behavior across renders and reduce unnecessary updates.
* **Bug Fixes / Privacy**
  * Adjusted authentication logging to avoid exposing email addresses in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->