### PR TITLE
feat(updater): persistent Skip This Version and 24h snooze for update notifications

### DIFF
--- a/apps/desktop/src/main/app-updater.ts
+++ b/apps/desktop/src/main/app-updater.ts
@@ -27,6 +27,7 @@ import { IPC_CHANNELS } from '../shared/constants';
 import type { AppUpdateInfo } from '../shared/types';
 import { compareVersions } from './updater/version-manager';
 import { isMacOS } from './platform';
+import { readSettingsFile, writeSettingsFile } from './settings-utils';
 
 // GitHub repo info for API calls
 const GITHUB_OWNER = 'AndyMik90';
@@ -156,6 +157,59 @@ function formatReleaseNotes(releaseNotes: UpdateInfo['releaseNotes']): string | 
 }
 
 /**
+ * Read update suppression preferences from settings.
+ */
+function getUpdatePreferences(): { skippedVersion: string | null; remindAfter: number | null } {
+  const settings = readSettingsFile();
+  return {
+    skippedVersion: (settings?.skippedUpdateVersion as string) || null,
+    remindAfter: (settings?.updateRemindAfter as number) || null,
+  };
+}
+
+/**
+ * Check if notifications for a version should be suppressed.
+ * Returns true if the user has skipped this exact version, or snoozed and the snooze hasn't expired.
+ */
+function shouldSuppressUpdate(version: string): boolean {
+  const prefs = getUpdatePreferences();
+  if (prefs.skippedVersion === version) return true;
+  if (prefs.remindAfter && Date.now() < prefs.remindAfter) return true;
+  return false;
+}
+
+/**
+ * Persist a request to skip a specific version permanently.
+ * That version will never trigger notifications again unless a newer version arrives.
+ */
+export function skipUpdateVersion(version: string): void {
+  const settings = readSettingsFile() || {};
+  settings.skippedUpdateVersion = version;
+  delete settings.updateRemindAfter;
+  writeSettingsFile(settings);
+  console.warn('[app-updater] Skipped version:', version);
+}
+
+/**
+ * Snooze update notifications for 24 hours.
+ */
+export function snoozeUpdate(): void {
+  const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+  const settings = readSettingsFile() || {};
+  settings.updateRemindAfter = Date.now() + TWENTY_FOUR_HOURS;
+  writeSettingsFile(settings);
+  console.warn('[app-updater] Snoozed updates until:', new Date(settings.updateRemindAfter as number).toISOString());
+}
+
+/**
+ * Check if update notifications are currently suppressed for a given version.
+ * Used by the renderer via IPC to avoid showing stale banners.
+ */
+export function isUpdateSuppressed(version: string): boolean {
+  return shouldSuppressUpdate(version);
+}
+
+/**
  * Set the update channel for electron-updater.
  * - 'latest': Only receive stable releases (default)
  * - 'beta': Receive pre-release/beta versions
@@ -233,6 +287,16 @@ export function initializeAppUpdater(window: BrowserWindow, betaUpdates = false)
       return;
     }
 
+    // Check if user has skipped or snoozed this version
+    if (shouldSuppressUpdate(info.version)) {
+      console.warn('[app-updater] Update suppressed (skipped or snoozed):', info.version);
+      // Still download silently so it's ready when the suppression expires
+      autoUpdater.downloadUpdate().catch((error) => {
+        console.error('[app-updater] Failed to download update:', error.message);
+      });
+      return;
+    }
+
     if (mainWindow) {
       mainWindow.webContents.send(IPC_CHANNELS.APP_UPDATE_AVAILABLE, {
         version: info.version,
@@ -265,9 +329,14 @@ export function initializeAppUpdater(window: BrowserWindow, betaUpdates = false)
       releaseNotes: formatReleaseNotes(info.releaseNotes),
       releaseDate: info.releaseDate
     };
-    if (mainWindow) {
-      // Reuse downloadedUpdateInfo instead of calling formatReleaseNotes again
-      mainWindow.webContents.send(IPC_CHANNELS.APP_UPDATE_DOWNLOADED, downloadedUpdateInfo);
+
+    // Only notify renderer if update is not suppressed
+    if (!shouldSuppressUpdate(info.version)) {
+      if (mainWindow) {
+        mainWindow.webContents.send(IPC_CHANNELS.APP_UPDATE_DOWNLOADED, downloadedUpdateInfo);
+      }
+    } else {
+      console.warn('[app-updater] Downloaded update suppressed (skipped or snoozed):', info.version);
     }
   });
 

--- a/apps/desktop/src/main/app-updater.ts
+++ b/apps/desktop/src/main/app-updater.ts
@@ -171,7 +171,7 @@ function getUpdatePreferences(): { skippedVersion: string | null; remindAfter: n
  * Check if notifications for a version should be suppressed.
  * Returns true if the user has skipped this exact version, or snoozed and the snooze hasn't expired.
  */
