### PR TITLE
fix: Insights chat panel scrolls off-screen after messages load

### DIFF
--- a/apps/desktop/src/renderer/components/Insights.tsx
+++ b/apps/desktop/src/renderer/components/Insights.tsx
@@ -405,7 +405,7 @@ export function Insights({ projectId }: InsightsProps) {
       )}
 
       {/* Main Chat Area */}
-      <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-6 py-4">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
Fixes #1977

## Problem

The Insights chat panel becomes invisible after messages load. The content briefly flashes on screen, then scrolls off the top of the viewport because the inner flex column lacks proper height constraints.

Without `min-h-0`, the flex item respects its default `min-height: auto`, allowing it to grow taller than its parent. This causes the `ScrollArea` inside to also grow unconstrained, pushing content beyond the visible viewport.

## Fix

Add `min-h-0 overflow-hidden` to the main chat area's inner flex column container in `Insights.tsx`:

```diff
- <div className="flex flex-1 flex-col">
+ <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
```

This constrains the flex item's minimum height to 0, allowing the `ScrollArea` to properly contain its content within the available viewport space.

## Notes

The second part of the original issue (scrollIntoView scrolling the wrong ancestor) has already been addressed in the current codebase — the code now uses `viewportEl.scrollTop` directly instead of `scrollIntoView()`.

## Test

- Open a project with existing Insights chat history (multiple messages)
- Navigate to the Insights view
- Verify messages stay visible within the panel and do not scroll off-screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat area layout and overflow handling in the Insights component to ensure content displays properly within the available vertical space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->