### PR TITLE
feat: add MiniMax as LLM provider with M3 (default), M2.7 and M2.7-highspeed

### DIFF
--- a/apps/desktop/src/main/ai/auth/resolver.ts
+++ b/apps/desktop/src/main/ai/auth/resolver.ts
@@ -331,6 +331,7 @@ const BUILTIN_TO_SUPPORTED: Record<string, SupportedProvider> = {
   xai: 'xai',
   openrouter: 'openrouter',
   zai: 'zai',
+  minimax: 'minimax',
   ollama: 'ollama',
 };
 

--- a/apps/desktop/src/main/ai/auth/types.ts
+++ b/apps/desktop/src/main/ai/auth/types.ts
@@ -79,6 +79,7 @@ export const PROVIDER_ENV_VARS: Record<SupportedProvider, string | undefined> = 
   xai: 'XAI_API_KEY',
   openrouter: 'OPENROUTER_API_KEY',
   zai: 'ZHIPU_API_KEY',
+  minimax: 'MINIMAX_API_KEY',
   ollama: undefined,   // No auth required for local Ollama
 } as const;
 
@@ -96,6 +97,7 @@ export const PROVIDER_SETTINGS_KEY: Partial<Record<SupportedProvider, string>> =
   azure: 'globalAzureApiKey',
   openrouter: 'globalOpenRouterApiKey',
   zai: 'globalZAIApiKey',
