### PR TITLE
fix: pre-populate memory onboarding step from existing settings

### DIFF
--- a/apps/desktop/src/renderer/components/onboarding/MemoryStep.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/MemoryStep.tsx
@@ -21,14 +21,14 @@ export function MemoryStep({ onNext, onBack }: MemoryStepProps) {
   const { settings, updateSettings } = useSettingsStore();
 
   const [config, setConfig] = useState<MemoryPanelConfig>({
-    enabled: true,
-    embeddingProvider: 'ollama',
+    enabled: settings.memoryEnabled ?? true,
+    embeddingProvider: settings.memoryEmbeddingProvider || 'ollama',
     openaiApiKey: settings.globalOpenAIApiKey || '',
     openaiEmbeddingModel: settings.memoryOpenaiEmbeddingModel || '',
-    azureOpenaiApiKey: '',
-    azureOpenaiBaseUrl: '',
-    azureOpenaiEmbeddingDeployment: '',
-    voyageApiKey: '',
+    azureOpenaiApiKey: settings.memoryAzureApiKey || '',
+    azureOpenaiBaseUrl: settings.memoryAzureBaseUrl || '',
+    azureOpenaiEmbeddingDeployment: settings.memoryAzureEmbeddingDeployment || '',
+    voyageApiKey: settings.memoryVoyageApiKey || '',
     voyageEmbeddingModel: settings.memoryVoyageEmbeddingModel || '',
     googleApiKey: settings.globalGoogleApiKey || '',
     googleEmbeddingModel: settings.memoryGoogleEmbeddingModel || '',


### PR DESCRIPTION
Fixes #1940

## Problem
The `MemoryStep` component in the onboarding wizard always initialized with hardcoded defaults, ignoring any previously saved configuration:
- `enabled` was hardcoded to `true` instead of reading `settings.memoryEnabled`
- `embeddingProvider` was hardcoded to `'ollama'` instead of reading `settings.memoryEmbeddingProvider`
- Azure OpenAI API key, base URL, and deployment were always empty strings
- Voyage AI API key was always an empty string

When users re-ran the wizard via Settings → Re-run Wizard, the memory step always showed defaults instead of their saved settings. Clicking "Save & Continue" would then silently overwrite their configuration with the defaults.

## Solution
Initialize all config fields from the existing `settings` store values, with appropriate fallbacks:

```diff
- enabled: true,
- embeddingProvider: 'ollama',
+ enabled: settings.memoryEnabled ?? true,
+ embeddingProvider: settings.memoryEmbeddingProvider || 'ollama',
  openaiApiKey: settings.globalOpenAIApiKey || '',
  openaiEmbeddingModel: settings.memoryOpenaiEmbeddingModel || '',
- azureOpenaiApiKey: '',
- azureOpenaiBaseUrl: '',
- azureOpenaiEmbeddingDeployment: '',
- voyageApiKey: '',
+ azureOpenaiApiKey: settings.memoryAzureApiKey || '',
+ azureOpenaiBaseUrl: settings.memoryAzureBaseUrl || '',
+ azureOpenaiEmbeddingDeployment: settings.memoryAzureEmbeddingDeployment || '',
+ voyageApiKey: settings.memoryVoyageApiKey || '',
```

## Testing
- Open the onboarding wizard with existing memory settings (e.g., with Voyage or Azure configured)
- Verify the wizard now shows the previously saved settings instead of defaults
- Verify Save & Continue correctly persists the (unchanged) settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memory configuration settings are now properly restored from your previous session, ensuring your selected embedding provider and saved API credentials are retained when reopening the app rather than resetting to defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->