### PR TITLE
fix: normalize PATH env key casing to prevent tool detection failures on Windows

### DIFF
--- a/apps/desktop/src/main/env-utils.ts
+++ b/apps/desktop/src/main/env-utils.ts
@@ -237,10 +237,7 @@ export function getAugmentedEnv(additionalPaths?: string[]): Record<string, stri
   const env = { ...process.env } as Record<string, string>;
   const pathSeparator = getPathDelimiter();
 
-  // On some Windows versions (e.g. Windows 10), spreading process.env produces the native
-  // key casing 'Path' instead of 'PATH'. Without normalization, env.PATH is undefined and
-  // the original system PATH is silently dropped, causing detection failures for tools
-  // like Claude Code, gh, and Python installed in non-standard locations.
+  // Normalize PATH key to handle case differences on Windows.
   normalizeEnvPathKey(env);
 
   // Get all candidate paths (platform + additional)

--- a/apps/desktop/src/main/env-utils.ts
+++ b/apps/desktop/src/main/env-utils.ts
@@ -17,6 +17,7 @@ import { execFileSync, execFile } from 'child_process';
 import { promisify } from 'util';
 import { getSentryEnvForSubprocess } from './sentry';
 import { isWindows, isUnix, getPathDelimiter, getNpmCommand } from './platform';
+import { normalizeEnvPathKey } from './agent/env-utils';
 
 const execFileAsync = promisify(execFile);
 
@@ -236,6 +237,12 @@ export function getAugmentedEnv(additionalPaths?: string[]): Record<string, stri
   const env = { ...process.env } as Record<string, string>;
   const pathSeparator = getPathDelimiter();
 
+  // On some Windows versions (e.g. Windows 10), spreading process.env produces the native
+  // key casing 'Path' instead of 'PATH'. Without normalization, env.PATH is undefined and
+  // the original system PATH is silently dropped, causing detection failures for tools
+  // like Claude Code, gh, and Python installed in non-standard locations.
+  normalizeEnvPathKey(env);
+
   // Get all candidate paths (platform + additional)
   const candidatePaths = getExpandedPlatformPaths(additionalPaths);
 
@@ -410,6 +417,12 @@ async function getNpmGlobalPrefixAsync(): Promise<string | null> {
 export async function getAugmentedEnvAsync(additionalPaths?: string[]): Promise<Record<string, string>> {
   const env = { ...process.env } as Record<string, string>;
   const pathSeparator = getPathDelimiter();
+
+  // On some Windows versions (e.g. Windows 10), spreading process.env produces the native
+  // key casing 'Path' instead of 'PATH'. Without normalization, env.PATH is undefined and
+  // the original system PATH is silently dropped, causing detection failures for tools
+  // like Claude Code, gh, and Python installed in non-standard locations.
+  normalizeEnvPathKey(env);
 
   // Get all candidate paths (platform + additional)
   const candidatePaths = getExpandedPlatformPaths(additionalPaths);

--- a/apps/desktop/src/main/env-utils.ts
+++ b/apps/desktop/src/main/env-utils.ts
@@ -415,10 +415,7 @@ export async function getAugmentedEnvAsync(additionalPaths?: string[]): Promise<
   const env = { ...process.env } as Record<string, string>;
   const pathSeparator = getPathDelimiter();
 
-  // On some Windows versions (e.g. Windows 10), spreading process.env produces the native
-  // key casing 'Path' instead of 'PATH'. Without normalization, env.PATH is undefined and
-  // the original system PATH is silently dropped, causing detection failures for tools
-  // like Claude Code, gh, and Python installed in non-standard locations.
+  // Normalize PATH key to handle case differences on Windows.
   normalizeEnvPathKey(env);
 
   // Get all candidate paths (platform + additional)


### PR DESCRIPTION
## Summary

On some Windows versions (e.g. Windows 10), `{ ...process.env }` produces the native key casing `Path` instead of `PATH`. Since `getAugmentedEnv()` accesses `env.PATH`, the value is `undefined`, causing the **entire original system PATH to be silently dropped**.

This leads to detection failures for any tools installed in non-standard locations. For example, when Node.js is installed on a non-C drive (e.g. `D:\NodeJs\`), detecting Claude Code fails with:

```
'node' is not recognized as an internal or external command
```

This happens because `claude.cmd` (the npm-generated wrapper) internally invokes `node`, which is no longer on the subprocess PATH. The same issue affects `gh`, `python`, and any other tool not in the hardcoded `COMMON_BIN_PATHS`.

### Root Cause

```js
const env = { ...process.env }; // On Win10: key is 'Path', not 'PATH'
let currentPath = env.PATH || ''; // undefined — entire system PATH lost!
```

**Debug output confirming the bug:**
```
PATH-like keys in process.env: [ 'Path' ]
env.PATH (after spread): undefined
env.Path (after spread): C:\Windows\system32;...;D:\NodeJs\;D:\NodeJs\node_global\;...
```

After `getAugmentedEnv()` runs, the env object contains **dual keys** (`Path` + `PATH`), where `PATH` only has hardcoded `COMMON_BIN_PATHS` (all C-drive) and the original `Path` with user-configured paths is ignored.

### Fix

Reuse the existing `normalizeEnvPathKey()` from `agent/env-utils.ts` (which was already written to solve this exact casing issue for agent spawning) in both `getAugmentedEnv()` and `getAugmentedEnvAsync()`, right after spreading `process.env`.

**Changes:**
- Import `normalizeEnvPathKey` from `./agent/env-utils`
- Call `normalizeEnvPathKey(env)` after `{ ...process.env }` in both sync and async versions
- This ensures the PATH key is consistently uppercase before any access

## Test plan

- [ ] On Windows 10 with Node.js installed on a non-C drive (e.g. `D:\NodeJs\`), verify Claude Code is detected successfully
- [ ] On Windows 10, verify `gh` and `python` are detected when installed in non-standard locations
- [ ] On Windows 11 / macOS / Linux, verify no regression in tool detection
- [ ] Run `npm run typecheck` — passes
- [ ] Run `npm run lint` — passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue on Windows where the system PATH could be lost or misrecognized during startup. This improves reliability when launching the app, ensures external commands and tools remain accessible, and increases compatibility across different Windows versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->