+  minimax: 'globalMiniMaxApiKey',
 } as const;
 
 /**

--- a/apps/desktop/src/main/ai/config/types.ts
+++ b/apps/desktop/src/main/ai/config/types.ts
@@ -147,6 +147,7 @@ export const MODEL_PROVIDER_MAP: Record<string, SupportedProvider> = {
   'llama-': 'groq',
   'grok-': 'xai',
   'glm-': 'zai',
+  'MiniMax-': 'minimax',
 } as const;
 
 // ============================================

--- a/apps/desktop/src/main/ai/config/types.ts
+++ b/apps/desktop/src/main/ai/config/types.ts
@@ -147,7 +147,7 @@ export const MODEL_PROVIDER_MAP: Record<string, SupportedProvider> = {
   'llama-': 'groq',
   'grok-': 'xai',
   'glm-': 'zai',
-  'MiniMax-': 'minimax',
+  'minimax-': 'minimax',
 } as const;
 
 // ============================================

--- a/apps/desktop/src/main/ai/providers/__tests__/factory.test.ts
+++ b/apps/desktop/src/main/ai/providers/__tests__/factory.test.ts
@@ -164,9 +164,9 @@ describe('detectProviderFromModel', () => {
   });
 
   it('detects MiniMax from minimax- prefix', () => {
+    expect(detectProviderFromModel('minimax-m3')).toBe('minimax');
     expect(detectProviderFromModel('minimax-m2.7')).toBe('minimax');
     expect(detectProviderFromModel('minimax-m2.7-highspeed')).toBe('minimax');
-    expect(detectProviderFromModel('minimax-m2.5')).toBe('minimax');
   });
 
   it('returns undefined for unknown model', () => {

--- a/apps/desktop/src/main/ai/providers/__tests__/factory.test.ts
+++ b/apps/desktop/src/main/ai/providers/__tests__/factory.test.ts
@@ -163,6 +163,10 @@ describe('detectProviderFromModel', () => {
     expect(detectProviderFromModel('grok-2')).toBe('xai');
   });
 
+  it('detects MiniMax from MiniMax- prefix', () => {
+    expect(detectProviderFromModel('MiniMax-M2.5')).toBe('minimax');
+  });
+
   it('returns undefined for unknown model', () => {
     expect(detectProviderFromModel('unknown-model')).toBeUndefined();
   });

--- a/apps/desktop/src/main/ai/providers/__tests__/factory.test.ts
+++ b/apps/desktop/src/main/ai/providers/__tests__/factory.test.ts
@@ -164,6 +164,8 @@ describe('detectProviderFromModel', () => {
   });
 
   it('detects MiniMax from minimax- prefix', () => {
+    expect(detectProviderFromModel('minimax-m2.7')).toBe('minimax');
+    expect(detectProviderFromModel('minimax-m2.7-highspeed')).toBe('minimax');
     expect(detectProviderFromModel('minimax-m2.5')).toBe('minimax');
   });
 

--- a/apps/desktop/src/main/ai/providers/__tests__/factory.test.ts
+++ b/apps/desktop/src/main/ai/providers/__tests__/factory.test.ts
@@ -163,8 +163,8 @@ describe('detectProviderFromModel', () => {
     expect(detectProviderFromModel('grok-2')).toBe('xai');
   });
 
-  it('detects MiniMax from MiniMax- prefix', () => {
-    expect(detectProviderFromModel('MiniMax-M2.5')).toBe('minimax');
+  it('detects MiniMax from minimax- prefix', () => {
+    expect(detectProviderFromModel('minimax-m2.5')).toBe('minimax');
   });
 
   it('returns undefined for unknown model', () => {

--- a/apps/desktop/src/main/ai/providers/factory.ts
+++ b/apps/desktop/src/main/ai/providers/factory.ts
@@ -141,6 +141,14 @@ function createProviderInstance(config: ProviderConfig) {
         headers,
       });
 
+    case SupportedProvider.MiniMax:
+      return createOpenAICompatible({
+        name: 'minimax',
+        apiKey,
+        baseURL: baseURL ?? 'https://api.minimax.io/v1',
+        headers,
+      });
+
     case SupportedProvider.Ollama: {
       // Account settings store the base Ollama URL (e.g., 'http://localhost:11434')
       // but the OpenAI-compatible SDK needs the /v1 path appended.

--- a/apps/desktop/src/main/ai/providers/registry.ts
+++ b/apps/desktop/src/main/ai/providers/registry.ts
@@ -86,6 +86,14 @@ function createProviderSDKInstance(
         headers,
       });
 
+    case SupportedProvider.MiniMax:
+      return createOpenAICompatible({
+        name: 'minimax',
+        apiKey,
+        baseURL: baseURL ?? 'https://api.minimax.io/v1',
+        headers,
+      });
+
     case SupportedProvider.Ollama: {
       // Account settings store the base Ollama URL (e.g., 'http://localhost:11434')
       // but the OpenAI-compatible SDK needs the /v1 path appended.

--- a/apps/desktop/src/main/ai/providers/types.ts
+++ b/apps/desktop/src/main/ai/providers/types.ts
@@ -20,6 +20,7 @@ export const SupportedProvider = {
   XAI: 'xai',
   OpenRouter: 'openrouter',
   ZAI: 'zai',
+  MiniMax: 'minimax',
   Ollama: 'ollama',
 } as const;
 

--- a/apps/desktop/src/shared/constants/models.ts
+++ b/apps/desktop/src/shared/constants/models.ts
@@ -67,7 +67,9 @@ export const ALL_AVAILABLE_MODELS: ModelOption[] = [
   { value: 'grok-3', label: 'Grok 3', provider: 'xai', description: 'Text', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 131072 } },
   { value: 'grok-3-mini', label: 'Grok 3 Mini', provider: 'xai', description: 'Fast reasoning', capabilities: { thinking: true, tools: true, vision: false, contextWindow: 131072 } },
   // MiniMax
-  { value: 'minimax-m2.5', label: 'MiniMax M2.5', provider: 'minimax', description: 'Peak performance', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
+  { value: 'minimax-m2.7', label: 'MiniMax M2.7', provider: 'minimax', description: 'Latest flagship model with enhanced reasoning and coding', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
+  { value: 'minimax-m2.7-highspeed', label: 'MiniMax M2.7 High Speed', provider: 'minimax', description: 'High-speed version of M2.7 for low-latency scenarios', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
+  { value: 'minimax-m2.5', label: 'MiniMax M2.5', provider: 'minimax', description: 'Previous generation', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
   { value: 'minimax-m2.5-highspeed', label: 'MiniMax M2.5 High Speed', provider: 'minimax', description: 'Fast and agile', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
   // Z.AI (Zhipu)
   { value: 'glm-5', label: 'GLM-5', provider: 'zai', description: 'Flagship', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 128000 } },
@@ -320,9 +322,9 @@ export const PROVIDER_PRESET_DEFINITIONS: Partial<Record<BuiltinProvider, Record
     quick:    { primaryModel: 'glm-4.5-flash',  primaryThinking: 'low', phaseModels: { spec: 'glm-4.5-flash', planning: 'glm-4.5-flash', coding: 'glm-4.5-flash', qa: 'glm-4.5-flash' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
   },
   minimax: {
-    auto:     { primaryModel: 'minimax-m2.5', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.5', planning: 'minimax-m2.5', coding: 'minimax-m2.5', qa: 'minimax-m2.5' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
-    balanced: { primaryModel: 'minimax-m2.5', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.5', planning: 'minimax-m2.5', coding: 'minimax-m2.5', qa: 'minimax-m2.5' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
-    quick:    { primaryModel: 'minimax-m2.5-highspeed', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.5-highspeed', planning: 'minimax-m2.5-highspeed', coding: 'minimax-m2.5-highspeed', qa: 'minimax-m2.5-highspeed' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    auto:     { primaryModel: 'minimax-m2.7', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.7', planning: 'minimax-m2.7', coding: 'minimax-m2.7', qa: 'minimax-m2.7' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    balanced: { primaryModel: 'minimax-m2.7', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.7', planning: 'minimax-m2.7', coding: 'minimax-m2.7', qa: 'minimax-m2.7' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    quick:    { primaryModel: 'minimax-m2.7-highspeed', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.7-highspeed', planning: 'minimax-m2.7-highspeed', coding: 'minimax-m2.7-highspeed', qa: 'minimax-m2.7-highspeed' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
   },
   ollama: {
     auto:     { primaryModel: '', primaryThinking: 'low', phaseModels: { spec: '', planning: '', coding: '', qa: '' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
@@ -422,7 +424,17 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     mistral: { modelId: 'mistral-large-latest', reasoning: { type: 'none' } },
     groq: { modelId: 'meta-llama/llama-4-maverick', reasoning: { type: 'none' } },
     zai: { modelId: 'glm-5', reasoning: { type: 'none' } },
-    minimax: { modelId: 'minimax-m2.5', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m2.7', reasoning: { type: 'none' } },
+  },
+  'minimax-m2.7': {
+    minimax: { modelId: 'minimax-m2.7', reasoning: { type: 'none' } },
+    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    openai: { modelId: 'gpt-5.3-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
+  },
+  'minimax-m2.7-highspeed': {
+    minimax: { modelId: 'minimax-m2.7-highspeed', reasoning: { type: 'none' } },
+    anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },
+    openai: { modelId: 'gpt-5.1-codex-mini', reasoning: { type: 'reasoning_effort', level: 'low' } },
   },
   'minimax-m2.5': {
     minimax: { modelId: 'minimax-m2.5', reasoning: { type: 'none' } },
@@ -462,7 +474,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     groq: { modelId: 'llama-3.3-70b-versatile', reasoning: { type: 'none' } },
     xai: { modelId: 'grok-3-mini', reasoning: { type: 'reasoning_effort', level: 'medium' } },
     zai: { modelId: 'glm-4.7', reasoning: { type: 'none' } },
-    minimax: { modelId: 'minimax-m2.5-highspeed', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m2.7', reasoning: { type: 'none' } },
   },
   'haiku': {
     anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },
@@ -471,7 +483,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     mistral: { modelId: 'mistral-small-latest', reasoning: { type: 'none' } },
     groq: { modelId: 'llama-3.3-70b-versatile', reasoning: { type: 'none' } },
     zai: { modelId: 'glm-4.5-flash', reasoning: { type: 'none' } },
-    minimax: { modelId: 'minimax-m2.5-highspeed', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m2.7-highspeed', reasoning: { type: 'none' } },
   },
   // ── OpenAI models ─────────────────────────────────────────────────────────
   'gpt-5.3-codex': {

--- a/apps/desktop/src/shared/constants/models.ts
+++ b/apps/desktop/src/shared/constants/models.ts
@@ -433,8 +433,8 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
   },
   'minimax-m2.7': {
     minimax: { modelId: 'minimax-m2.7', reasoning: { type: 'none' } },
-    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
-    openai: { modelId: 'gpt-5.3-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
+    anthropic: { modelId: 'claude-sonnet-4-6', reasoning: { type: 'thinking_tokens', level: 'medium' } },
+    openai: { modelId: 'gpt-5.2-codex', reasoning: { type: 'reasoning_effort', level: 'medium' } },
   },
   'minimax-m2.7-highspeed': {
     minimax: { modelId: 'minimax-m2.7-highspeed', reasoning: { type: 'none' } },

--- a/apps/desktop/src/shared/constants/models.ts
+++ b/apps/desktop/src/shared/constants/models.ts
@@ -66,6 +66,9 @@ export const ALL_AVAILABLE_MODELS: ModelOption[] = [
   { value: 'grok-4-0709', label: 'Grok 4', provider: 'xai', description: 'Flagship', capabilities: { thinking: true, tools: true, vision: true, contextWindow: 256000 } },
   { value: 'grok-3', label: 'Grok 3', provider: 'xai', description: 'Text', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 131072 } },
   { value: 'grok-3-mini', label: 'Grok 3 Mini', provider: 'xai', description: 'Fast reasoning', capabilities: { thinking: true, tools: true, vision: false, contextWindow: 131072 } },
+  // MiniMax
+  { value: 'MiniMax-M2.5', label: 'MiniMax M2.5', provider: 'minimax', description: 'Peak performance', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
+  { value: 'MiniMax-M2.5-highspeed', label: 'MiniMax M2.5 High Speed', provider: 'minimax', description: 'Fast and agile', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
   // Z.AI (Zhipu)
   { value: 'glm-5', label: 'GLM-5', provider: 'zai', description: 'Flagship', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 128000 } },
   { value: 'glm-4.7', label: 'GLM-4.7', provider: 'zai', description: 'Previous flagship', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 128000 } },
@@ -316,6 +319,11 @@ export const PROVIDER_PRESET_DEFINITIONS: Partial<Record<BuiltinProvider, Record
     balanced: { primaryModel: 'glm-4.7',        primaryThinking: 'low', phaseModels: { spec: 'glm-4.7', planning: 'glm-4.7', coding: 'glm-4.7', qa: 'glm-4.7' },                 phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
     quick:    { primaryModel: 'glm-4.5-flash',  primaryThinking: 'low', phaseModels: { spec: 'glm-4.5-flash', planning: 'glm-4.5-flash', coding: 'glm-4.5-flash', qa: 'glm-4.5-flash' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
   },
+  minimax: {
+    auto:     { primaryModel: 'MiniMax-M2.5', primaryThinking: 'low', phaseModels: { spec: 'MiniMax-M2.5', planning: 'MiniMax-M2.5', coding: 'MiniMax-M2.5', qa: 'MiniMax-M2.5' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    balanced: { primaryModel: 'MiniMax-M2.5', primaryThinking: 'low', phaseModels: { spec: 'MiniMax-M2.5', planning: 'MiniMax-M2.5', coding: 'MiniMax-M2.5', qa: 'MiniMax-M2.5' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    quick:    { primaryModel: 'MiniMax-M2.5-highspeed', primaryThinking: 'low', phaseModels: { spec: 'MiniMax-M2.5-highspeed', planning: 'MiniMax-M2.5-highspeed', coding: 'MiniMax-M2.5-highspeed', qa: 'MiniMax-M2.5-highspeed' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+  },
   ollama: {
     auto:     { primaryModel: '', primaryThinking: 'low', phaseModels: { spec: '', planning: '', coding: '', qa: '' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
     complex:  { primaryModel: '', primaryThinking: 'low', phaseModels: { spec: '', planning: '', coding: '', qa: '' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
@@ -414,6 +422,17 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     mistral: { modelId: 'mistral-large-latest', reasoning: { type: 'none' } },
     groq: { modelId: 'meta-llama/llama-4-maverick', reasoning: { type: 'none' } },
     zai: { modelId: 'glm-5', reasoning: { type: 'none' } },
+    minimax: { modelId: 'MiniMax-M2.5', reasoning: { type: 'none' } },
+  },
+  'MiniMax-M2.5': {
+    minimax: { modelId: 'MiniMax-M2.5', reasoning: { type: 'none' } },
+    anthropic: { modelId: 'claude-sonnet-4-6', reasoning: { type: 'thinking_tokens', level: 'medium' } },
+    openai: { modelId: 'gpt-5.2', reasoning: { type: 'reasoning_effort', level: 'medium' } },
+  },
+  'MiniMax-M2.5-highspeed': {
+    minimax: { modelId: 'MiniMax-M2.5-highspeed', reasoning: { type: 'none' } },
+    anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },
+    openai: { modelId: 'gpt-5.1-codex-mini', reasoning: { type: 'reasoning_effort', level: 'low' } },
   },
   'glm-5': {
     zai: { modelId: 'glm-5', reasoning: { type: 'none' } },
@@ -443,6 +462,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     groq: { modelId: 'llama-3.3-70b-versatile', reasoning: { type: 'none' } },
     xai: { modelId: 'grok-3-mini', reasoning: { type: 'reasoning_effort', level: 'medium' } },
     zai: { modelId: 'glm-4.7', reasoning: { type: 'none' } },
+    minimax: { modelId: 'MiniMax-M2.5', reasoning: { type: 'none' } },
   },
   'haiku': {
     anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },
@@ -451,6 +471,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     mistral: { modelId: 'mistral-small-latest', reasoning: { type: 'none' } },
     groq: { modelId: 'llama-3.3-70b-versatile', reasoning: { type: 'none' } },
     zai: { modelId: 'glm-4.5-flash', reasoning: { type: 'none' } },
+    minimax: { modelId: 'MiniMax-M2.5-highspeed', reasoning: { type: 'none' } },
   },
   // ── OpenAI models ─────────────────────────────────────────────────────────
   'gpt-5.3-codex': {

--- a/apps/desktop/src/shared/constants/models.ts
+++ b/apps/desktop/src/shared/constants/models.ts
@@ -462,7 +462,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     groq: { modelId: 'llama-3.3-70b-versatile', reasoning: { type: 'none' } },
     xai: { modelId: 'grok-3-mini', reasoning: { type: 'reasoning_effort', level: 'medium' } },
     zai: { modelId: 'glm-4.7', reasoning: { type: 'none' } },
-    minimax: { modelId: 'minimax-m2.5', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m2.5-highspeed', reasoning: { type: 'none' } },
   },
   'haiku': {
     anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },

--- a/apps/desktop/src/shared/constants/models.ts
+++ b/apps/desktop/src/shared/constants/models.ts
@@ -323,7 +323,7 @@ export const PROVIDER_PRESET_DEFINITIONS: Partial<Record<BuiltinProvider, Record
   minimax: {
     auto:     { primaryModel: 'minimax-m3', primaryThinking: 'low', phaseModels: { spec: 'minimax-m3', planning: 'minimax-m3', coding: 'minimax-m3', qa: 'minimax-m3' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
     complex:  { primaryModel: 'minimax-m3', primaryThinking: 'low', phaseModels: { spec: 'minimax-m3', planning: 'minimax-m3', coding: 'minimax-m3', qa: 'minimax-m3' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
-    balanced: { primaryModel: 'minimax-m3', primaryThinking: 'low', phaseModels: { spec: 'minimax-m3', planning: 'minimax-m3', coding: 'minimax-m3', qa: 'minimax-m3' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    balanced: { primaryModel: 'minimax-m2.7', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.7', planning: 'minimax-m2.7', coding: 'minimax-m2.7', qa: 'minimax-m2.7' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
     quick:    { primaryModel: 'minimax-m2.7-highspeed', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.7-highspeed', planning: 'minimax-m2.7-highspeed', coding: 'minimax-m2.7-highspeed', qa: 'minimax-m2.7-highspeed' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
   },
   ollama: {

--- a/apps/desktop/src/shared/constants/models.ts
+++ b/apps/desktop/src/shared/constants/models.ts
@@ -322,6 +322,7 @@ export const PROVIDER_PRESET_DEFINITIONS: Partial<Record<BuiltinProvider, Record
   },
   minimax: {
     auto:     { primaryModel: 'minimax-m3', primaryThinking: 'low', phaseModels: { spec: 'minimax-m3', planning: 'minimax-m3', coding: 'minimax-m3', qa: 'minimax-m3' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    complex:  { primaryModel: 'minimax-m3', primaryThinking: 'low', phaseModels: { spec: 'minimax-m3', planning: 'minimax-m3', coding: 'minimax-m3', qa: 'minimax-m3' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
     balanced: { primaryModel: 'minimax-m3', primaryThinking: 'low', phaseModels: { spec: 'minimax-m3', planning: 'minimax-m3', coding: 'minimax-m3', qa: 'minimax-m3' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
     quick:    { primaryModel: 'minimax-m2.7-highspeed', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.7-highspeed', planning: 'minimax-m2.7-highspeed', coding: 'minimax-m2.7-highspeed', qa: 'minimax-m2.7-highspeed' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
   },
@@ -468,7 +469,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     groq: { modelId: 'llama-3.3-70b-versatile', reasoning: { type: 'none' } },
     xai: { modelId: 'grok-3-mini', reasoning: { type: 'reasoning_effort', level: 'medium' } },
     zai: { modelId: 'glm-4.7', reasoning: { type: 'none' } },
-    minimax: { modelId: 'minimax-m3', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m2.7', reasoning: { type: 'none' } },
   },
   'haiku': {
     anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },

--- a/apps/desktop/src/shared/constants/models.ts
+++ b/apps/desktop/src/shared/constants/models.ts
@@ -67,10 +67,9 @@ export const ALL_AVAILABLE_MODELS: ModelOption[] = [
   { value: 'grok-3', label: 'Grok 3', provider: 'xai', description: 'Text', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 131072 } },
   { value: 'grok-3-mini', label: 'Grok 3 Mini', provider: 'xai', description: 'Fast reasoning', capabilities: { thinking: true, tools: true, vision: false, contextWindow: 131072 } },
   // MiniMax
-  { value: 'minimax-m2.7', label: 'MiniMax M2.7', provider: 'minimax', description: 'Latest flagship model with enhanced reasoning and coding', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
+  { value: 'minimax-m3', label: 'MiniMax M3', provider: 'minimax', description: 'Latest flagship model with 512K context, 128K output, and image input support', capabilities: { thinking: false, tools: true, vision: true, contextWindow: 512000 } },
+  { value: 'minimax-m2.7', label: 'MiniMax M2.7', provider: 'minimax', description: 'Previous generation flagship model', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
   { value: 'minimax-m2.7-highspeed', label: 'MiniMax M2.7 High Speed', provider: 'minimax', description: 'High-speed version of M2.7 for low-latency scenarios', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
-  { value: 'minimax-m2.5', label: 'MiniMax M2.5', provider: 'minimax', description: 'Previous generation', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
-  { value: 'minimax-m2.5-highspeed', label: 'MiniMax M2.5 High Speed', provider: 'minimax', description: 'Fast and agile', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
   // Z.AI (Zhipu)
   { value: 'glm-5', label: 'GLM-5', provider: 'zai', description: 'Flagship', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 128000 } },
   { value: 'glm-4.7', label: 'GLM-4.7', provider: 'zai', description: 'Previous flagship', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 128000 } },
@@ -322,8 +321,8 @@ export const PROVIDER_PRESET_DEFINITIONS: Partial<Record<BuiltinProvider, Record
     quick:    { primaryModel: 'glm-4.5-flash',  primaryThinking: 'low', phaseModels: { spec: 'glm-4.5-flash', planning: 'glm-4.5-flash', coding: 'glm-4.5-flash', qa: 'glm-4.5-flash' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
   },
   minimax: {
-    auto:     { primaryModel: 'minimax-m2.7', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.7', planning: 'minimax-m2.7', coding: 'minimax-m2.7', qa: 'minimax-m2.7' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
-    balanced: { primaryModel: 'minimax-m2.7', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.7', planning: 'minimax-m2.7', coding: 'minimax-m2.7', qa: 'minimax-m2.7' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    auto:     { primaryModel: 'minimax-m3', primaryThinking: 'low', phaseModels: { spec: 'minimax-m3', planning: 'minimax-m3', coding: 'minimax-m3', qa: 'minimax-m3' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    balanced: { primaryModel: 'minimax-m3', primaryThinking: 'low', phaseModels: { spec: 'minimax-m3', planning: 'minimax-m3', coding: 'minimax-m3', qa: 'minimax-m3' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
     quick:    { primaryModel: 'minimax-m2.7-highspeed', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.7-highspeed', planning: 'minimax-m2.7-highspeed', coding: 'minimax-m2.7-highspeed', qa: 'minimax-m2.7-highspeed' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
   },
   ollama: {
@@ -424,7 +423,12 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     mistral: { modelId: 'mistral-large-latest', reasoning: { type: 'none' } },
     groq: { modelId: 'meta-llama/llama-4-maverick', reasoning: { type: 'none' } },
     zai: { modelId: 'glm-5', reasoning: { type: 'none' } },
-    minimax: { modelId: 'minimax-m2.7', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m3', reasoning: { type: 'none' } },
+  },
+  'minimax-m3': {
+    minimax: { modelId: 'minimax-m3', reasoning: { type: 'none' } },
+    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    openai: { modelId: 'gpt-5.3-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
   },
   'minimax-m2.7': {
     minimax: { modelId: 'minimax-m2.7', reasoning: { type: 'none' } },
@@ -433,16 +437,6 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
   },
   'minimax-m2.7-highspeed': {
     minimax: { modelId: 'minimax-m2.7-highspeed', reasoning: { type: 'none' } },
-    anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },
-    openai: { modelId: 'gpt-5.1-codex-mini', reasoning: { type: 'reasoning_effort', level: 'low' } },
-  },
-  'minimax-m2.5': {
-    minimax: { modelId: 'minimax-m2.5', reasoning: { type: 'none' } },
-    anthropic: { modelId: 'claude-sonnet-4-6', reasoning: { type: 'thinking_tokens', level: 'medium' } },
-    openai: { modelId: 'gpt-5.2', reasoning: { type: 'reasoning_effort', level: 'medium' } },
-  },
-  'minimax-m2.5-highspeed': {
-    minimax: { modelId: 'minimax-m2.5-highspeed', reasoning: { type: 'none' } },
     anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },
     openai: { modelId: 'gpt-5.1-codex-mini', reasoning: { type: 'reasoning_effort', level: 'low' } },
   },
@@ -474,7 +468,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     groq: { modelId: 'llama-3.3-70b-versatile', reasoning: { type: 'none' } },
     xai: { modelId: 'grok-3-mini', reasoning: { type: 'reasoning_effort', level: 'medium' } },
     zai: { modelId: 'glm-4.7', reasoning: { type: 'none' } },
-    minimax: { modelId: 'minimax-m2.7', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m3', reasoning: { type: 'none' } },
   },
   'haiku': {
     anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },

--- a/apps/desktop/src/shared/constants/models.ts
+++ b/apps/desktop/src/shared/constants/models.ts
@@ -67,8 +67,8 @@ export const ALL_AVAILABLE_MODELS: ModelOption[] = [
   { value: 'grok-3', label: 'Grok 3', provider: 'xai', description: 'Text', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 131072 } },
   { value: 'grok-3-mini', label: 'Grok 3 Mini', provider: 'xai', description: 'Fast reasoning', capabilities: { thinking: true, tools: true, vision: false, contextWindow: 131072 } },
   // MiniMax
-  { value: 'MiniMax-M2.5', label: 'MiniMax M2.5', provider: 'minimax', description: 'Peak performance', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
-  { value: 'MiniMax-M2.5-highspeed', label: 'MiniMax M2.5 High Speed', provider: 'minimax', description: 'Fast and agile', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
+  { value: 'minimax-m2.5', label: 'MiniMax M2.5', provider: 'minimax', description: 'Peak performance', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
+  { value: 'minimax-m2.5-highspeed', label: 'MiniMax M2.5 High Speed', provider: 'minimax', description: 'Fast and agile', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 204800 } },
   // Z.AI (Zhipu)
   { value: 'glm-5', label: 'GLM-5', provider: 'zai', description: 'Flagship', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 128000 } },
   { value: 'glm-4.7', label: 'GLM-4.7', provider: 'zai', description: 'Previous flagship', capabilities: { thinking: false, tools: true, vision: false, contextWindow: 128000 } },
@@ -320,9 +320,9 @@ export const PROVIDER_PRESET_DEFINITIONS: Partial<Record<BuiltinProvider, Record
     quick:    { primaryModel: 'glm-4.5-flash',  primaryThinking: 'low', phaseModels: { spec: 'glm-4.5-flash', planning: 'glm-4.5-flash', coding: 'glm-4.5-flash', qa: 'glm-4.5-flash' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
   },
   minimax: {
-    auto:     { primaryModel: 'MiniMax-M2.5', primaryThinking: 'low', phaseModels: { spec: 'MiniMax-M2.5', planning: 'MiniMax-M2.5', coding: 'MiniMax-M2.5', qa: 'MiniMax-M2.5' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
-    balanced: { primaryModel: 'MiniMax-M2.5', primaryThinking: 'low', phaseModels: { spec: 'MiniMax-M2.5', planning: 'MiniMax-M2.5', coding: 'MiniMax-M2.5', qa: 'MiniMax-M2.5' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
-    quick:    { primaryModel: 'MiniMax-M2.5-highspeed', primaryThinking: 'low', phaseModels: { spec: 'MiniMax-M2.5-highspeed', planning: 'MiniMax-M2.5-highspeed', coding: 'MiniMax-M2.5-highspeed', qa: 'MiniMax-M2.5-highspeed' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    auto:     { primaryModel: 'minimax-m2.5', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.5', planning: 'minimax-m2.5', coding: 'minimax-m2.5', qa: 'minimax-m2.5' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    balanced: { primaryModel: 'minimax-m2.5', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.5', planning: 'minimax-m2.5', coding: 'minimax-m2.5', qa: 'minimax-m2.5' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
+    quick:    { primaryModel: 'minimax-m2.5-highspeed', primaryThinking: 'low', phaseModels: { spec: 'minimax-m2.5-highspeed', planning: 'minimax-m2.5-highspeed', coding: 'minimax-m2.5-highspeed', qa: 'minimax-m2.5-highspeed' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
   },
   ollama: {
     auto:     { primaryModel: '', primaryThinking: 'low', phaseModels: { spec: '', planning: '', coding: '', qa: '' }, phaseThinking: { spec: 'low', planning: 'low', coding: 'low', qa: 'low' } },
@@ -422,15 +422,15 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     mistral: { modelId: 'mistral-large-latest', reasoning: { type: 'none' } },
     groq: { modelId: 'meta-llama/llama-4-maverick', reasoning: { type: 'none' } },
     zai: { modelId: 'glm-5', reasoning: { type: 'none' } },
-    minimax: { modelId: 'MiniMax-M2.5', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m2.5', reasoning: { type: 'none' } },
   },
-  'MiniMax-M2.5': {
-    minimax: { modelId: 'MiniMax-M2.5', reasoning: { type: 'none' } },
+  'minimax-m2.5': {
+    minimax: { modelId: 'minimax-m2.5', reasoning: { type: 'none' } },
     anthropic: { modelId: 'claude-sonnet-4-6', reasoning: { type: 'thinking_tokens', level: 'medium' } },
     openai: { modelId: 'gpt-5.2', reasoning: { type: 'reasoning_effort', level: 'medium' } },
   },
-  'MiniMax-M2.5-highspeed': {
-    minimax: { modelId: 'MiniMax-M2.5-highspeed', reasoning: { type: 'none' } },
+  'minimax-m2.5-highspeed': {
+    minimax: { modelId: 'minimax-m2.5-highspeed', reasoning: { type: 'none' } },
     anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },
     openai: { modelId: 'gpt-5.1-codex-mini', reasoning: { type: 'reasoning_effort', level: 'low' } },
   },
@@ -462,7 +462,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     groq: { modelId: 'llama-3.3-70b-versatile', reasoning: { type: 'none' } },
     xai: { modelId: 'grok-3-mini', reasoning: { type: 'reasoning_effort', level: 'medium' } },
     zai: { modelId: 'glm-4.7', reasoning: { type: 'none' } },
-    minimax: { modelId: 'MiniMax-M2.5', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m2.5', reasoning: { type: 'none' } },
   },
   'haiku': {
     anthropic: { modelId: 'claude-haiku-4-5-20251001', reasoning: { type: 'none' } },
@@ -471,7 +471,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     mistral: { modelId: 'mistral-small-latest', reasoning: { type: 'none' } },
     groq: { modelId: 'llama-3.3-70b-versatile', reasoning: { type: 'none' } },
     zai: { modelId: 'glm-4.5-flash', reasoning: { type: 'none' } },
-    minimax: { modelId: 'MiniMax-M2.5-highspeed', reasoning: { type: 'none' } },
+    minimax: { modelId: 'minimax-m2.5-highspeed', reasoning: { type: 'none' } },
   },
   // ── OpenAI models ─────────────────────────────────────────────────────────
   'gpt-5.3-codex': {

--- a/apps/desktop/src/shared/constants/providers.ts
+++ b/apps/desktop/src/shared/constants/providers.ts
@@ -62,7 +62,7 @@ export const PROVIDER_REGISTRY: ProviderInfo[] = [
     configFields: ['baseUrl'],
   },
   {
-    id: 'minimax', name: 'MiniMax', description: 'MiniMax M2.7, M2.7-highspeed and M2.5 models',
+    id: 'minimax', name: 'MiniMax', description: 'MiniMax M3, M2.7 and M2.7-highspeed models',
     category: 'popular',
     authMethods: ['api-key'], envVars: ['MINIMAX_API_KEY'],
     configFields: ['baseUrl'], website: 'https://platform.minimax.io',

--- a/apps/desktop/src/shared/constants/providers.ts
+++ b/apps/desktop/src/shared/constants/providers.ts
@@ -62,6 +62,12 @@ export const PROVIDER_REGISTRY: ProviderInfo[] = [
     configFields: ['baseUrl'],
   },
   {
+    id: 'minimax', name: 'MiniMax', description: 'MiniMax M2.5 models',
+    category: 'popular',
+    authMethods: ['api-key'], envVars: ['MINIMAX_API_KEY'],
+    configFields: ['baseUrl'], website: 'https://platform.minimax.io',
+  },
+  {
     id: 'ollama', name: 'Ollama', description: 'Local open-source models',
     category: 'local',
     authMethods: [], envVars: [],

--- a/apps/desktop/src/shared/constants/providers.ts
+++ b/apps/desktop/src/shared/constants/providers.ts
@@ -62,7 +62,7 @@ export const PROVIDER_REGISTRY: ProviderInfo[] = [
     configFields: ['baseUrl'],
   },
   {
-    id: 'minimax', name: 'MiniMax', description: 'MiniMax M2.5 models',
+    id: 'minimax', name: 'MiniMax', description: 'MiniMax M2.7, M2.7-highspeed and M2.5 models',
     category: 'popular',
     authMethods: ['api-key'], envVars: ['MINIMAX_API_KEY'],
     configFields: ['baseUrl'], website: 'https://platform.minimax.io',

--- a/apps/desktop/src/shared/types/provider-account.ts
+++ b/apps/desktop/src/shared/types/provider-account.ts
@@ -7,7 +7,7 @@ export type CredentialSource = 'oauth' | 'api-key' | 'env' | 'keychain';
 export type BuiltinProvider =
   | 'anthropic' | 'openai' | 'google' | 'amazon-bedrock' | 'azure'
   | 'mistral' | 'groq' | 'xai' | 'openrouter' | 'zai'
-  | 'ollama' | 'openai-compatible';
+  | 'minimax' | 'ollama' | 'openai-compatible';
 
 export type BillingModel = 'subscription' | 'pay-per-use';
 

--- a/apps/desktop/src/shared/types/settings.ts
+++ b/apps/desktop/src/shared/types/settings.ts
@@ -284,6 +284,8 @@ export interface AppSettings {
   globalAzureApiKey?: string;
   globalAzureBaseUrl?: string;
   globalBedrockRegion?: string;
+  globalZAIApiKey?: string;
+  globalMiniMaxApiKey?: string;
   // Unified provider accounts (multi-provider)
   providerAccounts?: ProviderAccount[];
   /** Global priority order — array of ProviderAccount IDs. First = highest priority. */


