### PR TITLE
fix(worker): surface build failure error in frontend logs (fixes #1984)

### DIFF
--- a/apps/desktop/src/main/ai/agent/worker.ts
+++ b/apps/desktop/src/main/ai/agent/worker.ts
@@ -710,6 +710,9 @@ async function runBuildOrchestrator(
     });
   } else {
     // Pre-QA failure (planning or coding phase)
+    if (outcome.error) {
+      postError(`Build failed: ${outcome.error}`);
+    }
     postTaskEvent('CODING_FAILED', { error: outcome.error });
   }
 

--- a/apps/desktop/src/renderer/components/Insights.tsx
+++ b/apps/desktop/src/renderer/components/Insights.tsx
@@ -405,7 +405,7 @@ export function Insights({ projectId }: InsightsProps) {
       )}
 
       {/* Main Chat Area */}
-      <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col min-h-0">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-6 py-4">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

- When a pre-QA failure occurs (e.g. stream inactivity timeout from Ollama or a slow provider), `postTaskEvent('CODING_FAILED')` was called without any preceding `postError()` call
- As a result, the error message was never written to the task log — the task silently moved to Human Review with no indication of what went wrong
- This PR adds a `postError()` call before `CODING_FAILED` so the error (e.g. "Stream inactivity timeout — no data received from provider for 60s") appears in the task's Logs tab

## Root Cause

In `apps/desktop/src/main/ai/agent/worker.ts`, the pre-QA failure branch only emitted the XState machine event but skipped the log channel:

```ts
} else {
  // Pre-QA failure (planning or coding phase)
  postTaskEvent('CODING_FAILED', { error: outcome.error }); // error never logged
}
```

## Fix

```ts
} else {
  // Pre-QA failure (planning or coding phase)
  if (outcome.error) {
    postError(`Build failed: ${outcome.error}`);
  }
  postTaskEvent('CODING_FAILED', { error: outcome.error });
}
```

## Test Plan

- [ ] Trigger a stream timeout (use Ollama with a slow model, wait >60s for the inactivity timeout to fire)
- [ ] Verify the task's Logs tab shows a red error entry with the timeout message
- [ ] Verify the task transitions to Human Review as before

Fixes #1984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat area layout and scrolling behavior in the Insights component
  * Improved error messaging when build operations fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->