### PR TITLE
fix: track spawned profile ID to correctly attribute rate limit errors

### DIFF
--- a/apps/desktop/src/main/agent/agent-process.ts
+++ b/apps/desktop/src/main/agent/agent-process.ts
@@ -163,7 +163,7 @@ export class AgentProcessManager {
 
   private setupProcessEnvironment(
     extraEnv: Record<string, string>
-  ): NodeJS.ProcessEnv {
+  ): { env: NodeJS.ProcessEnv; profileId: string; profileName: string } {
     // Get best available Claude profile environment (automatically handles rate limits)
     const profileResult = getBestAvailableProfileEnv();
     const profileEnv = profileResult.env;
@@ -253,7 +253,7 @@ export class AgentProcessManager {
       apiKeyPrefix: mergedEnv.ANTHROPIC_API_KEY?.substring(0, 8) || '(not set)',
     });
 
-    return mergedEnv;
+    return { env: mergedEnv, profileId: profileResult.profileId, profileName: profileResult.profileName };
   }
 
   private handleProcessFailure(
@@ -263,7 +263,8 @@ export class AgentProcessManager {
   ): boolean {
     console.log('[AgentProcess] Checking for rate limit in output (last 500 chars):', allOutput.slice(-500));
 
-    const rateLimitDetection = detectRateLimit(allOutput);
+    const profileAssignment = this.state.getTaskProfileAssignment(taskId);
+    const rateLimitDetection = detectRateLimit(allOutput, profileAssignment?.profileId);
     console.log('[AgentProcess] Rate limit detection result:', {
       isRateLimited: rateLimitDetection.isRateLimited,
       resetTime: rateLimitDetection.resetTime,
@@ -549,7 +550,8 @@ export class AgentProcessManager {
       spawnId
     });
 
-    const env = this.setupProcessEnvironment(extraEnv);
+    const { env, profileId: spawnedProfileId, profileName: spawnedProfileName } = this.setupProcessEnvironment(extraEnv);
+    this.state.assignProfileToTask(taskId, spawnedProfileId, spawnedProfileName, 'proactive');
 
     // Get active API profile environment variables
     let apiProfileEnv: Record<string, string> = {};


### PR DESCRIPTION
Fixes #1903

## Problem

When a task process hits a rate limit, `detectRateLimit()` was called in `handleProcessFailure()` without passing the `profileId` of the profile that spawned the process. It fell back to `profileManager.getActiveProfile().id`, which may have changed since the process was spawned.

**Concrete scenario**: A user creates a Z.AI profile and switches to it. Tasks still running under "Primary"'s credentials hit Primary's rate limit. Because `getActiveProfile()` now returns Z.AI, the error gets attributed to Z.AI instead of Primary — showing the user an incorrect "Profile: Primary is rate limited" notification even while they believe they are using Z.AI only.

The `AgentState.assignProfileToTask()` mechanism already existed to track which profile was assigned to each task, but it was never called from `spawnProcess()`.

## Solution

1. Changed `setupProcessEnvironment()` to return `{ env, profileId, profileName }` so the caller knows which profile was selected by `getBestAvailableProfileEnv()`.
2. In `spawnProcess()`, record the profile assignment immediately after environment setup via `this.state.assignProfileToTask()`.
3. In `handleProcessFailure()`, look up the stored profile assignment and pass its `profileId` to `detectRateLimit()`, so rate limit events are correctly attributed to the profile that spawned the process.

## Testing

The existing tests in `agent-process.test.ts` already mock `getBestAvailableProfileEnv()` to return `{ env: {}, profileId: 'default', profileName: 'Default', wasSwapped: false }`, which is compatible with the updated return type — no test changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced profile management by improving how task profiles are tracked and assigned throughout the agent process lifecycle.
  * Improved rate limit detection to operate with profile-specific context, enabling more granular throttling analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->