-function shouldSuppressUpdate(version: string): boolean {
+export function shouldSuppressUpdate(version: string): boolean {
   const prefs = getUpdatePreferences();
   if (prefs.skippedVersion === version) return true;
   if (prefs.remindAfter && Date.now() < prefs.remindAfter) return true;

--- a/apps/desktop/src/main/ipc-handlers/app-update-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers/app-update-handlers.ts
@@ -14,7 +14,10 @@ import {
   downloadStableVersion,
   quitAndInstall,
   getCurrentVersion,
-  getDownloadedUpdateInfo
+  getDownloadedUpdateInfo,
+  skipUpdateVersion,
+  snoozeUpdate,
+  isUpdateSuppressed
 } from '../app-updater';
 
 /**
@@ -147,6 +150,55 @@ export function registerAppUpdateHandlers(): void {
           success: false,
           error: error instanceof Error ? error.message : 'Failed to get downloaded update info'
         };
+      }
+    }
+  );
+
+  /**
+   * APP_UPDATE_SKIP_VERSION: Permanently skip a specific version
+   * That version will never show notifications again until a newer version arrives
+   */
+  ipcMain.handle(
+    IPC_CHANNELS.APP_UPDATE_SKIP_VERSION,
+    async (_event, version: string): Promise<IPCResult> => {
+      try {
+        skipUpdateVersion(version);
+        return { success: true };
+      } catch (error) {
+        console.error('[app-update-handlers] Skip version failed:', error);
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to skip version' };
+      }
+    }
+  );
+
+  /**
+   * APP_UPDATE_SNOOZE: Snooze update notifications for 24 hours
+   */
+  ipcMain.handle(
+    IPC_CHANNELS.APP_UPDATE_SNOOZE,
+    async (): Promise<IPCResult> => {
+      try {
+        snoozeUpdate();
+        return { success: true };
+      } catch (error) {
+        console.error('[app-update-handlers] Snooze update failed:', error);
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to snooze update' };
+      }
+    }
+  );
+
+  /**
+   * APP_UPDATE_IS_SUPPRESSED: Check if update notifications are suppressed for a version
+   * Used by the renderer to avoid showing stale banners after a skip/snooze
+   */
+  ipcMain.handle(
+    IPC_CHANNELS.APP_UPDATE_IS_SUPPRESSED,
+    async (_event, version: string): Promise<IPCResult<boolean>> => {
+      try {
+        return { success: true, data: isUpdateSuppressed(version) };
+      } catch (error) {
+        console.error('[app-update-handlers] Check suppression failed:', error);
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to check suppression' };
       }
     }
   );

--- a/apps/desktop/src/main/ipc-handlers/app-update-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers/app-update-handlers.ts
@@ -17,7 +17,7 @@ import {
   getDownloadedUpdateInfo,
   skipUpdateVersion,
   snoozeUpdate,
-  isUpdateSuppressed
+  shouldSuppressUpdate
 } from '../app-updater';
 
 /**
@@ -162,6 +162,10 @@ export function registerAppUpdateHandlers(): void {
     IPC_CHANNELS.APP_UPDATE_SKIP_VERSION,
     async (_event, version: string): Promise<IPCResult> => {
       try {
+        // Validate version format (semver-like, max 50 chars)
+        if (!version || typeof version !== 'string' || version.length > 50 || !/^[\d\w.-]+$/.test(version)) {
+          return { success: false, error: 'Invalid version format' };
+        }
         skipUpdateVersion(version);
         return { success: true };
       } catch (error) {
@@ -195,7 +199,7 @@ export function registerAppUpdateHandlers(): void {
     IPC_CHANNELS.APP_UPDATE_IS_SUPPRESSED,
     async (_event, version: string): Promise<IPCResult<boolean>> => {
       try {
-        return { success: true, data: isUpdateSuppressed(version) };
+        return { success: true, data: shouldSuppressUpdate(version) };
       } catch (error) {
         console.error('[app-update-handlers] Check suppression failed:', error);
         return { success: false, error: error instanceof Error ? error.message : 'Failed to check suppression' };

--- a/apps/desktop/src/preload/api/app-update-api.ts
+++ b/apps/desktop/src/preload/api/app-update-api.ts
@@ -21,6 +21,9 @@ export interface AppUpdateAPI {
   installAppUpdate: () => void;
   getAppVersion: () => Promise<string>;
   getDownloadedAppUpdate: () => Promise<IPCResult<AppUpdateInfo | null>>;
+  skipAppUpdate: (version: string) => Promise<IPCResult>;
+  snoozeAppUpdate: () => Promise<IPCResult>;
+  isAppUpdateSuppressed: (version: string) => Promise<IPCResult<boolean>>;
 
   // Event Listeners
   onAppUpdateAvailable: (
@@ -68,6 +71,15 @@ export const createAppUpdateAPI = (): AppUpdateAPI => ({
 
   getDownloadedAppUpdate: (): Promise<IPCResult<AppUpdateInfo | null>> =>
     invokeIpc(IPC_CHANNELS.APP_UPDATE_GET_DOWNLOADED),
+
+  skipAppUpdate: (version: string): Promise<IPCResult> =>
+    invokeIpc(IPC_CHANNELS.APP_UPDATE_SKIP_VERSION, version),
+
+  snoozeAppUpdate: (): Promise<IPCResult> =>
+    invokeIpc(IPC_CHANNELS.APP_UPDATE_SNOOZE),
+
+  isAppUpdateSuppressed: (version: string): Promise<IPCResult<boolean>> =>
+    invokeIpc(IPC_CHANNELS.APP_UPDATE_IS_SUPPRESSED, version),
 
   // Event Listeners
   onAppUpdateAvailable: (

--- a/apps/desktop/src/renderer/components/AppUpdateNotification.tsx
+++ b/apps/desktop/src/renderer/components/AppUpdateNotification.tsx
@@ -165,6 +165,18 @@ export function AppUpdateNotification() {
     setIsOpen(false);
   };
 
+  const handleSkipVersion = async () => {
+    if (updateInfo) {
+      await window.electronAPI.skipAppUpdate(updateInfo.version);
+    }
+    setIsOpen(false);
+  };
+
+  const handleRemindLater = async () => {
+    await window.electronAPI.snoozeAppUpdate();
+    setIsOpen(false);
+  };
+
   if (!updateInfo) {
     return null;
   }
@@ -298,7 +310,12 @@ export function AppUpdateNotification() {
         </div>
 
         <DialogFooter className="flex flex-col sm:flex-row gap-3">
-          <Button variant="outline" onClick={handleDismiss} disabled={isDownloading}>
+          {!isDownloaded && !isDownloading && (
+            <Button variant="ghost" onClick={handleSkipVersion} className="text-muted-foreground">
+              {t("dialogs:appUpdate.skipThisVersion", "Skip This Version")}
+            </Button>
+          )}
+          <Button variant="outline" onClick={isDownloaded ? handleDismiss : handleRemindLater} disabled={isDownloading}>
             {isDownloaded
               ? t("dialogs:appUpdate.installLater", "Install Later")
               : t("dialogs:appUpdate.remindMeLater", "Remind Me Later")}

--- a/apps/desktop/src/renderer/components/AppUpdateNotification.tsx
+++ b/apps/desktop/src/renderer/components/AppUpdateNotification.tsx
@@ -166,14 +166,22 @@ export function AppUpdateNotification() {
   };
 
   const handleSkipVersion = async () => {
-    if (updateInfo) {
-      await window.electronAPI.skipAppUpdate(updateInfo.version);
+    try {
+      if (updateInfo) {
+        await window.electronAPI.skipAppUpdate(updateInfo.version);
+      }
+    } catch {
+      // Skip is best-effort; close the dialog regardless
     }
     setIsOpen(false);
   };
 
   const handleRemindLater = async () => {
-    await window.electronAPI.snoozeAppUpdate();
+    try {
+      await window.electronAPI.snoozeAppUpdate();
+    } catch {
+      // Snooze is best-effort; close the dialog regardless
+    }
     setIsOpen(false);
   };
 

--- a/apps/desktop/src/renderer/components/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/UpdateBanner.tsx
@@ -36,6 +36,14 @@ export function UpdateBanner({ className }: UpdateBannerProps) {
       const result = await window.electronAPI.checkAppUpdate();
       if (result.success && result.data) {
         const newVersion = result.data.version;
+
+        // Check if this version is suppressed (skipped or snoozed)
+        const suppressed = await window.electronAPI.isAppUpdateSuppressed(newVersion);
+        if (suppressed.success && suppressed.data) {
+          setUpdateInfo(null);
+          return;
+        }
+
         // New update available - show banner (unless same version already dismissed)
         if (currentVersionRef.current !== newVersion) {
           setIsDismissed(false);
@@ -173,8 +181,11 @@ export function UpdateBanner({ className }: UpdateBannerProps) {
     }
   };
 
-  // Handle dismiss
-  const handleDismiss = () => {
+  // Handle dismiss - snoozes for 24 hours so the banner doesn't reappear on next poll
+  const handleDismiss = async () => {
+    if (updateInfo) {
+      await window.electronAPI.snoozeAppUpdate();
+    }
     setIsDismissed(true);
   };
 

--- a/apps/desktop/src/renderer/components/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/UpdateBanner.tsx
@@ -70,6 +70,11 @@ export function UpdateBanner({ className }: UpdateBannerProps) {
       try {
         const result = await window.electronAPI.getDownloadedAppUpdate();
         if (result.success && result.data) {
+          // Check if this downloaded version is suppressed (skipped or snoozed)
+          const suppressed = await window.electronAPI.isAppUpdateSuppressed(result.data.version);
+          if (suppressed.success && suppressed.data) {
+            return; // Don't show banner for suppressed downloaded updates
+          }
           currentVersionRef.current = result.data.version;
           setUpdateInfo({
             version: result.data.version,
@@ -183,8 +188,12 @@ export function UpdateBanner({ className }: UpdateBannerProps) {
 
   // Handle dismiss - snoozes for 24 hours so the banner doesn't reappear on next poll
   const handleDismiss = async () => {
-    if (updateInfo) {
-      await window.electronAPI.snoozeAppUpdate();
+    try {
+      if (updateInfo) {
+        await window.electronAPI.snoozeAppUpdate();
+      }
+    } catch {
+      // Snooze is best-effort; dismiss the banner regardless
     }
     setIsDismissed(true);
   };

--- a/apps/desktop/src/renderer/lib/mocks/settings-mock.ts
+++ b/apps/desktop/src/renderer/lib/mocks/settings-mock.ts
@@ -49,6 +49,9 @@ export const settingsMock = {
   downloadStableUpdate: async () => ({ success: true }),
   installAppUpdate: () => { console.warn('[browser-mock] installAppUpdate called'); },
   getDownloadedAppUpdate: async () => ({ success: true, data: null }),
+  skipAppUpdate: async (_version: string) => ({ success: true }),
+  snoozeAppUpdate: async () => ({ success: true }),
+  isAppUpdateSuppressed: async (_version: string) => ({ success: true, data: false }),
 
   // App Update Event Listeners (no-op in browser mode)
   onAppUpdateAvailable: () => () => {},

--- a/apps/desktop/src/shared/constants/ipc.ts
+++ b/apps/desktop/src/shared/constants/ipc.ts
@@ -531,6 +531,9 @@ export const IPC_CHANNELS = {
   APP_UPDATE_INSTALL: 'app-update:install',
   APP_UPDATE_GET_VERSION: 'app-update:get-version',
   APP_UPDATE_GET_DOWNLOADED: 'app-update:get-downloaded',  // Get downloaded update info (for showing Install button on Settings open)
+  APP_UPDATE_SKIP_VERSION: 'app-update:skip-version',  // Skip a specific version permanently
+  APP_UPDATE_SNOOZE: 'app-update:snooze',  // Snooze update notifications for 24 hours
+  APP_UPDATE_IS_SUPPRESSED: 'app-update:is-suppressed',  // Check if update notifications are suppressed
 
   // App auto-update events (main -> renderer)
   APP_UPDATE_AVAILABLE: 'app-update:available',

--- a/apps/desktop/src/shared/i18n/locales/en/dialogs.json
+++ b/apps/desktop/src/shared/i18n/locales/en/dialogs.json
@@ -169,7 +169,8 @@
     "claudeCodeChangelog": "View Claude Code Changelog",
     "claudeCodeChangelogAriaLabel": "View Claude Code Changelog (opens in new window)",
     "readOnlyVolumeTitle": "Cannot install from disk image",
-    "readOnlyVolumeDescription": "Please move Aperant to your Applications folder before updating."
+    "readOnlyVolumeDescription": "Please move Aperant to your Applications folder before updating.",
+    "skipThisVersion": "Skip This Version"
   },
   "addCompetitor": {
     "title": "Add Competitor",

--- a/apps/desktop/src/shared/i18n/locales/fr/dialogs.json
+++ b/apps/desktop/src/shared/i18n/locales/fr/dialogs.json
@@ -169,7 +169,8 @@
     "claudeCodeChangelog": "Voir le journal des modifications Claude Code",
     "claudeCodeChangelogAriaLabel": "Voir le journal des modifications Claude Code (s'ouvre dans une nouvelle fenêtre)",
     "readOnlyVolumeTitle": "Impossible d'installer depuis une image disque",
-    "readOnlyVolumeDescription": "Veuillez déplacer Aperant dans votre dossier Applications avant de mettre à jour."
+    "readOnlyVolumeDescription": "Veuillez déplacer Aperant dans votre dossier Applications avant de mettre à jour.",
+    "skipThisVersion": "Ignorer cette version"
   },
   "addCompetitor": {
     "title": "Ajouter un concurrent",

--- a/apps/desktop/src/shared/types/ipc.ts
+++ b/apps/desktop/src/shared/types/ipc.ts
@@ -708,6 +708,9 @@ export interface ElectronAPI {
   downloadStableUpdate: () => Promise<IPCResult>;
   installAppUpdate: () => void;
   getDownloadedAppUpdate: () => Promise<IPCResult<AppUpdateInfo | null>>;
+  skipAppUpdate: (version: string) => Promise<IPCResult>;
+  snoozeAppUpdate: () => Promise<IPCResult>;
+  isAppUpdateSuppressed: (version: string) => Promise<IPCResult<boolean>>;
 
   // Electron app update event listeners
   onAppUpdateAvailable: (

--- a/apps/desktop/src/shared/types/settings.ts
+++ b/apps/desktop/src/shared/types/settings.ts
@@ -354,6 +354,10 @@ export interface AppSettings {
   autoNameClaudeTerminals?: boolean;
   // Track which version warnings have been shown (e.g., ["2.7.5"])
   seenVersionWarnings?: string[];
+  // Version the user has permanently skipped for update notifications
+  skippedUpdateVersion?: string;
+  // Timestamp (ms) after which update notifications should resume (snooze)
+  updateRemindAfter?: number;
   // Sidebar collapsed state (icons only when true)
   sidebarCollapsed?: boolean;
   // GPU acceleration for terminal rendering (WebGL)


### PR DESCRIPTION
## Summary

Adds persistent "Skip This Version" and 24-hour "Remind Me Later" snooze to the update notification system so users aren't nagged repeatedly when they can't or don't want to update.

Fixes #1944

## Problem

Users were getting update popups every few minutes with no way to permanently dismiss them. The dismiss was in-memory only (reset on restart), and "Remind Me Later" just closed the dialog with no persistent effect.

## Solution

- **Skip This Version** — Persists the skipped version to `settings.json`. That specific version never shows notifications again. A newer version bypasses the skip automatically.
- **Remind Me Later** — Snoozes all update notifications for 24 hours. The sidebar banner X-dismiss also snoozes instead of just hiding in-memory.
- Updates still download silently when suppressed so they're staged and ready when the user wants them.

## Changes

- `app-updater.ts` — Suppression logic (`shouldSuppressUpdate`), settings persistence (`skipUpdateVersion`, `snoozeUpdate`), gated `update-available` and `update-downloaded` IPC events
- `app-update-handlers.ts` — 3 new IPC handlers with version format validation
- `app-update-api.ts` — Preload API additions (`skipAppUpdate`, `snoozeAppUpdate`, `isAppUpdateSuppressed`)
- `AppUpdateNotification.tsx` — "Skip This Version" ghost button + "Remind Me Later" calls snooze
- `UpdateBanner.tsx` — Suppression check on mount and poll, X-dismiss calls snooze
- `settings.ts` — Added `skippedUpdateVersion` and `updateRemindAfter` to `AppSettings` type
- `ipc.ts` — 3 new IPC channel constants + ElectronAPI type declarations
- `settings-mock.ts` — Browser mock stubs
- `en/dialogs.json`, `fr/dialogs.json` — i18n key for "Skip This Version"

## Testing

- [x] Biome CI passes
- [x] TypeScript typecheck passes
- [x] All 4603 unit tests pass
- [x] Production build succeeds
- [x] Pre-PR validation with 9 review agents (security, quality, logic, codebase-fit, test-integrity, i18n, cross-platform)
- [ ] Manual testing on macOS
- [ ] Manual testing on Windows
- [ ] Manual testing on Linux

## Cross-Platform Compatibility

All new code uses Electron's `app.getPath('userData')` via `settings-utils.ts` for settings persistence — works identically on macOS, Windows, and Linux. No platform-specific code introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skip specific app versions from update notifications—suppression applies permanently until cleared
  * Snooze update notifications for 24 hours before they reappear
  * New "Skip This Version" button and "Remind Later" option in update dialogs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->