### PR TITLE
fix: close claude CLI window after successful /login 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 This file provides guidance to Claude Code when working with this repository.
 
-Auto Claude is an autonomous multi-agent coding framework that plans, builds, and validates software for you. It's a monorepo with a Python backend (CLI + agent logic) and an Electron/React frontend (desktop UI).
+Aperant (formerly Auto Claude) is an autonomous multi-agent coding framework that plans, builds, and validates software for you. It's a monorepo with a Python backend (CLI + agent logic) and an Electron/React frontend (desktop UI).
 
 > **Deep-dive reference:** [ARCHITECTURE.md](shared_docs/ARCHITECTURE.md) | **Frontend contributing:** [apps/frontend/CONTRIBUTING.md](apps/frontend/CONTRIBUTING.md)
 
 ## Product Overview
 
-Auto Claude is a desktop application (+ CLI) where users describe a goal and AI agents autonomously handle planning, implementation, and QA validation. All work happens in isolated git worktrees so the main branch stays safe.
+Aperant is a desktop application (+ CLI) where users describe a goal and AI agents autonomously handle planning, implementation, and QA validation. All work happens in isolated git worktrees so the main branch stays safe.
 
 **Core workflow:** User creates a task → Spec creation pipeline assesses complexity and writes a specification → Planner agent breaks it into subtasks → Coder agent implements (can spawn parallel subagents) → QA reviewer validates → QA fixer resolves issues → User reviews and merges.
 
@@ -25,7 +25,7 @@ Auto Claude is a desktop application (+ CLI) where users describe a goal and AI 
 - **Memory System** — Graphiti-based knowledge graph retains insights across sessions
 - **Isolated Workspaces** — Git worktree isolation for every build; AI-powered semantic merge
 - **Flexible Authentication** — Use a Claude Code subscription (OAuth) or API profiles with any Anthropic-compatible endpoint (e.g., Anthropic API, z.ai for GLM models)
-- **Multi-Account Swapping** — Register multiple Claude accounts; when one hits a rate limit, Auto Claude automatically switches to an available account
+- **Multi-Account Swapping** — Register multiple Claude accounts; when one hits a rate limit, Aperant automatically switches to an available account
 - **Cross-Platform** — Native desktop app for Windows, macOS, and Linux with auto-updates
 
 ## Critical Rules

