### PR TITLE
fix: await removeProject to prevent race condition on project re-add (fixes #1910)

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -163,6 +163,7 @@ export function App() {
   const [showRemoveProjectDialog, setShowRemoveProjectDialog] = useState(false);
   const [removeProjectError, setRemoveProjectError] = useState<string | null>(null);
   const [projectToRemove, setProjectToRemove] = useState<Project | null>(null);
+  const [isRemovingProject, setIsRemovingProject] = useState(false);
 
   // Setup drag sensors
   const sensors = useSensors(
@@ -662,16 +663,23 @@ export function App() {
     }
   };
 
-  const handleConfirmRemoveProject = () => {
+  const handleConfirmRemoveProject = async () => {
     if (projectToRemove) {
       try {
         // Clear any previous error
         setRemoveProjectError(null);
-        // Remove the project from the app (files are preserved on disk for re-adding later)
-        removeProject(projectToRemove.id);
-        // Only clear dialog state on success
-        setShowRemoveProjectDialog(false);
-        setProjectToRemove(null);
+        setIsRemovingProject(true);
+        // Await removal so the backend fully completes before the dialog closes.
+        // Without await, a race condition allows addProject() to run while
+        // removeProject() is still in-flight, causing the backend to return the
+        // old project ID and later wipe all tasks when removal finally resolves.
+        const success = await removeProject(projectToRemove.id);
+        if (success) {
+          setShowRemoveProjectDialog(false);
+          setProjectToRemove(null);
+        } else {
+          setRemoveProjectError(t('dialogs:removeProject.error'));
+        }
       } catch (err) {
         // Log error and keep dialog open so user can retry or cancel
         console.error('[App] Failed to remove project:', err);
@@ -679,6 +687,8 @@ export function App() {
         setRemoveProjectError(
           err instanceof Error ? err.message : t('common:errors.unknownError')
         );
+      } finally {
+        setIsRemovingProject(false);
       }
     }
   };
@@ -687,6 +697,7 @@ export function App() {
     setShowRemoveProjectDialog(false);
     setProjectToRemove(null);
     setRemoveProjectError(null);
+    setIsRemovingProject(false);
   };
 
   // Handle drag start - set the active dragged project
@@ -1122,10 +1133,10 @@ export function App() {
               </div>
             )}
             <DialogFooter>
-              <Button variant="outline" onClick={handleCancelRemoveProject}>
+              <Button variant="outline" onClick={handleCancelRemoveProject} disabled={isRemovingProject}>
                 {t('removeProject.cancel')}
               </Button>
-              <Button variant="destructive" onClick={handleConfirmRemoveProject}>
+              <Button variant="destructive" onClick={handleConfirmRemoveProject} disabled={isRemovingProject}>
                 {t('removeProject.remove')}
               </Button>
             </DialogFooter>


### PR DESCRIPTION
Fixes #1910

## Problem

After closing a project tab and immediately re-adding the same directory, the UI shows up completely empty — no Kanban cards, no roadmap.

The root cause is a race condition in `handleConfirmRemoveProject`: `removeProject()` was called without `await`, so the dialog closed immediately. If the user quickly re-added the same directory, `addProject` IPC could arrive at the main process *before* `removeProject` completed — so the backend still found the old project and returned the old project ID. When removal finally resolved, it called `store.removeProject(oldId)` + `store.closeProjectTab(oldId)`, wiping all tasks from state and leaving the UI empty.

## Solution

Make `handleConfirmRemoveProject` async and await `removeProject()`. The dialog stays open until removal fully completes, eliminating the race window. Also disable dialog buttons while removal is in progress to prevent double-submission.

## Testing

1. Open two projects (so the close tab X button appears)
2. Close one project tab and confirm with Remove
3. Immediately click Add Project and re-add the same directory
4. Verify the project reopens with all Kanban tasks and roadmap intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved project removal workflow by disabling dialog buttons during the removal process, preventing accidental interactions.
* Enhanced error handling to display descriptive messages when project removal fails.
* Added loading state feedback to indicate when a removal operation is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->