### PR DESCRIPTION
## Summary
- Add MiniMax as a first-class LLM provider using OpenAI-compatible adapter
- Register **MiniMax-M3** as the default model (512K context, 128K output, image input support)
- Keep **MiniMax-M2.7** (flagship) and **MiniMax-M2.7-highspeed** (low-latency) as alternatives
- Set the `quick` preset to M2.7-highspeed; `auto` and `balanced` use M3

## Changes
- Register MiniMax provider in `SupportedProvider` enum, factory, registry, auth resolver, and auth/config maps
- Add 3 models to `ALL_AVAILABLE_MODELS`: M3 (vision-capable, 512K window), M2.7 and M2.7-highspeed
- Add provider presets (auto/balanced/quick) targeting M3 / M2.7-highspeed
- Add `DEFAULT_MODEL_EQUIVALENCES` entries for M3, M2.7 and M2.7-highspeed (drop M2.5/M2.5-highspeed)
- Update `detectProviderFromModel` test to assert M3 detection
- Add `PROVIDER_REGISTRY` entry for settings UI describing the M3 / M2.7 / M2.7-highspeed lineup

## Why
MiniMax-M3 is the latest flagship model with:
- 512K context window
- Up to 128K output tokens
- Image input support (OpenAI / Anthropic compatible)

M2.7 / M2.7-highspeed are retained for users who still want the previous generation. Older M2.5 / M2.5-highspeed entries are removed.

## Testing
- Unit tests updated and passing (`detectProviderFromModel` covers M3, M2.7, M2.7-highspeed)
- Manually verified provider list shows M3 as default and M2.7 / M2.7-highspeed as fallbacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax provider with models minimax-m3, minimax-m2.7, and minimax-m2.7-highspeed.
  * Introduced MiniMax presets (auto, balanced, quick) and model equivalence mappings for integration.
  * Added credential/config support for MiniMax (API key, optional base URL), provider registry entry, and new global API key settings.

* **Tests**
  * Added a test to verify MiniMax model ID detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->