### PR TITLE
fix: sync kanban card stage with live agent phase

### DIFF
--- a/apps/frontend/src/main/task-state-manager.ts
+++ b/apps/frontend/src/main/task-state-manager.ts
@@ -362,7 +362,12 @@ export class TaskStateManager {
 
     const phase = XSTATE_TO_PHASE[xstateState] || 'idle';
 
-    // Emit execution progress with the phase derived from XState
+    // Emit execution progress with the phase derived from XState.
+    // IMPORTANT: Do NOT use Date.now() as sequenceNumber here — doing so would
+    // permanently block all subsequent agent execution-progress events, because
+    // the agent uses small sequential integers (1, 2, 3…) that are always less
+    // than a timestamp. Instead emit with sequenceNumber=0 so the agent's own
+    // events can continue updating phaseProgress once the phase is established.
     safeSendToRenderer(
       this.getMainWindow,
       IPC_CHANNELS.TASK_EXECUTION_PROGRESS,
@@ -372,7 +377,7 @@ export class TaskStateManager {
         phaseProgress: phase === 'complete' ? 100 : 50,
         overallProgress: phase === 'complete' ? 100 : 50,
         message: `State: ${xstateState}`,
-        sequenceNumber: Date.now()  // Use timestamp as sequence to ensure it's newer
+        sequenceNumber: 0
       },
       projectId
     );

--- a/apps/frontend/src/main/task-state-manager.ts
+++ b/apps/frontend/src/main/task-state-manager.ts
@@ -374,8 +374,8 @@ export class TaskStateManager {
       taskId,
       {
         phase,
-        phaseProgress: phase === 'complete' ? 100 : 50,
-        overallProgress: phase === 'complete' ? 100 : 50,
+        phaseProgress: phase === 'complete' ? 100 : 0,
+        overallProgress: phase === 'complete' ? 100 : 0,
         message: `State: ${xstateState}`,
         sequenceNumber: 0
       },


### PR DESCRIPTION
## Summary
- Fixes kanban board task cards showing stale "planning" stage when the task has actually progressed to "coding"
- **Root cause:** `emitPhaseFromState` in `task-state-manager.ts` used `sequenceNumber: Date.now()` (~1.7 trillion) for XState phase transitions. The renderer's `updateExecutionProgress` has an out-of-order guard that drops events where `incomingSeq < currentSeq`. Once the initial "planning" phase set `currentSeq` to a timestamp, ALL subsequent agent progress events (using small sequential integers: 1, 2, 3...) were permanently dropped, freezing the card on "planning"
- **Fix:** Changed `sequenceNumber: Date.now()` to `sequenceNumber: 0` so XState updates bypass the sequence guard and don't poison the sequence counter for subsequent agent events

Fixes #1885

## Test plan
- [x] All 3467 frontend unit tests pass
- [ ] Start a task → observe kanban board → card should update from "planning" to "coding" as the agent progresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task state reporting so execution-progress events use stable sequencing and show 0% for non-final phases, preventing misleading intermediate progress values and improving real-time progress accuracy during task execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->