### PR TITLE
fix: make stream inactivity timeout configurable, increase for Ollama

### DIFF
--- a/apps/desktop/src/main/ai/agent/worker.ts
+++ b/apps/desktop/src/main/ai/agent/worker.ts
@@ -341,6 +341,9 @@ async function runSingleSession(
           modelId: phaseModelId,
         })
       : undefined,
+    // Local providers like Ollama can take much longer than 60s to generate a
+    // response on slower hardware. Use a 5-minute timeout instead of the default.
+    streamInactivityTimeoutMs: baseSession.provider === 'ollama' ? 300_000 : undefined,
   };
 
   let sessionResult: SessionResult;
@@ -517,6 +520,7 @@ async function runDefaultSession(
             modelId: session.modelId,
           })
         : undefined,
+      streamInactivityTimeoutMs: session.provider === 'ollama' ? 300_000 : undefined,
     }, {
       contextWindowLimit,
       apiKey: session.apiKey,
@@ -1113,6 +1117,7 @@ async function runAgenticSpecOrchestrator(
             modelId: session.modelId,
           })
         : undefined,
+      streamInactivityTimeoutMs: session.provider === 'ollama' ? 300_000 : undefined,
     }, {
       contextWindowLimit,
       apiKey: session.apiKey,

--- a/apps/desktop/src/main/ai/session/runner.ts
+++ b/apps/desktop/src/main/ai/session/runner.ts
@@ -125,6 +125,13 @@ export interface RunnerOptions {
   onAccountSwitch?: (failedAccountId: string, error: SessionError) => Promise<QueueResolvedAuth | null>;
   /** Current account ID from the priority queue (needed for account-switch retry) */
   currentAccountId?: string;
+  /**
+   * Stream inactivity timeout in milliseconds. If no stream parts arrive within
+   * this period, the stream is aborted. Defaults to 60 seconds. Local providers
+   * (e.g., Ollama) may need a higher value since model inference can take much
+   * longer than cloud providers.
+   */
+  streamInactivityTimeoutMs?: number;
 }
 
 // =============================================================================
@@ -149,7 +156,7 @@ export async function runAgentSession(
   config: SessionConfig,
   options: RunnerOptions = {},
 ): Promise<SessionResult> {
-  const { onEvent, onAuthRefresh, onModelRefresh, tools, memoryContext, onAccountSwitch, currentAccountId } = options;
+  const { onEvent, onAuthRefresh, onModelRefresh, tools, memoryContext, onAccountSwitch, currentAccountId, streamInactivityTimeoutMs } = options;
   const startTime = Date.now();
 
   let authRetries = 0;
@@ -159,7 +166,7 @@ export async function runAgentSession(
   // Retry loop for auth refresh and account switching
   while (authRetries <= MAX_AUTH_RETRIES) {
     try {
-      const result = await executeStream(activeConfig, tools, onEvent, memoryContext);
+      const result = await executeStream(activeConfig, tools, onEvent, memoryContext, streamInactivityTimeoutMs);
       return {
         ...result,
         durationMs: Date.now() - startTime,
@@ -265,6 +272,7 @@ async function executeStream(
   tools: Record<string, AITool> | undefined,
   onEvent: SessionEventCallback | undefined,
   memoryContext: MemorySessionContext | undefined,
+  inactivityTimeoutMs: number = STREAM_INACTIVITY_TIMEOUT_MS,
 ): Promise<Omit<SessionResult, 'durationMs'>> {
   const baseMaxSteps = config.maxSteps ?? DEFAULT_MAX_STEPS;
 
@@ -472,14 +480,14 @@ async function executeStream(
   });
 
   // Consume the full stream with inactivity timeout protection.
-  // The timer fires if no stream parts arrive within STREAM_INACTIVITY_TIMEOUT_MS,
+  // The timer fires if no stream parts arrive within inactivityTimeoutMs,
   // aborting the stream and preventing indefinite worker hangs.
   let streamInactivityTimer: ReturnType<typeof setTimeout> | null = null;
   const resetStreamInactivityTimer = () => {
     if (streamInactivityTimer) clearTimeout(streamInactivityTimer);
     streamInactivityTimer = setTimeout(() => {
       streamInactivityController.abort(STREAM_INACTIVITY_REASON);
-    }, STREAM_INACTIVITY_TIMEOUT_MS);
+    }, inactivityTimeoutMs);
   };
 
   resetStreamInactivityTimer(); // Arm for initial response
@@ -503,7 +511,7 @@ async function executeStream(
         usage: summary.usage,
         error: {
           code: 'stream_timeout',
-          message: `Stream inactivity timeout — no data received from provider for ${STREAM_INACTIVITY_TIMEOUT_MS / 1000}s`,
+          message: `Stream inactivity timeout — no data received from provider for ${inactivityTimeoutMs / 1000}s`,
           retryable: true,
         },
         messages,


### PR DESCRIPTION
Fixes AndyMik90/Auto-Claude#1984

## Problem

When using Auto Claude with local Ollama models on slower hardware, tasks silently fail and transfer to Human Review without any error message shown in the frontend logs. This happens because:

1. `STREAM_INACTIVITY_TIMEOUT_MS` was hardcoded at 60 seconds in `runner.ts`
2. Ollama models running on a slow machine (CPU inference, large models) can take several minutes just to generate the first token
3. When the timeout fires, the task is aborted without a clear error surfaced to the user

## Solution

- Add an optional `streamInactivityTimeoutMs` field to `RunnerOptions` so callers can override the inactivity timeout per-session (defaults to the existing 60s for backward compatibility)
- Thread the parameter through `executeStream()` instead of using the hardcoded constant
- In all three worker session runners (`runSingleSession`, `runDefaultSession`, `runAgenticSpecOrchestrator`), detect the Ollama provider and pass a 5-minute (300s) timeout to accommodate slow local inference

The 60s default is preserved for cloud providers where 60s without a response almost certainly indicates a real problem. The 5-minute timeout for Ollama gives local inference time to complete on slower hardware without hanging indefinitely.

## Testing

- Verified TypeScript types are consistent across the call chain
- The `streamInactivityTimeoutMs` parameter flows correctly: `RunnerOptions` → `runAgentSession()` → `executeStream()` with proper default fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented configurable stream inactivity timeout mechanism for improved session management.
  * Ollama provider now enforces a 5-minute inactivity threshold to automatically handle unresponsive streams and enhance system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->