--- a/apps/frontend/src/main/terminal/claude-integration-handler.ts
+++ b/apps/frontend/src/main/terminal/claude-integration-handler.ts
@@ -540,17 +540,16 @@ export function handleOAuthToken(
 
       console.warn('[ClaudeIntegration] Profile credentials verified via Keychain (not caching token):', profileId);
 
-      // Set flag to watch for Claude's ready state (onboarding complete)
-      terminal.awaitingOnboardingComplete = true;
-
-      // needsOnboarding: true tells the UI to show "complete setup" message
-      // instead of "success" - user should finish Claude's onboarding before closing
+      // Credentials verified - close the auth terminal immediately.
+      // claude /login exits after OAuth completes and does not continue as an interactive
+      // session, so the welcome screen never appears and waiting for it would leave the
+      // window open forever.
       safeSendToRenderer(getWindow, IPC_CHANNELS.TERMINAL_OAUTH_TOKEN, {
         terminalId: terminal.id,
         profileId,
         email: emailFromOutput || keychainCreds.email || profile?.email,
         success: true,
-        needsOnboarding: true,
+        needsOnboarding: false,
         detectedAt: new Date().toISOString()
       } as OAuthTokenEvent);
     } else {
@@ -561,17 +560,12 @@ export function handleOAuthToken(
       if (hasCredentials) {
         console.warn('[ClaudeIntegration] Profile credentials verified (no Keychain token):', profileId);
 
-        // Set flag to watch for Claude's ready state (onboarding complete)
-        terminal.awaitingOnboardingComplete = true;
-
-        // needsOnboarding: true tells the UI to show "complete setup" message
-        // instead of "success" - user should finish Claude's onboarding before closing
         safeSendToRenderer(getWindow, IPC_CHANNELS.TERMINAL_OAUTH_TOKEN, {
           terminalId: terminal.id,
           profileId,
           email: emailFromOutput || profile?.email,
           success: true,
-          needsOnboarding: true,
+          needsOnboarding: false,
           detectedAt: new Date().toISOString()
         } as OAuthTokenEvent);
       } else {

--- a/apps/frontend/src/renderer/components/settings/AuthTerminal.tsx
+++ b/apps/frontend/src/renderer/components/settings/AuthTerminal.tsx
@@ -252,6 +252,14 @@ export function AuthTerminal({
             debugLog('Setting status to success (no onboarding needed)', { terminalId });
             setStatus('success');
             onAuthSuccess?.(info.email);
+            // Auto-close after a brief delay to show success UI
+            successTimeoutRef.current = setTimeout(() => {
+              if (isCreatedRef.current) {
+                window.electronAPI.destroyTerminal(terminalId).catch(console.error);
+                isCreatedRef.current = false;
+              }
+              onClose();
+            }, 1500);
           }
         } else {
           debugLog('OAuth failed', { terminalId, message: info.message });


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

<!-- What does this PR do? 2-3 sentences -->

Just a minor UX improvement ensures login window actually closes after a successful login. That preventing a confusing continuous `/login` loop. Currently, it seems to be stuck in login window even after onboarding prompts are answered.

Eventually,  `CLAUDE_CONFIG_DIR` is passed explicitly per-profile as an environment variable when spawning agents.
Further questions from `Claude CLI's` workspace/folder  during onboarding set up ~/.claude/ defaults,  but project
bypasses those entirely by injecting its own `configDir` path at runtime.

So those post-login questions only affect Claude CLI's own default behavior when run standalone. Those default ain't used by Aperent as it always passes its own configuration. It seems to be safe to close the auth window straight after credentials are confirmed in Keychain without answering CLIs prompt after login is confirmed.

### The Problem
The code was setting `needsOnboarding: true` and waiting indefinitely for a welcome screen that never appears. This left the auth window stuck open after a successful login, continuously prompting the user to log in again.

### Technical Changes
- **`claude-integration-handler.ts`**: Send `needsOnboarding: false` after a successful login (for both the `keychain-token` and `configDir-fallback` paths). Removed the `awaitingOnboardingComplete` flag that was waiting for a welcome screen that never arrives during the `claude /login` flow.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [x] Frontend
- [ ] Backend
- [ ] Fullstack

**Testing level:**
- [ ] Untested -- AI output not yet verified
- [ ] Lightly tested -- ran the app / spot-checked key paths
- [x] Fully tested -- all tests pass, manually verified behavior

## Platform Testing Checklist

**CRITICAL:** This project supports Windows, macOS, and Linux. Platform-specific bugs are a common source of breakage.

- [ ] **Windows tested** (either on Windows or via CI)
- [ ] **macOS tested** (either on macOS or via CI)
- [x] **Linux tested** (CI covers this)
- [ ] Used centralized `platform/` module instead of direct `process.platform` checks
- [ ] No hardcoded paths (used `findExecutable()` or platform abstractions)

**If you only have access to one OS:** CI now tests on all platforms. Ensure all checks pass before submitting.

## CI/Testing Requirements

- [ ] All CI checks pass on **all platforms** (Windows, macOS, Linux)
- [x] All existing tests pass
- [ ] New features include test coverage
- [ ] Bug fixes include regression tests

## Screenshots

**Before:**

TBD


**After:**
Behavior after stays the same except window is now closed right after successful authentication  


## Breaking Changes
**Breaking:** No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product naming and branding references throughout all documentation files and materials.

* **Improvements**
  * The authentication terminal now automatically closes approximately 1.5 seconds after successful login, displaying a brief success confirmation notification. The previous behavior of waiting for onboarding to complete after login has been removed from the authentication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->