### PR TITLE
fix: expand tilde in configDir before fs calls when adding account

### DIFF
--- a/apps/frontend/src/main/ipc-handlers/terminal-handlers.ts
+++ b/apps/frontend/src/main/ipc-handlers/terminal-handlers.ts
@@ -10,7 +10,7 @@ import { terminalNameGenerator } from '../terminal-name-generator';
 import { readSettingsFileAsync } from '../settings-utils';
 import { debugLog, } from '../../shared/utils/debug-logger';
 import { migrateSession } from '../claude-profile/session-utils';
-import { createProfileDirectory } from '../claude-profile/profile-utils';
+import { createProfileDirectory, expandHomePath } from '../claude-profile/profile-utils';
 import { isValidConfigDir } from '../utils/config-path-validator';
 
 
@@ -161,10 +161,13 @@ export function registerTerminalHandlers(
             };
           }
 
-          // Ensure config directory exists
+          // Ensure config directory exists (expand ~ before passing to Node.js fs functions,
+          // which do not perform shell tilde expansion)
+          const resolvedConfigDir = expandHomePath(profile.configDir);
+          profile.configDir = resolvedConfigDir;
           const { mkdirSync, existsSync } = await import('fs');
-          if (!existsSync(profile.configDir)) {
-            mkdirSync(profile.configDir, { recursive: true });
+          if (!existsSync(resolvedConfigDir)) {
+            mkdirSync(resolvedConfigDir, { recursive: true });
           }
         }
 

--- a/apps/frontend/src/renderer/components/settings/AccountSettings.tsx
+++ b/apps/frontend/src/renderer/components/settings/AccountSettings.tsx
@@ -339,6 +339,12 @@ export function AccountSettings({ settings, onSettingsChange, isOpen }: AccountS
             description: authResult.error || t('accounts.toast.tryAgain'),
           });
         }
+      } else if (!result.success) {
+        toast({
+          variant: 'destructive',
+          title: t('accounts.toast.addProfileFailed'),
+          description: result.error || t('accounts.toast.tryAgain'),
+        });
       }
     } catch (_err) {
       toast({


### PR DESCRIPTION
## Summary

- **Root cause**: `existsSync`/`mkdirSync` in the `CLAUDE_PROFILE_SAVE` IPC handler were called with the unexpanded tilde path (e.g. `~/.claude-profiles/name`). Node.js `fs` functions do not perform shell tilde expansion, so this either throws `EACCES`/`ENOENT` or creates a directory at the wrong literal path.
- **Silent failure**: The catch block returned `{ success: false }` but the renderer had no `else` branch to surface the error, so clicking Add appeared to do nothing with zero feedback.

## Changes

**`apps/frontend/src/main/ipc-handlers/terminal-handlers.ts`**
- Import `expandHomePath` from `profile-utils` (already exported)
- Expand tilde in `profile.configDir` via `expandHomePath()` before passing to `existsSync`/`mkdirSync`
- Update `profile.configDir` to the resolved absolute path so `saveProfile` receives a consistent value

**`apps/frontend/src/renderer/components/settings/AccountSettings.tsx`**
- Add `else if (!result.success)` branch in `handleAddClaudeProfile` to show a destructive toast when `saveClaudeProfile` returns `{ success: false }`, so errors are surfaced instead of swallowed silently

## Test plan

- [ ] Open Settings → Accounts
- [ ] Enter a name in the Account Name field and click Add
- [ ] Auth terminal should open in the Agent Terminals sidebar
- [ ] Verify `~/.claude-profiles/<name>/` directory is created at the correct absolute path
- [ ] Verify that on failure, a toast error is shown instead of silent nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced home directory path handling in Claude Code profile settings to properly resolve paths
  * Added error notifications when Claude profile creation fails, providing users with clear feedback on what went wrong

<!-- end of auto-generated comment: release notes by coderabbit.ai -->