### PR TITLE
fix: prevent Insights chat panel from scrolling off-screen

### DIFF
--- a/apps/desktop/src/renderer/components/Insights.tsx
+++ b/apps/desktop/src/renderer/components/Insights.tsx
@@ -405,7 +405,7 @@ export function Insights({ projectId }: InsightsProps) {
       )}
 
       {/* Main Chat Area */}
-      <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col min-h-0">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-6 py-4">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
Fixes #1977

## Problem
The Insights chat panel becomes invisible after messages load. The content briefly flashes on screen, then scrolls off the top of the viewport and cannot be seen without zooming out.

The inner flex container `<div className="flex flex-1 flex-col">` was missing `min-h-0`. Without it, the default flex `min-height: auto` allows the flex child to grow taller than its parent. This causes the `ScrollArea` inside to also grow unconstrained, overflowing the layout and scrolling off-screen.

## Solution
Add `min-h-0` to the main chat area flex container in `Insights.tsx`:

```tsx
- <div className="flex flex-1 flex-col">
+ <div className="flex flex-1 flex-col min-h-0">
```

This constrains the flex child to its parent's height, allowing the `ScrollArea` to properly contain the messages within the viewport.

Note: The `scrollIntoView` issue mentioned in the bug report was already addressed in a prior refactor — the component now uses the `viewportEl` ref directly (`viewportEl.scrollTop = viewportEl.scrollHeight`) instead of `scrollIntoView()`.

## Testing
- Verified the fix by checking the `min-h-0` presence resolves the flex min-height constraint issue
- The reporter of the original issue confirmed a similar patch to `app.asar` resolved the scrolling behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout behavior in the Insights section to ensure the main chat area properly adjusts its size within the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->