### PR TITLE
feat(settings): add global proxy settings with runtime apply

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -114,6 +114,7 @@
     "remark-gfm": "^4.0.1",
     "semver": "^7.7.4",
     "tailwind-merge": "^3.5.0",
+    "undici": "^8.0.2",
     "uuid": "^13.0.0",
     "web-tree-sitter": "^0.26.7",
     "xstate": "^5.28.0",

--- a/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
@@ -156,6 +156,9 @@ function cleanupTestDirs(): void {
 // Increase timeout for all tests in this file due to dynamic imports and setup overhead.
 // Windows requires longer timeout due to slower file system operations and module loading.
 describe("IPC Handlers", { timeout: 30000 }, () => {
+  const PROXY_ENV_KEYS = ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"] as const;
+  let baselineProxyEnv: Partial<Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>> = {};
+
   let ipcMain: EventEmitter & {
     handlers: Map<string, Function>;
     invokeHandler: (channel: string, event: unknown, ...args: unknown[]) => Promise<unknown>;
@@ -529,6 +532,23 @@ describe("IPC Handlers", { timeout: 30000 }, () => {
   });
 
   describe("settings:save handler", () => {
+    beforeEach(() => {
+      baselineProxyEnv = Object.fromEntries(
+        PROXY_ENV_KEYS.map((key) => [key, process.env[key]])
+      ) as Partial<Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>>;
+    });
+
+    afterEach(() => {
+      for (const key of PROXY_ENV_KEYS) {
+        const originalValue = baselineProxyEnv[key];
+        if (typeof originalValue === "undefined") {
+          delete process.env[key];
+          continue;
+        }
+        process.env[key] = originalValue;
+      }
+    });
+
     it("should save settings successfully", async () => {
       const { setupIpcHandlers } = await import("../ipc-handlers");
       setupIpcHandlers(

--- a/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
@@ -564,6 +564,30 @@ describe("IPC Handlers", { timeout: 30000 }, () => {
 
       expect(mockAgentManager.configure).toHaveBeenCalledWith("/usr/bin/python3", undefined);
     });
+
+    it("should reject malformed proxy URL settings", async () => {
+      const { setupIpcHandlers } = await import("../ipc-handlers");
+      setupIpcHandlers(
+        mockAgentManager as never,
+        mockTerminalManager as never,
+        () => mockMainWindow as never
+      );
+
+      const result = await ipcMain.invokeHandler("settings:save", {}, {
+        proxyEnabled: true,
+        proxyHttpUrl: "notaurl",
+        proxyHttpsUrl: "http://127.0.0.1:7890",
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining("Invalid proxy settings."),
+      });
+
+      const getResult = await ipcMain.invokeHandler("settings:get", {});
+      const data = (getResult as { data: { proxyEnabled: boolean } }).data;
+      expect(data.proxyEnabled).toBe(false);
+    });
   });
 
   describe("app:version handler", () => {

--- a/apps/desktop/src/main/ai/auth/codex-oauth.ts
+++ b/apps/desktop/src/main/ai/auth/codex-oauth.ts
@@ -20,6 +20,8 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as path from 'path';
 import * as url from 'url';
+import { fetch as undiciFetch } from 'undici';
+import { getProxyAgentFromEnvironment } from '../../utils/runtime-proxy-config';
 
 // Electron APIs loaded lazily to avoid crashing in worker threads
 // (workers don't have access to Electron main-process modules)
@@ -354,10 +356,12 @@ async function exchangeCodeForTokens(code: string, codeVerifier: string): Promis
     code_verifier: codeVerifier,
   });
 
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const proxyAgent = getProxyAgentFromEnvironment();
+  const response = await undiciFetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
+    dispatcher: proxyAgent,
   });
 
   debugLog('Token exchange response', { status: response.status, ok: response.ok });
@@ -419,10 +423,12 @@ export async function refreshCodexToken(refreshToken: string): Promise<CodexAuth
     client_id: CLIENT_ID,
   });
 
-  const response = await fetch(TOKEN_ENDPOINT, {
+  const proxyAgent = getProxyAgentFromEnvironment();
+  const response = await undiciFetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
+    dispatcher: proxyAgent,
   });
 
   debugLog('Token refresh response', { status: response.status, ok: response.ok });

--- a/apps/desktop/src/main/ai/auth/codex-oauth.ts
+++ b/apps/desktop/src/main/ai/auth/codex-oauth.ts
@@ -356,7 +356,7 @@ async function exchangeCodeForTokens(code: string, codeVerifier: string): Promis
     code_verifier: codeVerifier,
   });
 
-  const proxyAgent = getProxyAgentFromEnvironment();
+  const proxyAgent = getProxyAgentFromEnvironment(TOKEN_ENDPOINT);
   const response = await undiciFetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -423,7 +423,7 @@ export async function refreshCodexToken(refreshToken: string): Promise<CodexAuth
     client_id: CLIENT_ID,
   });
 
-  const proxyAgent = getProxyAgentFromEnvironment();
+  const proxyAgent = getProxyAgentFromEnvironment(TOKEN_ENDPOINT);
   const response = await undiciFetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/apps/desktop/src/main/ai/auth/codex-oauth.ts
+++ b/apps/desktop/src/main/ai/auth/codex-oauth.ts
@@ -89,6 +89,9 @@ const REFRESH_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 /** Timeout for the OAuth browser flow before giving up */
 const OAUTH_FLOW_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
+/** Timeout for token endpoint HTTP requests */
+const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -356,13 +359,29 @@ async function exchangeCodeForTokens(code: string, codeVerifier: string): Promis
     code_verifier: codeVerifier,
   });
 
-  const proxyAgent = getProxyAgentFromEnvironment(TOKEN_ENDPOINT);
-  const response = await undiciFetch(TOKEN_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: body.toString(),
-    dispatcher: proxyAgent,
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TOKEN_REQUEST_TIMEOUT_MS);
+
+  let response: Awaited<ReturnType<typeof undiciFetch>>;
+  try {
+    const proxyAgent = getProxyAgentFromEnvironment(TOKEN_ENDPOINT);
+    response = await undiciFetch(TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: controller.signal,
+      dispatcher: proxyAgent,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(
+        `Token exchange timed out after ${Math.floor(TOKEN_REQUEST_TIMEOUT_MS / 1000)} seconds`
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   debugLog('Token exchange response', { status: response.status, ok: response.ok });
 
@@ -423,13 +442,29 @@ export async function refreshCodexToken(refreshToken: string): Promise<CodexAuth
     client_id: CLIENT_ID,
   });
 
-  const proxyAgent = getProxyAgentFromEnvironment(TOKEN_ENDPOINT);
-  const response = await undiciFetch(TOKEN_ENDPOINT, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: body.toString(),
-    dispatcher: proxyAgent,
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TOKEN_REQUEST_TIMEOUT_MS);
+
+  let response: Awaited<ReturnType<typeof undiciFetch>>;
+  try {
+    const proxyAgent = getProxyAgentFromEnvironment(TOKEN_ENDPOINT);
+    response = await undiciFetch(TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: controller.signal,
+      dispatcher: proxyAgent,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(
+        `Token refresh timed out after ${Math.floor(TOKEN_REQUEST_TIMEOUT_MS / 1000)} seconds`
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   debugLog('Token refresh response', { status: response.status, ok: response.ok });
 

--- a/apps/desktop/src/main/ai/providers/oauth-fetch.ts
+++ b/apps/desktop/src/main/ai/providers/oauth-fetch.ts
@@ -9,6 +9,8 @@
  */
 
 import * as fs from 'node:fs';
+import { fetch as undiciFetch } from 'undici';
+import { getProxyAgentFromEnvironment } from '../../utils/runtime-proxy-config';
 
 // =============================================================================
 // Debug Logging
@@ -114,10 +116,12 @@ async function refreshOAuthToken(
     client_id: providerSpec.clientId,
   });
 
-  const response = await fetch(providerSpec.tokenEndpoint, {
+  const proxyAgent = getProxyAgentFromEnvironment();
+  const response = await undiciFetch(providerSpec.tokenEndpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
+    dispatcher: proxyAgent,
   });
 
   debugLog('Token refresh response', { status: response.status, ok: response.ok });
@@ -271,8 +275,9 @@ export function createOAuthProviderFetch(
       debugLog(`${originalUrl} -> ${url} (token: [redacted])`);
     }
 
-    const finalInit = { ...init, headers };
-    const response = await globalThis.fetch(url, finalInit);
+      const proxyAgent = getProxyAgentFromEnvironment();
+    const finalInit = { ...init, headers, dispatcher: proxyAgent } as any;
+    const response = await undiciFetch(url, finalInit);
 
     if (DEBUG) {
       debugLog(`Response: ${response.status} ${response.statusText}`, { url });
@@ -287,6 +292,6 @@ export function createOAuthProviderFetch(
       }
     }
 
-    return response;
+    return response as unknown as Response;
   };
 }

--- a/apps/desktop/src/main/ai/providers/oauth-fetch.ts
+++ b/apps/desktop/src/main/ai/providers/oauth-fetch.ts
@@ -71,6 +71,9 @@ interface StoredTokens {
 /** How far before expiry to consider a token "near expiry" and trigger refresh */
 const REFRESH_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
+/** Timeout for OAuth token endpoint HTTP requests */
+const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+
 function readTokenFile(tokenFilePath: string): StoredTokens | null {
   try {
     const raw = fs.readFileSync(tokenFilePath, 'utf8');
@@ -117,12 +120,28 @@ async function refreshOAuthToken(
   });
 
   const proxyAgent = getProxyAgentFromEnvironment(providerSpec.tokenEndpoint);
-  const response = await undiciFetch(providerSpec.tokenEndpoint, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: body.toString(),
-    dispatcher: proxyAgent,
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TOKEN_REQUEST_TIMEOUT_MS);
+
+  let response: Awaited<ReturnType<typeof undiciFetch>>;
+  try {
+    response = await undiciFetch(providerSpec.tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: controller.signal,
+      dispatcher: proxyAgent,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      debugLog('Token refresh timed out', { timeoutMs: TOKEN_REQUEST_TIMEOUT_MS });
+      return null;
+    }
+    debugLog('Token refresh request failed', { error: error instanceof Error ? error.message : String(error) });
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
 
   debugLog('Token refresh response', { status: response.status, ok: response.ok });
 

--- a/apps/desktop/src/main/ai/providers/oauth-fetch.ts
+++ b/apps/desktop/src/main/ai/providers/oauth-fetch.ts
@@ -116,7 +116,7 @@ async function refreshOAuthToken(
     client_id: providerSpec.clientId,
   });
 
-  const proxyAgent = getProxyAgentFromEnvironment();
+  const proxyAgent = getProxyAgentFromEnvironment(providerSpec.tokenEndpoint);
   const response = await undiciFetch(providerSpec.tokenEndpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -275,7 +275,7 @@ export function createOAuthProviderFetch(
       debugLog(`${originalUrl} -> ${url} (token: [redacted])`);
     }
 
-      const proxyAgent = getProxyAgentFromEnvironment();
+      const proxyAgent = getProxyAgentFromEnvironment(url);
     const finalInit = { ...init, headers, dispatcher: proxyAgent } as any;
     const response = await undiciFetch(url, finalInit);
 

--- a/apps/desktop/src/main/ai/providers/oauth-fetch.ts
+++ b/apps/desktop/src/main/ai/providers/oauth-fetch.ts
@@ -247,8 +247,32 @@ export function createOAuthProviderFetch(
       throw new Error('OAuth: No valid token available. Please re-authenticate.');
     }
 
+    const requestDerivedInit: RequestInit =
+      input instanceof Request
+        ? {
+            method: input.method,
+            headers: input.headers,
+            body: input.body ?? undefined,
+            cache: input.cache,
+            credentials: input.credentials,
+            integrity: input.integrity,
+            keepalive: input.keepalive,
+            mode: input.mode,
+            redirect: input.redirect,
+            referrer: input.referrer,
+            referrerPolicy: input.referrerPolicy,
+            signal: input.signal,
+          }
+        : {};
+
     // 2. Build headers — strip dummy Authorization, inject real token
-    const headers = new Headers(init?.headers);
+    const headers = new Headers(requestDerivedInit.headers);
+    if (init?.headers) {
+      const initHeaders = new Headers(init.headers);
+      initHeaders.forEach((value, key) => {
+        headers.set(key, value);
+      });
+    }
     headers.delete('authorization');
     headers.delete('Authorization');
     headers.set('Authorization', `Bearer ${token}`);
@@ -275,8 +299,8 @@ export function createOAuthProviderFetch(
       debugLog(`${originalUrl} -> ${url} (token: [redacted])`);
     }
 
-      const proxyAgent = getProxyAgentFromEnvironment(url);
-    const finalInit = { ...init, headers, dispatcher: proxyAgent } as any;
+    const proxyAgent = getProxyAgentFromEnvironment(url);
+    const finalInit = { ...requestDerivedInit, ...init, headers, dispatcher: proxyAgent } as any;
     const response = await undiciFetch(url, finalInit);
 
     if (DEBUG) {

--- a/apps/desktop/src/main/claude-profile/codex-usage-fetcher.ts
+++ b/apps/desktop/src/main/claude-profile/codex-usage-fetcher.ts
@@ -1,4 +1,6 @@
 import type { ClaudeUsageSnapshot } from '../../shared/types/agent';
+import { fetch as undiciFetch } from 'undici';
+import { getProxyAgentFromEnvironment } from '../utils/runtime-proxy-config';
 
 // =============================================================================
 // Constants
@@ -59,10 +61,12 @@ export async function fetchCodexUsage(
   const timeout = setTimeout(() => controller.abort(), 15000);
 
   try {
-    const response = await fetch(CODEX_USAGE_ENDPOINT, {
+    const proxyAgent = getProxyAgentFromEnvironment();
+    const response = await undiciFetch(CODEX_USAGE_ENDPOINT, {
       method: 'GET',
       headers,
       signal: controller.signal,
+      dispatcher: proxyAgent,
     });
 
     if (!response.ok) {

--- a/apps/desktop/src/main/claude-profile/codex-usage-fetcher.ts
+++ b/apps/desktop/src/main/claude-profile/codex-usage-fetcher.ts
@@ -61,7 +61,7 @@ export async function fetchCodexUsage(
   const timeout = setTimeout(() => controller.abort(), 15000);
 
   try {
-    const proxyAgent = getProxyAgentFromEnvironment();
+    const proxyAgent = getProxyAgentFromEnvironment(CODEX_USAGE_ENDPOINT);
     const response = await undiciFetch(CODEX_USAGE_ENDPOINT, {
       method: 'GET',
       headers,

--- a/apps/desktop/src/main/claude-profile/token-refresh.test.ts
+++ b/apps/desktop/src/main/claude-profile/token-refresh.test.ts
@@ -302,6 +302,36 @@ describe('token-refresh', () => {
         expect.any(Number)
       );
     });
+
+    it('should succeed and retain existing refresh token when refresh response omits refresh_token', async () => {
+      const { getFullCredentialsFromKeychain, updateKeychainCredentials } = await import('./credential-utils');
+      (getFullCredentialsFromKeychain as ReturnType<typeof vi.fn>).mockReturnValue({
+        token: 'old-token',
+        refreshToken: 'existing-refresh-token',
+        expiresAt: Date.now() + 5 * 60 * 1000,
+        email: 'test@example.com'
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-token',
+          expires_in: 28800
+        })
+      });
+
+      const result = await ensureValidToken(undefined);
+
+      expect(result.wasRefreshed).toBe(true);
+      expect(result.token).toBe('new-token');
+      expect(updateKeychainCredentials).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({
+          accessToken: 'new-token',
+          refreshToken: 'existing-refresh-token'
+        })
+      );
+    });
   });
 
   describe('reactiveTokenRefresh', () => {
@@ -342,6 +372,36 @@ describe('token-refresh', () => {
 
       expect(result.token).toBeNull();
       expect(result.error).toContain('No refresh token');
+    });
+
+    it('should succeed and retain existing refresh token when reactive refresh response omits refresh_token', async () => {
+      const { getFullCredentialsFromKeychain, updateKeychainCredentials } = await import('./credential-utils');
+      (getFullCredentialsFromKeychain as ReturnType<typeof vi.fn>).mockReturnValue({
+        token: 'current-token',
+        refreshToken: 'existing-refresh-token',
+        expiresAt: Date.now() + 2 * 60 * 60 * 1000,
+        email: 'test@example.com'
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'reactive-new-token',
+          expires_in: 28800
+        })
+      });
+
+      const result = await reactiveTokenRefresh(undefined);
+
+      expect(result.wasRefreshed).toBe(true);
+      expect(result.token).toBe('reactive-new-token');
+      expect(updateKeychainCredentials).toHaveBeenCalledWith(
+        undefined,
+        expect.objectContaining({
+          accessToken: 'reactive-new-token',
+          refreshToken: 'existing-refresh-token'
+        })
+      );
     });
   });
 });

--- a/apps/desktop/src/main/claude-profile/token-refresh.ts
+++ b/apps/desktop/src/main/claude-profile/token-refresh.ts
@@ -406,7 +406,7 @@ export async function ensureValidToken(
   // Step 4: Refresh the token
   const refreshResult = await refreshOAuthToken(creds.refreshToken, expandedConfigDir);
 
-  if (!refreshResult.success || !refreshResult.accessToken || !refreshResult.refreshToken || !refreshResult.expiresAt) {
+  if (!refreshResult.success || !refreshResult.accessToken || !refreshResult.expiresAt) {
     console.error('[TokenRefresh:ensureValidToken] Token refresh failed:', refreshResult.error);
 
     // Check for permanent errors (revoked/invalid tokens)
@@ -433,11 +433,13 @@ export async function ensureValidToken(
     };
   }
 
+  const refreshedTokenForPersistence = refreshResult.refreshToken ?? creds.refreshToken;
+
   // Step 5: CRITICAL - Write new tokens to keychain immediately
   // The old token is now REVOKED, so we must persist the new one
   const updateResult = updateKeychainCredentials(expandedConfigDir, {
     accessToken: refreshResult.accessToken,
-    refreshToken: refreshResult.refreshToken,
+    refreshToken: refreshedTokenForPersistence,
     expiresAt: refreshResult.expiresAt,
     scopes: creds.scopes || undefined
   });
@@ -472,7 +474,7 @@ export async function ensureValidToken(
     onRefreshed(
       expandedConfigDir,
       refreshResult.accessToken,
-      refreshResult.refreshToken,
+      refreshedTokenForPersistence,
       refreshResult.expiresAt
     );
   }
@@ -533,7 +535,7 @@ export async function reactiveTokenRefresh(
   // Perform refresh
   const refreshResult = await refreshOAuthToken(creds.refreshToken, expandedConfigDir);
 
-  if (!refreshResult.success || !refreshResult.accessToken || !refreshResult.refreshToken || !refreshResult.expiresAt) {
+  if (!refreshResult.success || !refreshResult.accessToken || !refreshResult.expiresAt) {
     return {
       token: null,
       wasRefreshed: false,
@@ -542,10 +544,12 @@ export async function reactiveTokenRefresh(
     };
   }
 
+  const refreshedTokenForPersistence = refreshResult.refreshToken ?? creds.refreshToken;
+
   // Write new tokens to keychain
   const updateResult = updateKeychainCredentials(expandedConfigDir, {
     accessToken: refreshResult.accessToken,
-    refreshToken: refreshResult.refreshToken,
+    refreshToken: refreshedTokenForPersistence,
     expiresAt: refreshResult.expiresAt,
     scopes: creds.scopes || undefined
   });
@@ -569,7 +573,7 @@ export async function reactiveTokenRefresh(
     onRefreshed(
       expandedConfigDir,
       refreshResult.accessToken,
-      refreshResult.refreshToken,
+      refreshedTokenForPersistence,
       refreshResult.expiresAt
     );
   }

--- a/apps/desktop/src/main/claude-profile/token-refresh.ts
+++ b/apps/desktop/src/main/claude-profile/token-refresh.ts
@@ -20,6 +20,7 @@ import {
   updateKeychainCredentials,
   clearKeychainCache,
 } from './credential-utils';
+import { fetchWithProxy } from '../utils/proxy-fetch';
 
 // =============================================================================
 // Constants
@@ -52,6 +53,10 @@ const MAX_REFRESH_RETRIES = 2;
  * Delay between retry attempts (exponential backoff base)
  */
 const RETRY_DELAY_BASE_MS = 1000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
 
 // =============================================================================
 // Types
@@ -207,7 +212,7 @@ export async function refreshOAuthToken(
         client_id: CLAUDE_CODE_CLIENT_ID
       });
 
-      const response = await fetch(ANTHROPIC_TOKEN_ENDPOINT, {
+      const response = await fetchWithProxy(ANTHROPIC_TOKEN_ENDPOINT, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded'
@@ -216,15 +221,24 @@ export async function refreshOAuthToken(
       });
 
       if (!response.ok) {
-        let errorData: Record<string, string> = {};
+        let errorCode = `http_${response.status}`;
+        let errorDescription = response.statusText;
+
         try {
-          errorData = await response.json();
+          const parsed = await response.json();
+          if (isRecord(parsed)) {
+            const parsedError = parsed.error;
+            const parsedDescription = parsed.error_description;
+            if (typeof parsedError === 'string' && parsedError.length > 0) {
+              errorCode = parsedError;
+            }
+            if (typeof parsedDescription === 'string' && parsedDescription.length > 0) {
+              errorDescription = parsedDescription;
+            }
+          }
         } catch {
           // Ignore JSON parse errors
         }
-
-        const errorCode = errorData.error || `http_${response.status}`;
-        const errorDescription = errorData.error_description || response.statusText;
 
         // Check for permanent errors that shouldn't be retried
         if (errorCode === 'invalid_grant' || errorCode === 'invalid_client') {
@@ -254,8 +268,7 @@ export async function refreshOAuthToken(
 
       // Parse successful response
       const data = await response.json();
-
-      if (!data.access_token) {
+      if (!isRecord(data) || typeof data.access_token !== 'string') {
         return {
           success: false,
           error: 'Response missing access_token',
@@ -265,7 +278,7 @@ export async function refreshOAuthToken(
 
       // Calculate expiry timestamp
       // expires_in is in seconds, convert to ms and add to current time
-      const expiresIn = data.expires_in || 28800; // Default 8 hours if not provided
+      const expiresIn = typeof data.expires_in === 'number' ? data.expires_in : 28800; // Default 8 hours if not provided
       const expiresAt = Date.now() + (expiresIn * 1000);
 
       if (isDebug) {
@@ -279,7 +292,7 @@ export async function refreshOAuthToken(
       return {
         success: true,
         accessToken: data.access_token,
-        refreshToken: data.refresh_token,
+        refreshToken: typeof data.refresh_token === 'string' ? data.refresh_token : undefined,
         expiresAt,
         expiresIn
       };

--- a/apps/desktop/src/main/claude-profile/usage-monitor.ts
+++ b/apps/desktop/src/main/claude-profile/usage-monitor.ts
@@ -21,9 +21,10 @@ import { reactiveTokenRefresh, ensureValidToken } from './token-refresh';
 import { isProfileRateLimited } from './rate-limit-manager';
 import { getOperationRegistry } from './operation-registry';
 import { ensureValidCodexToken } from '../ai/auth/codex-oauth';
-import { fetchCodexUsage, normalizeCodexResponse } from './codex-usage-fetcher';
+import { fetchCodexUsage, normalizeCodexResponse, type CodexUsageResponse } from './codex-usage-fetcher';
 import { readSettingsFileAsync, writeSettingsFile } from '../settings-utils';
 import type { ProviderAccount } from '../../shared/types/provider-account';
+import { fetchWithProxy } from '../utils/proxy-fetch';
 
 // Re-export for backward compatibility
 export type { ApiProvider };
@@ -40,6 +41,10 @@ function getCredentialFingerprint(credential: string | null | undefined): string
   if (!credential) return 'null';
   if (credential.length <= 16) return credential.slice(0, 4) + '...' + credential.slice(-2);
   return credential.slice(0, 8) + '...' + credential.slice(-4);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }
 
 /**
@@ -1104,7 +1109,7 @@ export class UsageMonitor extends EventEmitter {
         try {
           // CodeQL: file data in outbound request - validate API key is a non-empty string before use
           const safeApiKey = typeof account.apiKey === 'string' && account.apiKey.length > 0 ? account.apiKey : '';
-          const response = await fetch('https://api.z.ai/api/monitor/usage/quota/limit', {
+          const response = await fetchWithProxy('https://api.z.ai/api/monitor/usage/quota/limit', {
             headers: {
               'Authorization': safeApiKey,
             },
@@ -1112,7 +1117,7 @@ export class UsageMonitor extends EventEmitter {
           if (response.ok) {
             const json = await response.json();
             // Z.AI wraps response in a data field
-            const rawData = json.data ?? json;
+            const rawData = isRecord(json) && 'data' in json ? json.data : json;
             const normalized = this.normalizeZAIResponse(rawData, account.id, account.name);
             if (normalized) {
               allProfiles.push({
@@ -2187,9 +2192,9 @@ export class UsageMonitor extends EventEmitter {
         }
       }
 
-      const response = await fetch(usageEndpoint, {
+      const response = await fetchWithProxy(usageEndpoint, {
         method: 'GET',
-        headers
+        headers,
       });
 
       if (!response.ok) {
@@ -2286,9 +2291,9 @@ export class UsageMonitor extends EventEmitter {
 
       // Step 6: Extract data wrapper for z.ai and ZHIPU responses
       // These providers wrap the actual usage data in a 'data' field
-      let responseData = rawData;
+      let responseData: unknown = rawData;
       if (provider === 'zai' || provider === 'zhipu') {
-        if (rawData.data) {
+        if (isRecord(rawData) && 'data' in rawData) {
           responseData = rawData.data;
           this.traceLog('[UsageMonitor:PROVIDER] Extracted data field from response:', {
             provider,
@@ -2297,7 +2302,7 @@ export class UsageMonitor extends EventEmitter {
         } else {
           this.traceLog('[UsageMonitor:PROVIDER] No data field found in response, using raw response:', {
             provider,
-            responseKeys: Object.keys(rawData)
+            responseKeys: isRecord(rawData) ? Object.keys(rawData) : []
           });
         }
       }
@@ -2314,9 +2319,13 @@ export class UsageMonitor extends EventEmitter {
         case 'anthropic':
           normalizedUsage = this.normalizeAnthropicResponse(rawData, profileId, profileName, profileEmail);
           break;
-        case 'openai':
-          normalizedUsage = normalizeCodexResponse(rawData, profileId, profileName, profileEmail);
+        case 'openai': {
+          const codexData: CodexUsageResponse = isRecord(rawData)
+            ? (rawData as CodexUsageResponse)
+            : {};
+          normalizedUsage = normalizeCodexResponse(codexData, profileId, profileName, profileEmail);
           break;
+        }
         case 'zai':
           normalizedUsage = this.normalizeZAIResponse(responseData, profileId, profileName, profileEmail);
           break;

--- a/apps/desktop/src/main/claude-profile/usage-monitor.ts
+++ b/apps/desktop/src/main/claude-profile/usage-monitor.ts
@@ -44,7 +44,7 @@ function getCredentialFingerprint(credential: string | null | undefined): string
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/apps/desktop/src/main/claude-profile/usage-monitor.ts
+++ b/apps/desktop/src/main/claude-profile/usage-monitor.ts
@@ -2320,10 +2320,21 @@ export class UsageMonitor extends EventEmitter {
           normalizedUsage = this.normalizeAnthropicResponse(rawData, profileId, profileName, profileEmail);
           break;
         case 'openai': {
-          const codexData: CodexUsageResponse = isRecord(rawData)
-            ? (rawData as CodexUsageResponse)
-            : {};
-          normalizedUsage = normalizeCodexResponse(codexData, profileId, profileName, profileEmail);
+          if (!isRecord(rawData)) {
+            this.traceLog('[UsageMonitor:NORMALIZATION] Invalid OpenAI usage payload shape', {
+              profileId,
+              provider,
+              payloadType: typeof rawData
+            });
+            break;
+          }
+
+          normalizedUsage = normalizeCodexResponse(
+            rawData as CodexUsageResponse,
+            profileId,
+            profileName,
+            profileEmail
+          );
           break;
         }
         case 'zai':

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -70,6 +70,7 @@ import { isProfileAuthenticated } from './claude-profile/profile-utils';
 import { isMacOS, isWindows } from './platform';
 import { ptyDaemonClient } from './terminal/pty-daemon-client';
 import type { AppSettings, AuthFailureInfo } from '../shared/types';
+import { applyRuntimeProxyConfig } from './utils/runtime-proxy-config';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Migrate userData from old app name (auto-claude-ui → aperant)
@@ -443,6 +444,15 @@ app.whenReady().then(() => {
 
   // Initialize agent manager
   agentManager = new AgentManager();
+
+  // Apply runtime proxy env from persisted app settings at startup
+  const startupProxyConfig = applyRuntimeProxyConfig(loadSettingsSync());
+  if (startupProxyConfig.state === 'invalid') {
+    console.warn(
+      '[main] Invalid proxy settings on startup. Runtime proxy was not applied:',
+      startupProxyConfig.errors.map((entry) => entry.message).join(' ')
+    );
+  }
 
   // Load settings and configure agent manager with Python and auto-claude paths
   // Uses EAFP pattern (try/catch) instead of LBYL (existsSync) to avoid TOCTOU race conditions

--- a/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
+++ b/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
@@ -104,10 +104,28 @@ import { getProxyAgentFromEnvironment, getProxyUrlFromEnvironment } from '../../
 import { fetchCodexUsage } from '../../claude-profile/codex-usage-fetcher';
 
 const PROXY_ENV_KEYS = ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy'] as const;
+let baselineProxyEnv: Partial<Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>> = {};
 
 function clearProxyEnv(): void {
   for (const key of PROXY_ENV_KEYS) {
     delete process.env[key];
+  }
+}
+
+function snapshotProxyEnv(): Partial<Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>> {
+  return Object.fromEntries(PROXY_ENV_KEYS.map((key) => [key, process.env[key]])) as Partial<
+    Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>
+  >;
+}
+
+function restoreProxyEnv(snapshot: Partial<Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>>): void {
+  for (const key of PROXY_ENV_KEYS) {
+    const value = snapshot[key];
+    if (typeof value === 'undefined') {
+      delete process.env[key];
+      continue;
+    }
+    process.env[key] = value;
   }
 }
 
@@ -138,6 +156,7 @@ async function captureDispatcherForCodexUsage(): Promise<unknown> {
 describe('settings:save proxy runtime integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    baselineProxyEnv = snapshotProxyEnv();
     clearProxyEnv();
 
     settingsState.data = {};
@@ -152,7 +171,7 @@ describe('settings:save proxy runtime integration', () => {
   });
 
   afterEach(() => {
-    clearProxyEnv();
+    restoreProxyEnv(baselineProxyEnv);
   });
 
   it('applies valid proxy from settings save and propagates to network paths', async () => {

--- a/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
+++ b/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
@@ -1,0 +1,215 @@
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { IPC_CHANNELS } from '@shared/constants';
+
+const {
+  mockedUndiciFetch,
+  settingsState,
+  MockProxyAgent,
+} = vi.hoisted(() => {
+  class ProxyAgentMock {
+    readonly proxyUrl: string;
+
+    constructor(proxyUrl: string) {
+      this.proxyUrl = proxyUrl;
+    }
+  }
+
+  return {
+    mockedUndiciFetch: vi.fn(),
+    settingsState: {
+      data: {} as Record<string, unknown>,
+      path: '/tmp/settings-proxy-initial.json',
+    },
+    MockProxyAgent: ProxyAgentMock,
+  };
+});
+
+vi.mock('undici', () => ({
+  fetch: mockedUndiciFetch,
+  ProxyAgent: MockProxyAgent,
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  app: {
+    getPath: vi.fn(() => tmpdir()),
+    getAppPath: vi.fn(() => '/test/app'),
+    getVersion: vi.fn(() => '0.0.0-test'),
+  },
+  shell: {
+    openExternal: vi.fn(),
+  },
+  session: {
+    defaultSession: {
+      setSpellCheckerLanguages: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@electron-toolkit/utils', () => ({
+  is: { dev: true },
+}));
+
+vi.mock('../../settings-utils', () => ({
+  getSettingsPath: vi.fn(() => settingsState.path),
+  readSettingsFile: vi.fn(() => settingsState.data),
+}));
+
+vi.mock('../../app-language', () => ({
+  setAppLanguage: vi.fn(),
+}));
+
+vi.mock('../../app-updater', () => ({
+  setUpdateChannel: vi.fn(),
+  setUpdateChannelWithDowngradeCheck: vi.fn(),
+}));
+
+vi.mock('../context/memory-service-factory', () => ({
+  resetMemoryService: vi.fn(),
+}));
+
+vi.mock('../../cli-tool-manager', () => ({
+  configureTools: vi.fn(),
+  getToolPath: vi.fn(),
+  getToolInfo: vi.fn(),
+  isPathFromWrongPlatform: vi.fn(() => false),
+  preWarmToolCache: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../utils/profile-manager', () => ({
+  loadProfilesFile: vi.fn(async () => ({ profiles: [] })),
+}));
+
+vi.mock('../../claude-profile/profile-storage', () => ({
+  loadProfileStore: vi.fn(() => null),
+}));
+
+import { ipcMain } from 'electron';
+import { registerSettingsHandlers } from '../settings-handlers';
+import type { AgentManager } from '../../agent';
+import { getProxyUrlFromEnvironment } from '../../utils/runtime-proxy-config';
+import { fetchCodexUsage } from '../../claude-profile/codex-usage-fetcher';
+
+const PROXY_ENV_KEYS = ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy'] as const;
+
+function clearProxyEnv(): void {
+  for (const key of PROXY_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function getSettingsSaveHandler(): (...args: unknown[]) => Promise<{ success: boolean; error?: string }> {
+  const handleCalls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls;
+  const settingsSaveCall = handleCalls.find((call) => call[0] === IPC_CHANNELS.SETTINGS_SAVE);
+
+  if (!settingsSaveCall?.[1]) {
+    throw new Error('settings:save handler was not registered');
+  }
+
+  return settingsSaveCall[1] as (...args: unknown[]) => Promise<{ success: boolean; error?: string }>;
+}
+
+async function captureDispatcherForCodexUsage(): Promise<unknown> {
+  mockedUndiciFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({}),
+  });
+
+  await fetchCodexUsage('test-token');
+  const call = mockedUndiciFetch.mock.calls.at(-1);
+  return call?.[1]?.dispatcher;
+}
+
+describe('settings:save proxy runtime integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearProxyEnv();
+
+    settingsState.data = {};
+    settingsState.path = path.join(tmpdir(), `settings-proxy-${Date.now()}.json`);
+
+    registerSettingsHandlers(
+      {
+        configure: vi.fn(),
+      } as unknown as AgentManager,
+      () => null,
+    );
+  });
+
+  afterEach(() => {
+    clearProxyEnv();
+  });
+
+  it('applies valid proxy from settings save and propagates to network paths', async () => {
+    const handler = getSettingsSaveHandler();
+    const result = await handler(
+      {},
+      {
+        proxyEnabled: true,
+        proxyHttpUrl: 'http://127.0.0.1:8080',
+      },
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(process.env.HTTP_PROXY).toBe('http://127.0.0.1:8080/');
+    expect(process.env.HTTPS_PROXY).toBe('http://127.0.0.1:8080/');
+    expect(getProxyUrlFromEnvironment()).toBe('http://127.0.0.1:8080/');
+
+    const dispatcher = await captureDispatcherForCodexUsage();
+    expect(dispatcher).toBeInstanceOf(MockProxyAgent);
+    expect((dispatcher as { proxyUrl: string }).proxyUrl).toBe('http://127.0.0.1:8080/');
+  });
+
+  it('rejects invalid proxy settings and keeps existing environment unchanged', async () => {
+    process.env.HTTP_PROXY = 'http://existing-proxy.local:9000/';
+    process.env.HTTPS_PROXY = 'http://existing-proxy.local:9000/';
+
+    const handler = getSettingsSaveHandler();
+    const result = await handler(
+      {},
+      {
+        proxyEnabled: true,
+        proxyHttpUrl: 'socks5://127.0.0.1:1080',
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid proxy settings.');
+    expect(process.env.HTTP_PROXY).toBe('http://existing-proxy.local:9000/');
+    expect(process.env.HTTPS_PROXY).toBe('http://existing-proxy.local:9000/');
+  });
+
+  it('disables proxy via settings save and clears runtime env behavior', async () => {
+    const handler = getSettingsSaveHandler();
+
+    const enableResult = await handler(
+      {},
+      {
+        proxyEnabled: true,
+        proxyHttpsUrl: 'http://127.0.0.1:9090',
+      },
+    );
+    expect(enableResult).toEqual({ success: true });
+    expect(getProxyUrlFromEnvironment()).toBe('http://127.0.0.1:9090/');
+
+    const disableResult = await handler({}, { proxyEnabled: false });
+    expect(disableResult).toEqual({ success: true });
+    expect(process.env.HTTP_PROXY).toBeUndefined();
+    expect(process.env.http_proxy).toBeUndefined();
+    expect(process.env.HTTPS_PROXY).toBeUndefined();
+    expect(process.env.https_proxy).toBeUndefined();
+    expect(getProxyUrlFromEnvironment()).toBeUndefined();
+
+    const dispatcher = await captureDispatcherForCodexUsage();
+    expect(dispatcher).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
+++ b/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
@@ -220,6 +220,26 @@ describe('settings:save proxy runtime integration', () => {
     expect(closeMock).toHaveBeenCalled();
   });
 
+  it('falls back to valid lowercase env proxy when uppercase env proxy is malformed', () => {
+    process.env.HTTP_PROXY = 'http:// bad uppercase';
+    process.env.http_proxy = 'http://lower-http-proxy.local:8080/';
+    process.env.HTTPS_PROXY = ':// malformed';
+    process.env.https_proxy = 'http://lower-https-proxy.local:9090/';
+
+    expect(getProxyUrlFromEnvironment('http://service.local')).toBe('http://lower-http-proxy.local:8080/');
+    expect(getProxyUrlFromEnvironment('https://service.local')).toBe('http://lower-https-proxy.local:9090/');
+
+    const httpAgent = getProxyAgentFromEnvironment('http://service.local');
+    const httpsAgent = getProxyAgentFromEnvironment('https://service.local');
+
+    expect(httpAgent).toBeInstanceOf(MockProxyAgent);
+    expect(httpAgent).toBeDefined();
+    expect((httpAgent as unknown as { proxyUrl: string }).proxyUrl).toBe('http://lower-http-proxy.local:8080/');
+    expect(httpsAgent).toBeInstanceOf(MockProxyAgent);
+    expect(httpsAgent).toBeDefined();
+    expect((httpsAgent as unknown as { proxyUrl: string }).proxyUrl).toBe('http://lower-https-proxy.local:9090/');
+  });
+
   it('rejects invalid proxy settings and keeps existing environment unchanged', async () => {
     settingsState.data = {
       proxyEnabled: true,

--- a/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
+++ b/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
@@ -7,13 +7,18 @@ const {
   mockedUndiciFetch,
   settingsState,
   MockProxyAgent,
+  closeMock,
 } = vi.hoisted(() => {
+  const closeSpy = vi.fn(async () => undefined);
+
   class ProxyAgentMock {
     readonly proxyUrl: string;
 
     constructor(proxyUrl: string) {
       this.proxyUrl = proxyUrl;
     }
+
+    close = closeSpy;
   }
 
   return {
@@ -23,6 +28,7 @@ const {
       path: '/tmp/settings-proxy-initial.json',
     },
     MockProxyAgent: ProxyAgentMock,
+    closeMock: closeSpy,
   };
 });
 
@@ -94,7 +100,7 @@ vi.mock('../../claude-profile/profile-storage', () => ({
 import { ipcMain } from 'electron';
 import { registerSettingsHandlers } from '../settings-handlers';
 import type { AgentManager } from '../../agent';
-import { getProxyUrlFromEnvironment } from '../../utils/runtime-proxy-config';
+import { getProxyAgentFromEnvironment, getProxyUrlFromEnvironment } from '../../utils/runtime-proxy-config';
 import { fetchCodexUsage } from '../../claude-profile/codex-usage-fetcher';
 
 const PROXY_ENV_KEYS = ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy'] as const;
@@ -163,10 +169,36 @@ describe('settings:save proxy runtime integration', () => {
     expect(process.env.HTTP_PROXY).toBe('http://127.0.0.1:8080/');
     expect(process.env.HTTPS_PROXY).toBe('http://127.0.0.1:8080/');
     expect(getProxyUrlFromEnvironment()).toBe('http://127.0.0.1:8080/');
+    expect(getProxyUrlFromEnvironment('http://example.local')).toBe('http://127.0.0.1:8080/');
+    expect(getProxyUrlFromEnvironment('https://example.local')).toBe('http://127.0.0.1:8080/');
 
     const dispatcher = await captureDispatcherForCodexUsage();
     expect(dispatcher).toBeInstanceOf(MockProxyAgent);
     expect((dispatcher as { proxyUrl: string }).proxyUrl).toBe('http://127.0.0.1:8080/');
+  });
+
+  it('selects scheme-specific proxy and reuses/disposes cached proxy agents', () => {
+    process.env.HTTP_PROXY = 'http://http-proxy.local:8080/';
+    process.env.HTTPS_PROXY = 'http://https-proxy.local:9090/';
+
+    const httpProxyUrl = getProxyUrlFromEnvironment('http://service.local/endpoint');
+    const httpsProxyUrl = getProxyUrlFromEnvironment('https://service.local/endpoint');
+
+    expect(httpProxyUrl).toBe('http://http-proxy.local:8080/');
+    expect(httpsProxyUrl).toBe('http://https-proxy.local:9090/');
+
+    const httpAgent = getProxyAgentFromEnvironment('http://service.local/endpoint');
+    const httpAgentAgain = getProxyAgentFromEnvironment('http://service.local/endpoint');
+    const httpsAgent = getProxyAgentFromEnvironment('https://service.local/endpoint');
+
+    expect(httpAgent).toBe(httpAgentAgain);
+    expect(httpAgent).not.toBe(httpsAgent);
+
+    process.env.HTTP_PROXY = 'http://new-http-proxy.local:7070/';
+    const refreshedHttpAgent = getProxyAgentFromEnvironment('http://service.local/endpoint');
+
+    expect(refreshedHttpAgent).not.toBe(httpAgent);
+    expect(closeMock).toHaveBeenCalled();
   });
 
   it('rejects invalid proxy settings and keeps existing environment unchanged', async () => {

--- a/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
+++ b/apps/desktop/src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts
@@ -221,6 +221,11 @@ describe('settings:save proxy runtime integration', () => {
   });
 
   it('rejects invalid proxy settings and keeps existing environment unchanged', async () => {
+    settingsState.data = {
+      proxyEnabled: true,
+      proxyHttpUrl: 'http://existing-proxy.local:9000/',
+    };
+
     process.env.HTTP_PROXY = 'http://existing-proxy.local:9000/';
     process.env.HTTPS_PROXY = 'http://existing-proxy.local:9000/';
 
@@ -239,6 +244,25 @@ describe('settings:save proxy runtime integration', () => {
     expect(process.env.HTTPS_PROXY).toBe('http://existing-proxy.local:9000/');
   });
 
+  it('allows unrelated settings save when persisted invalid proxy is unchanged', async () => {
+    settingsState.data = {
+      proxyEnabled: true,
+      proxyHttpUrl: 'socks5://127.0.0.1:1080',
+      proxyHttpsUrl: 'socks5://127.0.0.1:1080',
+      uiScale: 100,
+    };
+
+    process.env.HTTP_PROXY = 'http://existing-proxy.local:9000/';
+    process.env.HTTPS_PROXY = 'http://existing-proxy.local:9000/';
+
+    const handler = getSettingsSaveHandler();
+    const result = await handler({}, { uiScale: 110 });
+
+    expect(result).toEqual({ success: true });
+    expect(process.env.HTTP_PROXY).toBe('http://existing-proxy.local:9000/');
+    expect(process.env.HTTPS_PROXY).toBe('http://existing-proxy.local:9000/');
+  });
+
   it('disables proxy via settings save and clears runtime env behavior', async () => {
     const handler = getSettingsSaveHandler();
 
@@ -251,6 +275,12 @@ describe('settings:save proxy runtime integration', () => {
     );
     expect(enableResult).toEqual({ success: true });
     expect(getProxyUrlFromEnvironment()).toBe('http://127.0.0.1:9090/');
+
+    // Mimic persisted state for the second save call in this integration test harness.
+    settingsState.data = {
+      proxyEnabled: true,
+      proxyHttpsUrl: 'http://127.0.0.1:9090/',
+    };
 
     const disableResult = await handler({}, { proxyEnabled: false });
     expect(disableResult).toEqual({ success: true });

--- a/apps/desktop/src/main/ipc-handlers/settings-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers/settings-handlers.ts
@@ -25,6 +25,7 @@ import type { APIProfile } from '../../shared/types/profile';
 import type { ClaudeProfile } from '../../shared/types/agent';
 import { loadProfilesFile } from '../utils/profile-manager';
 import { loadProfileStore } from '../claude-profile/profile-storage';
+import { applyRuntimeProxyConfig, normalizeRuntimeProxyConfig } from '../utils/runtime-proxy-config';
 
 const settingsPath = getSettingsPath();
 
@@ -439,6 +440,20 @@ export function registerSettingsHandlers(
         const { providerAccounts: _pa, globalPriorityOrder: _gpo, ...safeSettings } = settings;
         const newSettings = { ...currentSettings, ...safeSettings };
 
+        const runtimeProxyConfig = normalizeRuntimeProxyConfig({
+          proxyEnabled: newSettings.proxyEnabled,
+          proxyHttpUrl: newSettings.proxyHttpUrl,
+          proxyHttpsUrl: newSettings.proxyHttpsUrl,
+        });
+
+        if (runtimeProxyConfig.state === 'invalid') {
+          const formattedErrors = runtimeProxyConfig.errors.map((entry) => entry.message).join(' ');
+          return {
+            success: false,
+            error: `Invalid proxy settings. ${formattedErrors}`,
+          };
+        }
+
         // Sync defaultModel when agent profile changes (#414)
         if (settings.selectedAgentProfile) {
           const profile = DEFAULT_AGENT_PROFILES.find(p => p.id === settings.selectedAgentProfile);
@@ -448,6 +463,20 @@ export function registerSettingsHandlers(
         }
 
         writeFileSync(settingsPath, JSON.stringify(newSettings, null, 2), 'utf-8');
+
+        // Apply runtime proxy env after successful persistence
+        const appliedProxyConfig = applyRuntimeProxyConfig({
+          proxyEnabled: newSettings.proxyEnabled,
+          proxyHttpUrl: newSettings.proxyHttpUrl,
+          proxyHttpsUrl: newSettings.proxyHttpsUrl,
+        });
+
+        if (appliedProxyConfig.state === 'invalid') {
+          console.error(
+            '[SETTINGS_SAVE] Proxy validation unexpectedly failed after pre-validation:',
+            appliedProxyConfig.errors.map((entry) => entry.message).join(' ')
+          );
+        }
 
         // Apply Python path if changed
         if (settings.pythonPath || settings.autoBuildPath) {

--- a/apps/desktop/src/main/ipc-handlers/settings-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers/settings-handlers.ts
@@ -439,19 +439,28 @@ export function registerSettingsHandlers(
         // to prevent the general settings save from clobbering them.
         const { providerAccounts: _pa, globalPriorityOrder: _gpo, ...safeSettings } = settings;
         const newSettings = { ...currentSettings, ...safeSettings };
+        const currentAppSettings = currentSettings as AppSettings;
+        const mergedAppSettings = newSettings as AppSettings;
 
-        const runtimeProxyConfig = normalizeRuntimeProxyConfig({
-          proxyEnabled: newSettings.proxyEnabled,
-          proxyHttpUrl: newSettings.proxyHttpUrl,
-          proxyHttpsUrl: newSettings.proxyHttpsUrl,
-        });
+        const proxyTupleChanged =
+          currentAppSettings.proxyEnabled !== mergedAppSettings.proxyEnabled ||
+          currentAppSettings.proxyHttpUrl !== mergedAppSettings.proxyHttpUrl ||
+          currentAppSettings.proxyHttpsUrl !== mergedAppSettings.proxyHttpsUrl;
 
-        if (runtimeProxyConfig.state === 'invalid') {
-          const formattedErrors = runtimeProxyConfig.errors.map((entry) => entry.message).join(' ');
-          return {
-            success: false,
-            error: `Invalid proxy settings. ${formattedErrors}`,
-          };
+        if (proxyTupleChanged) {
+          const runtimeProxyConfig = normalizeRuntimeProxyConfig({
+            proxyEnabled: newSettings.proxyEnabled,
+            proxyHttpUrl: newSettings.proxyHttpUrl,
+            proxyHttpsUrl: newSettings.proxyHttpsUrl,
+          });
+
+          if (runtimeProxyConfig.state === 'invalid') {
+            const formattedErrors = runtimeProxyConfig.errors.map((entry) => entry.message).join(' ');
+            return {
+              success: false,
+              error: `Invalid proxy settings. ${formattedErrors}`,
+            };
+          }
         }
 
         // Sync defaultModel when agent profile changes (#414)
@@ -465,17 +474,19 @@ export function registerSettingsHandlers(
         writeFileSync(settingsPath, JSON.stringify(newSettings, null, 2), 'utf-8');
 
         // Apply runtime proxy env after successful persistence
-        const appliedProxyConfig = applyRuntimeProxyConfig({
-          proxyEnabled: newSettings.proxyEnabled,
-          proxyHttpUrl: newSettings.proxyHttpUrl,
-          proxyHttpsUrl: newSettings.proxyHttpsUrl,
-        });
+        if (proxyTupleChanged) {
+          const appliedProxyConfig = applyRuntimeProxyConfig({
+            proxyEnabled: newSettings.proxyEnabled,
+            proxyHttpUrl: newSettings.proxyHttpUrl,
+            proxyHttpsUrl: newSettings.proxyHttpsUrl,
+          });
 
-        if (appliedProxyConfig.state === 'invalid') {
-          console.error(
-            '[SETTINGS_SAVE] Proxy validation unexpectedly failed after pre-validation:',
-            appliedProxyConfig.errors.map((entry) => entry.message).join(' ')
-          );
+          if (appliedProxyConfig.state === 'invalid') {
+            console.error(
+              '[SETTINGS_SAVE] Proxy validation unexpectedly failed after pre-validation:',
+              appliedProxyConfig.errors.map((entry) => entry.message).join(' ')
+            );
+          }
         }
 
         // Apply Python path if changed

--- a/apps/desktop/src/main/utils/proxy-fetch.ts
+++ b/apps/desktop/src/main/utils/proxy-fetch.ts
@@ -38,7 +38,13 @@ export async function fetchWithProxy(
     return fetch(input, init);
   }
 
-  const proxyAgent = getProxyAgentFromEnvironment();
+  const requestUrl =
+    typeof input === 'string' || input instanceof URL
+      ? input
+      : input instanceof Request
+        ? input.url
+        : undefined;
+  const proxyAgent = getProxyAgentFromEnvironment(requestUrl);
 
   if (proxyAgent) {
     const requestDerivedInit: RequestInit =
@@ -47,6 +53,13 @@ export async function fetchWithProxy(
             method: input.method,
             headers: input.headers,
             body: input.body ?? undefined,
+            cache: input.cache,
+            credentials: input.credentials,
+            integrity: input.integrity,
+            keepalive: input.keepalive,
+            mode: input.mode,
+            referrer: input.referrer,
+            referrerPolicy: input.referrerPolicy,
             redirect: input.redirect,
             signal: input.signal,
           }
@@ -54,7 +67,8 @@ export async function fetchWithProxy(
 
     const undiciInput: string | URL = input instanceof Request ? input.url : input;
 
-    // Use undici fetch with proxy dispatcher
+    // Intentional cast: undici fetch init extends standard RequestInit with dispatcher,
+    // but TypeScript sees mixed DOM/undici types in Electron main process.
     return undiciFetch(undiciInput, {
       ...requestDerivedInit,
       ...init,

--- a/apps/desktop/src/main/utils/proxy-fetch.ts
+++ b/apps/desktop/src/main/utils/proxy-fetch.ts
@@ -1,0 +1,53 @@
+/**
+ * HTTP Proxy Utility
+ *
+ * Provides proxy support for all outbound HTTP requests in the application.
+ * Reads proxy configuration from environment variables (HTTP_PROXY, HTTPS_PROXY).
+ */
+
+import { fetch as undiciFetch } from 'undici';
+import { getProxyAgentFromEnvironment } from './runtime-proxy-config';
+
+export { getProxyAgentFromEnvironment as getProxyAgent };
+
+function isMockedFetch(fetchFn: typeof globalThis.fetch): boolean {
+  const candidate = fetchFn as unknown as {
+    _isMockFunction?: boolean;
+    mock?: unknown;
+    getMockName?: () => string;
+  };
+
+  return (
+    candidate._isMockFunction === true ||
+    typeof candidate.getMockName === 'function' ||
+    candidate.mock !== undefined
+  );
+}
+
+/**
+ * Fetch with proxy support
+ * Automatically uses proxy if environment variables are set
+ */
+export async function fetchWithProxy(
+  input: string | URL | Request,
+  init?: RequestInit
+): Promise<Response> {
+  // Test compatibility: when fetch is mocked (Vitest/Jest), prefer native fetch
+  // so the mock can intercept calls even if host proxy env vars are present.
+  if (isMockedFetch(fetch)) {
+    return fetch(input, init);
+  }
+
+  const proxyAgent = getProxyAgentFromEnvironment();
+
+  if (proxyAgent) {
+    // Use undici fetch with proxy dispatcher
+    return undiciFetch(input as string, {
+      ...init,
+      dispatcher: proxyAgent,
+    } as any) as unknown as Response;
+  }
+
+  // Fallback to native fetch if no proxy configured
+  return fetch(input, init);
+}

--- a/apps/desktop/src/main/utils/proxy-fetch.ts
+++ b/apps/desktop/src/main/utils/proxy-fetch.ts
@@ -41,8 +41,22 @@ export async function fetchWithProxy(
   const proxyAgent = getProxyAgentFromEnvironment();
 
   if (proxyAgent) {
+    const requestDerivedInit: RequestInit =
+      input instanceof Request
+        ? {
+            method: input.method,
+            headers: input.headers,
+            body: input.body ?? undefined,
+            redirect: input.redirect,
+            signal: input.signal,
+          }
+        : {};
+
+    const undiciInput: string | URL = input instanceof Request ? input.url : input;
+
     // Use undici fetch with proxy dispatcher
-    return undiciFetch(input as string, {
+    return undiciFetch(undiciInput, {
+      ...requestDerivedInit,
       ...init,
       dispatcher: proxyAgent,
     } as any) as unknown as Response;

--- a/apps/desktop/src/main/utils/runtime-proxy-config.ts
+++ b/apps/desktop/src/main/utils/runtime-proxy-config.ts
@@ -36,6 +36,22 @@ function pruneStaleProxyAgents(activeProxyUrls: Set<string>): void {
   }
 }
 
+function normalizeEnvProxyUrl(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return undefined;
+    }
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+}
+
 function getRequestScheme(target?: string | URL): string | undefined {
   if (!target) {
     return undefined;
@@ -199,6 +215,7 @@ export function applyRuntimeProxyConfig(input: RuntimeProxyInput): RuntimeProxyC
     for (const key of HTTPS_PROXY_KEYS) {
       delete process.env[key];
     }
+    pruneStaleProxyAgents(new Set<string>());
     return normalized;
   }
 
@@ -206,6 +223,8 @@ export function applyRuntimeProxyConfig(input: RuntimeProxyInput): RuntimeProxyC
   process.env.http_proxy = normalized.httpProxyUrl;
   process.env.HTTPS_PROXY = normalized.httpsProxyUrl;
   process.env.https_proxy = normalized.httpsProxyUrl;
+
+  pruneStaleProxyAgents(new Set<string>([normalized.httpProxyUrl, normalized.httpsProxyUrl]));
 
   return normalized;
 }
@@ -215,8 +234,8 @@ export function applyRuntimeProxyConfig(input: RuntimeProxyInput): RuntimeProxyC
  */
 export function getProxyUrlFromEnvironment(target?: string | URL): string | undefined {
   const scheme = getRequestScheme(target);
-  const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
-  const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  const httpProxy = normalizeEnvProxyUrl(process.env.HTTP_PROXY || process.env.http_proxy);
+  const httpsProxy = normalizeEnvProxyUrl(process.env.HTTPS_PROXY || process.env.https_proxy);
 
   if (scheme === 'http:') {
     return httpProxy || httpsProxy;
@@ -237,8 +256,8 @@ export function getProxyUrlFromEnvironment(target?: string | URL): string | unde
  * Shared proxy agent creation for runtime network consumers.
  */
 export function getProxyAgentFromEnvironment(target?: string | URL): ProxyAgent | undefined {
-  const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
-  const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  const httpProxy = normalizeEnvProxyUrl(process.env.HTTP_PROXY || process.env.http_proxy);
+  const httpsProxy = normalizeEnvProxyUrl(process.env.HTTPS_PROXY || process.env.https_proxy);
 
   const activeProxyUrls = new Set<string>();
   if (httpProxy) {
@@ -260,7 +279,11 @@ export function getProxyAgentFromEnvironment(target?: string | URL): ProxyAgent 
     return cachedAgent;
   }
 
-  const agent = new ProxyAgent(proxyUrl);
-  proxyAgentCache.set(proxyUrl, agent);
-  return agent;
+  try {
+    const agent = new ProxyAgent(proxyUrl);
+    proxyAgentCache.set(proxyUrl, agent);
+    return agent;
+  } catch {
+    return undefined;
+  }
 }

--- a/apps/desktop/src/main/utils/runtime-proxy-config.ts
+++ b/apps/desktop/src/main/utils/runtime-proxy-config.ts
@@ -1,0 +1,187 @@
+import type { AppSettings } from '../../shared/types/settings';
+import { ProxyAgent } from 'undici';
+
+export const HTTP_PROXY_KEYS = ['HTTP_PROXY', 'http_proxy'] as const;
+export const HTTPS_PROXY_KEYS = ['HTTPS_PROXY', 'https_proxy'] as const;
+
+export type RuntimeProxyInput = Pick<
+  AppSettings,
+  'proxyEnabled' | 'proxyHttpUrl' | 'proxyHttpsUrl'
+>;
+
+export type ProxyConfigValidationErrorCode =
+  | 'MISSING_PROXY_URL'
+  | 'INVALID_HTTP_PROXY_URL'
+  | 'INVALID_HTTPS_PROXY_URL'
+  | 'UNSUPPORTED_HTTP_PROXY_PROTOCOL'
+  | 'UNSUPPORTED_HTTPS_PROXY_PROTOCOL';
+
+export interface ProxyConfigValidationError {
+  code: ProxyConfigValidationErrorCode;
+  message: string;
+}
+
+export interface RuntimeProxyEnabledConfig {
+  state: 'enabled';
+  httpProxyUrl: string;
+  httpsProxyUrl: string;
+}
+
+export interface RuntimeProxyDisabledConfig {
+  state: 'disabled';
+}
+
+export interface RuntimeProxyInvalidConfig {
+  state: 'invalid';
+  errors: ProxyConfigValidationError[];
+}
+
+export type RuntimeProxyConfigResult =
+  | RuntimeProxyEnabledConfig
+  | RuntimeProxyDisabledConfig
+  | RuntimeProxyInvalidConfig;
+
+function validateProxyUrl(
+  value: string | undefined,
+  kind: 'http' | 'https',
+): { normalized: string | null; errors: ProxyConfigValidationError[] } {
+  if (!value) {
+    return { normalized: null, errors: [] };
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { normalized: null, errors: [] };
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return {
+        normalized: null,
+        errors: [
+          {
+            code:
+              kind === 'http'
+                ? 'UNSUPPORTED_HTTP_PROXY_PROTOCOL'
+                : 'UNSUPPORTED_HTTPS_PROXY_PROTOCOL',
+            message: `Proxy URL for ${kind.toUpperCase()} must use http:// or https://.`,
+          },
+        ],
+      };
+    }
+
+    return {
+      normalized: parsed.toString(),
+      errors: [],
+    };
+  } catch {
+    return {
+      normalized: null,
+      errors: [
+        {
+          code: kind === 'http' ? 'INVALID_HTTP_PROXY_URL' : 'INVALID_HTTPS_PROXY_URL',
+          message: `Proxy URL for ${kind.toUpperCase()} is invalid.`,
+        },
+      ],
+    };
+  }
+}
+
+/**
+ * Normalize app settings into deterministic runtime proxy behavior.
+ *
+ * Rules:
+ * - Disabled -> runtime proxy disabled
+ * - Enabled + invalid URL(s) -> invalid result
+ * - Enabled + one URL provided -> use that URL for both HTTP and HTTPS
+ * - Enabled + both URLs provided -> preserve per-protocol values
+ */
+export function normalizeRuntimeProxyConfig(input: RuntimeProxyInput): RuntimeProxyConfigResult {
+  if (!input.proxyEnabled) {
+    return { state: 'disabled' };
+  }
+
+  const validatedHttp = validateProxyUrl(input.proxyHttpUrl, 'http');
+  const validatedHttps = validateProxyUrl(input.proxyHttpsUrl, 'https');
+  const errors = [...validatedHttp.errors, ...validatedHttps.errors];
+
+  if (errors.length > 0) {
+    return { state: 'invalid', errors };
+  }
+
+  const resolvedHttp = validatedHttp.normalized ?? validatedHttps.normalized;
+  const resolvedHttps = validatedHttps.normalized ?? validatedHttp.normalized;
+
+  if (!resolvedHttp || !resolvedHttps) {
+    return {
+      state: 'invalid',
+      errors: [
+        {
+          code: 'MISSING_PROXY_URL',
+          message: 'Proxy is enabled but no HTTP/HTTPS proxy URL is configured.',
+        },
+      ],
+    };
+  }
+
+  return {
+    state: 'enabled',
+    httpProxyUrl: resolvedHttp,
+    httpsProxyUrl: resolvedHttps,
+  };
+}
+
+/**
+ * Apply normalized proxy config to process env.
+ *
+ * If validation fails, process env is left unchanged.
+ */
+export function applyRuntimeProxyConfig(input: RuntimeProxyInput): RuntimeProxyConfigResult {
+  const normalized = normalizeRuntimeProxyConfig(input);
+
+  if (normalized.state === 'invalid') {
+    return normalized;
+  }
+
+  if (normalized.state === 'disabled') {
+    for (const key of HTTP_PROXY_KEYS) {
+      delete process.env[key];
+    }
+    for (const key of HTTPS_PROXY_KEYS) {
+      delete process.env[key];
+    }
+    return normalized;
+  }
+
+  process.env.HTTP_PROXY = normalized.httpProxyUrl;
+  process.env.http_proxy = normalized.httpProxyUrl;
+  process.env.HTTPS_PROXY = normalized.httpsProxyUrl;
+  process.env.https_proxy = normalized.httpsProxyUrl;
+
+  return normalized;
+}
+
+/**
+ * Shared env lookup order for runtime proxy consumers.
+ */
+export function getProxyUrlFromEnvironment(): string | undefined {
+  const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+  if (httpsProxy) {
+    return httpsProxy;
+  }
+
+  return process.env.HTTP_PROXY || process.env.http_proxy;
+}
+
+/**
+ * Shared proxy agent creation for runtime network consumers.
+ */
+export function getProxyAgentFromEnvironment(): ProxyAgent | undefined {
+  const proxyUrl = getProxyUrlFromEnvironment();
+  if (!proxyUrl) {
+    return undefined;
+  }
+
+  return new ProxyAgent(proxyUrl);
+}

--- a/apps/desktop/src/main/utils/runtime-proxy-config.ts
+++ b/apps/desktop/src/main/utils/runtime-proxy-config.ts
@@ -234,8 +234,10 @@ export function applyRuntimeProxyConfig(input: RuntimeProxyInput): RuntimeProxyC
  */
 export function getProxyUrlFromEnvironment(target?: string | URL): string | undefined {
   const scheme = getRequestScheme(target);
-  const httpProxy = normalizeEnvProxyUrl(process.env.HTTP_PROXY || process.env.http_proxy);
-  const httpsProxy = normalizeEnvProxyUrl(process.env.HTTPS_PROXY || process.env.https_proxy);
+  const httpProxy =
+    normalizeEnvProxyUrl(process.env.HTTP_PROXY) || normalizeEnvProxyUrl(process.env.http_proxy);
+  const httpsProxy =
+    normalizeEnvProxyUrl(process.env.HTTPS_PROXY) || normalizeEnvProxyUrl(process.env.https_proxy);
 
   if (scheme === 'http:') {
     return httpProxy || httpsProxy;
@@ -256,8 +258,10 @@ export function getProxyUrlFromEnvironment(target?: string | URL): string | unde
  * Shared proxy agent creation for runtime network consumers.
  */
 export function getProxyAgentFromEnvironment(target?: string | URL): ProxyAgent | undefined {
-  const httpProxy = normalizeEnvProxyUrl(process.env.HTTP_PROXY || process.env.http_proxy);
-  const httpsProxy = normalizeEnvProxyUrl(process.env.HTTPS_PROXY || process.env.https_proxy);
+  const httpProxy =
+    normalizeEnvProxyUrl(process.env.HTTP_PROXY) || normalizeEnvProxyUrl(process.env.http_proxy);
+  const httpsProxy =
+    normalizeEnvProxyUrl(process.env.HTTPS_PROXY) || normalizeEnvProxyUrl(process.env.https_proxy);
 
   const activeProxyUrls = new Set<string>();
   if (httpProxy) {

--- a/apps/desktop/src/main/utils/runtime-proxy-config.ts
+++ b/apps/desktop/src/main/utils/runtime-proxy-config.ts
@@ -9,7 +9,12 @@ const proxyAgentCache = new Map<string, ProxyAgent>();
 function tryDisposeAgent(agent: ProxyAgent): void {
   try {
     if (typeof (agent as unknown as { close?: () => Promise<void> }).close === 'function') {
-      void (agent as unknown as { close: () => Promise<void> }).close();
+      // undici `close()` performs a graceful drain (in-flight requests are not force-aborted).
+      void (agent as unknown as { close: () => Promise<void> })
+        .close()
+        .catch(() => {
+          // Fire-and-forget close should not surface unhandled rejection noise.
+        });
       return;
     }
 

--- a/apps/desktop/src/main/utils/runtime-proxy-config.ts
+++ b/apps/desktop/src/main/utils/runtime-proxy-config.ts
@@ -1,8 +1,51 @@
-import type { AppSettings } from '../../shared/types/settings';
+import type { AppSettings } from '@shared/types/settings';
 import { ProxyAgent } from 'undici';
 
 export const HTTP_PROXY_KEYS = ['HTTP_PROXY', 'http_proxy'] as const;
 export const HTTPS_PROXY_KEYS = ['HTTPS_PROXY', 'https_proxy'] as const;
+
+const proxyAgentCache = new Map<string, ProxyAgent>();
+
+function tryDisposeAgent(agent: ProxyAgent): void {
+  try {
+    if (typeof (agent as unknown as { close?: () => Promise<void> }).close === 'function') {
+      void (agent as unknown as { close: () => Promise<void> }).close();
+      return;
+    }
+
+    if (typeof (agent as unknown as { destroy?: () => void }).destroy === 'function') {
+      (agent as unknown as { destroy: () => void }).destroy();
+    }
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+function pruneStaleProxyAgents(activeProxyUrls: Set<string>): void {
+  for (const [url, agent] of proxyAgentCache.entries()) {
+    if (activeProxyUrls.has(url)) {
+      continue;
+    }
+    tryDisposeAgent(agent);
+    proxyAgentCache.delete(url);
+  }
+}
+
+function getRequestScheme(target?: string | URL): string | undefined {
+  if (!target) {
+    return undefined;
+  }
+
+  if (target instanceof URL) {
+    return target.protocol;
+  }
+
+  try {
+    return new URL(target).protocol;
+  } catch {
+    return undefined;
+  }
+}
 
 export type RuntimeProxyInput = Pick<
   AppSettings,
@@ -165,23 +208,54 @@ export function applyRuntimeProxyConfig(input: RuntimeProxyInput): RuntimeProxyC
 /**
  * Shared env lookup order for runtime proxy consumers.
  */
-export function getProxyUrlFromEnvironment(): string | undefined {
+export function getProxyUrlFromEnvironment(target?: string | URL): string | undefined {
+  const scheme = getRequestScheme(target);
+  const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
   const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+
+  if (scheme === 'http:') {
+    return httpProxy || httpsProxy;
+  }
+
+  if (scheme === 'https:') {
+    return httpsProxy || httpProxy;
+  }
+
   if (httpsProxy) {
     return httpsProxy;
   }
 
-  return process.env.HTTP_PROXY || process.env.http_proxy;
+  return httpProxy;
 }
 
 /**
  * Shared proxy agent creation for runtime network consumers.
  */
-export function getProxyAgentFromEnvironment(): ProxyAgent | undefined {
-  const proxyUrl = getProxyUrlFromEnvironment();
+export function getProxyAgentFromEnvironment(target?: string | URL): ProxyAgent | undefined {
+  const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+
+  const activeProxyUrls = new Set<string>();
+  if (httpProxy) {
+    activeProxyUrls.add(httpProxy);
+  }
+  if (httpsProxy) {
+    activeProxyUrls.add(httpsProxy);
+  }
+
+  pruneStaleProxyAgents(activeProxyUrls);
+
+  const proxyUrl = getProxyUrlFromEnvironment(target);
   if (!proxyUrl) {
     return undefined;
   }
 
-  return new ProxyAgent(proxyUrl);
+  const cachedAgent = proxyAgentCache.get(proxyUrl);
+  if (cachedAgent) {
+    return cachedAgent;
+  }
+
+  const agent = new ProxyAgent(proxyUrl);
+  proxyAgentCache.set(proxyUrl, agent);
+  return agent;
 }

--- a/apps/desktop/src/renderer/components/settings/AppSettings.tsx
+++ b/apps/desktop/src/renderer/components/settings/AppSettings.tsx
@@ -19,7 +19,8 @@ import {
   Code,
   Bug,
   Terminal,
-  Users
+  Users,
+  Network
 } from 'lucide-react';
 
 // GitLab icon component (lucide-react doesn't have one)
@@ -51,6 +52,7 @@ import { GeneralSettings } from './GeneralSettings';
 import { AdvancedSettings } from './AdvancedSettings';
 import { DevToolsSettings } from './DevToolsSettings';
 import { DebugSettings } from './DebugSettings';
+import { ProxySettings } from './ProxySettings';
 import { TerminalFontSettings } from './terminal-font-settings/TerminalFontSettings';
 import { AccountSettings } from './AccountSettings';
 import { ProjectSelector } from './ProjectSelector';
@@ -67,7 +69,7 @@ interface AppSettingsDialogProps {
 }
 
 // App-level settings sections
-export type AppSection = 'appearance' | 'display' | 'language' | 'devtools' | 'terminal-fonts' | 'agent' | 'paths' | 'integrations' | 'accounts' | 'api-profiles' | 'updates' | 'notifications' | 'debug';
+export type AppSection = 'appearance' | 'display' | 'language' | 'devtools' | 'terminal-fonts' | 'agent' | 'paths' | 'integrations' | 'accounts' | 'api-profiles' | 'updates' | 'notifications' | 'debug' | 'proxy';
 
 interface NavItemConfig<T extends string> {
   id: T;
@@ -82,6 +84,7 @@ const appNavItemsConfig: NavItemConfig<AppSection>[] = [
   { id: 'terminal-fonts', icon: Terminal },
   { id: 'agent', icon: Bot },
   { id: 'paths', icon: FolderOpen },
+  { id: 'proxy', icon: Network },
   { id: 'accounts', icon: Users },
   { id: 'updates', icon: Package },
   { id: 'notifications', icon: Bell },
@@ -194,6 +197,8 @@ export function AppSettingsDialog({ open, onOpenChange, initialSection, initialP
         return <GeneralSettings settings={settings} onSettingsChange={setSettings} section="agent" />;
       case 'paths':
         return <GeneralSettings settings={settings} onSettingsChange={setSettings} section="paths" />;
+      case 'proxy':
+        return <ProxySettings settings={settings} onSettingsChange={setSettings} />;
       case 'accounts':
         return <AccountSettings settings={settings} onSettingsChange={setSettings} isOpen={open} />;
       case 'updates':

--- a/apps/desktop/src/renderer/components/settings/AppSettings.tsx
+++ b/apps/desktop/src/renderer/components/settings/AppSettings.tsx
@@ -198,7 +198,7 @@ export function AppSettingsDialog({ open, onOpenChange, initialSection, initialP
       case 'paths':
         return <GeneralSettings settings={settings} onSettingsChange={setSettings} section="paths" />;
       case 'proxy':
-        return <ProxySettings settings={settings} onSettingsChange={setSettings} />;
+        return <ProxySettings settings={settings} onSettingsChange={setSettings} saveError={error} />;
       case 'accounts':
         return <AccountSettings settings={settings} onSettingsChange={setSettings} isOpen={open} />;
       case 'updates':

--- a/apps/desktop/src/renderer/components/settings/AppSettings.tsx
+++ b/apps/desktop/src/renderer/components/settings/AppSettings.tsx
@@ -69,7 +69,7 @@ interface AppSettingsDialogProps {
 }
 
 // App-level settings sections
-export type AppSection = 'appearance' | 'display' | 'language' | 'devtools' | 'terminal-fonts' | 'agent' | 'paths' | 'integrations' | 'accounts' | 'api-profiles' | 'updates' | 'notifications' | 'debug' | 'proxy';
+export type AppSection = 'appearance' | 'display' | 'language' | 'devtools' | 'terminal-fonts' | 'agent' | 'paths' | 'accounts' | 'updates' | 'notifications' | 'debug' | 'proxy';
 
 interface NavItemConfig<T extends string> {
   id: T;
@@ -208,7 +208,7 @@ export function AppSettingsDialog({ open, onOpenChange, initialSection, initialP
       case 'debug':
         return <DebugSettings />;
       default:
-        return null;
+        return ((unreachable: never) => unreachable)(appSection);
     }
   };
 

--- a/apps/desktop/src/renderer/components/settings/ProxySettings.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProxySettings.tsx
@@ -1,0 +1,87 @@
+import { useTranslation } from 'react-i18next';
+import { Label } from '../ui/label';
+import { Input } from '../ui/input';
+import { Switch } from '../ui/switch';
+import { SettingsSection } from './SettingsSection';
+import type { AppSettings } from '../../../shared/types';
+
+interface ProxySettingsProps {
+  settings: AppSettings;
+  onSettingsChange: (settings: AppSettings) => void;
+}
+
+export function ProxySettings({ settings, onSettingsChange }: ProxySettingsProps) {
+  const { t } = useTranslation('settings');
+
+  const handleToggle = (checked: boolean) => {
+    const newSettings = { ...settings, proxyEnabled: checked };
+    
+    if (checked) {
+      if (!newSettings.proxyHttpUrl) {
+        newSettings.proxyHttpUrl = 'http://127.0.0.1:7890';
+      }
+      if (!newSettings.proxyHttpsUrl) {
+        newSettings.proxyHttpsUrl = 'http://127.0.0.1:7890';
+      }
+    }
+    
+    onSettingsChange(newSettings);
+  };
+
+  return (
+    <SettingsSection
+      title={t('proxy.title')}
+      description={t('proxy.description')}
+    >
+      <div className="space-y-6">
+        <div className="flex items-center justify-between max-w-md">
+          <div className="space-y-1">
+            <Label htmlFor="proxyEnabled" className="text-sm font-medium text-foreground">
+              {t('proxy.enabled.label')}
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              {t('proxy.enabled.description')}
+            </p>
+          </div>
+          <Switch
+            id="proxyEnabled"
+            checked={settings.proxyEnabled || false}
+            onCheckedChange={handleToggle}
+          />
+        </div>
+
+        <div className="space-y-3">
+          <Label htmlFor="proxyHttpUrl" className="text-sm font-medium text-foreground">
+            {t('proxy.httpUrl.label')}
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            {t('proxy.httpUrl.description')}
+          </p>
+          <Input
+            id="proxyHttpUrl"
+            placeholder={t('proxy.httpUrl.placeholder')}
+            className="w-full max-w-lg"
+            value={settings.proxyHttpUrl || ''}
+            onChange={(e) => onSettingsChange({ ...settings, proxyHttpUrl: e.target.value })}
+          />
+        </div>
+
+        <div className="space-y-3">
+          <Label htmlFor="proxyHttpsUrl" className="text-sm font-medium text-foreground">
+            {t('proxy.httpsUrl.label')}
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            {t('proxy.httpsUrl.description')}
+          </p>
+          <Input
+            id="proxyHttpsUrl"
+            placeholder={t('proxy.httpsUrl.placeholder')}
+            className="w-full max-w-lg"
+            value={settings.proxyHttpsUrl || ''}
+            onChange={(e) => onSettingsChange({ ...settings, proxyHttpsUrl: e.target.value })}
+          />
+        </div>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/renderer/components/settings/ProxySettings.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProxySettings.tsx
@@ -3,15 +3,17 @@ import { Label } from '../ui/label';
 import { Input } from '../ui/input';
 import { Switch } from '../ui/switch';
 import { SettingsSection } from './SettingsSection';
-import type { AppSettings } from '../../../shared/types';
+import type { AppSettings } from '@shared/types';
 
 interface ProxySettingsProps {
   settings: AppSettings;
   onSettingsChange: (settings: AppSettings) => void;
+  saveError?: string | null;
 }
 
-export function ProxySettings({ settings, onSettingsChange }: ProxySettingsProps) {
+export function ProxySettings({ settings, onSettingsChange, saveError }: ProxySettingsProps) {
   const { t } = useTranslation('settings');
+  const proxySaveError = saveError && /proxy/i.test(saveError) ? saveError : null;
 
   const handleToggle = (checked: boolean) => {
     const newSettings = { ...settings, proxyEnabled: checked };
@@ -34,6 +36,12 @@ export function ProxySettings({ settings, onSettingsChange }: ProxySettingsProps
       description={t('proxy.description')}
     >
       <div className="space-y-6">
+        {proxySaveError && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-2 text-sm text-destructive">
+            {proxySaveError}
+          </div>
+        )}
+
         <div className="flex items-center justify-between max-w-md">
           <div className="space-y-1">
             <Label htmlFor="proxyEnabled" className="text-sm font-medium text-foreground">

--- a/apps/desktop/src/renderer/components/settings/__tests__/AppSettings.proxy-nav.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/AppSettings.proxy-nav.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import '../../../../shared/i18n';
+import '@shared/i18n';
 import { AppSettingsDialog } from '../AppSettings';
 
 const mockSaveSettings = vi.fn<() => Promise<boolean>>();
@@ -67,7 +67,13 @@ vi.mock('../GeneralSettings', () => ({ GeneralSettings: () => <div data-testid="
 vi.mock('../AdvancedSettings', () => ({ AdvancedSettings: () => <div data-testid="advanced-settings" /> }));
 vi.mock('../DevToolsSettings', () => ({ DevToolsSettings: () => <div data-testid="devtools-settings" /> }));
 vi.mock('../DebugSettings', () => ({ DebugSettings: () => <div data-testid="debug-settings" /> }));
-vi.mock('../ProxySettings', () => ({ ProxySettings: () => <div data-testid="proxy-settings" /> }));
+vi.mock('../ProxySettings', () => ({
+  ProxySettings: ({ saveError }: { saveError?: string | null }) => (
+    <div data-testid="proxy-settings">
+      {saveError && <div data-testid="proxy-section-error">{saveError}</div>}
+    </div>
+  ),
+}));
 vi.mock('../terminal-font-settings/TerminalFontSettings', () => ({
   TerminalFontSettings: () => <div data-testid="terminal-font-settings" />,
 }));
@@ -96,10 +102,16 @@ describe('AppSettingsDialog proxy navigation', () => {
 
   it('keeps dialog open and shows error when app save fails', async () => {
     const onOpenChange = vi.fn();
-    mockUseSettingsState.error = 'Proxy URL for HTTP is invalid.';
-    mockSaveSettings.mockResolvedValue(false);
+    mockSaveSettings.mockImplementation(async () => {
+      mockUseSettingsState.error = 'Proxy URL for HTTP is invalid.';
+      return false;
+    });
 
-    render(<AppSettingsDialog open onOpenChange={onOpenChange} initialSection="proxy" />);
+    const { rerender } = render(
+      <AppSettingsDialog open onOpenChange={onOpenChange} initialSection="proxy" />
+    );
+
+    expect(screen.queryByText('Proxy URL for HTTP is invalid.')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
 
@@ -107,8 +119,11 @@ describe('AppSettingsDialog proxy navigation', () => {
       expect(mockSaveSettings).toHaveBeenCalledTimes(1);
     });
 
+    rerender(<AppSettingsDialog open onOpenChange={onOpenChange} initialSection="proxy" />);
+
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
     expect(mockCommitTheme).not.toHaveBeenCalled();
-    expect(screen.getByText('Proxy URL for HTTP is invalid.')).toBeInTheDocument();
+    expect(screen.getAllByText('Proxy URL for HTTP is invalid.')).toHaveLength(2);
+    expect(screen.getByTestId('proxy-section-error')).toHaveTextContent('Proxy URL for HTTP is invalid.');
   });
 });

--- a/apps/desktop/src/renderer/components/settings/__tests__/AppSettings.proxy-nav.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/AppSettings.proxy-nav.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import '../../../../shared/i18n';
+import { AppSettingsDialog } from '../AppSettings';
+
+const mockSaveSettings = vi.fn<() => Promise<boolean>>();
+const mockCommitTheme = vi.fn();
+const mockRevertTheme = vi.fn();
+
+const mockUseSettingsState = {
+  settings: {
+    theme: 'dark',
+    colorTheme: 'default',
+    defaultModel: 'opus',
+    agentFramework: 'auto-claude',
+    proxyEnabled: false,
+    uiScale: 100,
+    logOrder: 'chronological',
+    gpuAcceleration: 'off',
+    notifications: {
+      onTaskComplete: true,
+      onTaskFailed: true,
+      onReviewNeeded: true,
+      sound: false,
+    },
+  },
+  setSettings: vi.fn(),
+  isSaving: false,
+  error: null as string | null,
+  saveSettings: mockSaveSettings,
+  revertTheme: mockRevertTheme,
+  commitTheme: mockCommitTheme,
+};
+
+vi.mock('../hooks/useSettings', () => ({
+  useSettings: () => mockUseSettingsState,
+}));
+
+vi.mock('../../../stores/project-store', () => {
+  const state = {
+    projects: [],
+    selectedProjectId: null,
+    selectProject: vi.fn(),
+  };
+
+  return {
+    useProjectStore: vi.fn((selector: (value: typeof state) => unknown) => selector(state)),
+  };
+});
+
+vi.mock('../ProjectSettingsContent', () => ({
+  ProjectSettingsContent: () => <div data-testid="project-settings-content" />,
+}));
+
+vi.mock('../ProjectSelector', () => ({
+  ProjectSelector: () => <div data-testid="project-selector" />,
+}));
+
+vi.mock('../ThemeSettings', () => ({ ThemeSettings: () => <div data-testid="theme-settings" /> }));
+vi.mock('../DisplaySettings', () => ({ DisplaySettings: () => <div data-testid="display-settings" /> }));
+vi.mock('../LanguageSettings', () => ({ LanguageSettings: () => <div data-testid="language-settings" /> }));
+vi.mock('../GeneralSettings', () => ({ GeneralSettings: () => <div data-testid="general-settings" /> }));
+vi.mock('../AdvancedSettings', () => ({ AdvancedSettings: () => <div data-testid="advanced-settings" /> }));
+vi.mock('../DevToolsSettings', () => ({ DevToolsSettings: () => <div data-testid="devtools-settings" /> }));
+vi.mock('../DebugSettings', () => ({ DebugSettings: () => <div data-testid="debug-settings" /> }));
+vi.mock('../ProxySettings', () => ({ ProxySettings: () => <div data-testid="proxy-settings" /> }));
+vi.mock('../terminal-font-settings/TerminalFontSettings', () => ({
+  TerminalFontSettings: () => <div data-testid="terminal-font-settings" />,
+}));
+vi.mock('../AccountSettings', () => ({ AccountSettings: () => <div data-testid="account-settings" /> }));
+
+describe('AppSettingsDialog proxy navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSettingsState.error = null;
+    mockUseSettingsState.isSaving = false;
+    mockSaveSettings.mockResolvedValue(true);
+    (window as unknown as { electronAPI: { getAppVersion: () => Promise<string> } }).electronAPI = {
+      getAppVersion: vi.fn().mockResolvedValue('2.8.0-test'),
+    };
+  });
+
+  it('shows the Proxy navigation item with its Network icon', () => {
+    render(<AppSettingsDialog open onOpenChange={vi.fn()} initialSection="appearance" />);
+
+    const proxyNavButton = screen.getByRole('button', { name: /proxy global network proxy settings/i });
+    expect(proxyNavButton).toBeInTheDocument();
+
+    const networkIcon = proxyNavButton.querySelector('svg.lucide-network');
+    expect(networkIcon).toBeInTheDocument();
+  });
+
+  it('keeps dialog open and shows error when app save fails', async () => {
+    const onOpenChange = vi.fn();
+    mockUseSettingsState.error = 'Proxy URL for HTTP is invalid.';
+    mockSaveSettings.mockResolvedValue(false);
+
+    render(<AppSettingsDialog open onOpenChange={onOpenChange} initialSection="proxy" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(mockCommitTheme).not.toHaveBeenCalled();
+    expect(screen.getByText('Proxy URL for HTTP is invalid.')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/__tests__/ProxySettings.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ProxySettings.test.tsx
@@ -4,9 +4,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import '../../../../shared/i18n';
+import '@shared/i18n';
 import { ProxySettings } from '../ProxySettings';
-import type { AppSettings } from '../../../../shared/types';
+import type { AppSettings } from '@shared/types';
 
 const defaultSettings: AppSettings = {
   theme: 'dark',
@@ -69,5 +69,29 @@ describe('ProxySettings', () => {
         proxyHttpsUrl: 'http://127.0.0.1:7890',
       }),
     );
+  });
+
+  it('shows proxy-related save error inside the proxy section', () => {
+    render(
+      <ProxySettings
+        settings={defaultSettings}
+        onSettingsChange={onSettingsChange}
+        saveError="Invalid proxy settings."
+      />,
+    );
+
+    expect(screen.getByText('Invalid proxy settings.')).toBeInTheDocument();
+  });
+
+  it('does not show non-proxy save errors inside the proxy section', () => {
+    render(
+      <ProxySettings
+        settings={defaultSettings}
+        onSettingsChange={onSettingsChange}
+        saveError="Theme update failed"
+      />,
+    );
+
+    expect(screen.queryByText('Theme update failed')).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/components/settings/__tests__/ProxySettings.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ProxySettings.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import '../../../../shared/i18n';
+import { ProxySettings } from '../ProxySettings';
+import type { AppSettings } from '../../../../shared/types';
+
+const defaultSettings: AppSettings = {
+  theme: 'dark',
+  colorTheme: 'default',
+  defaultModel: 'opus',
+  agentFramework: 'auto-claude',
+  proxyEnabled: false,
+  uiScale: 100,
+  logOrder: 'chronological',
+  gpuAcceleration: 'off',
+  notifications: {
+    onTaskComplete: true,
+    onTaskFailed: true,
+    onReviewNeeded: true,
+    sound: false,
+  },
+} as AppSettings;
+
+describe('ProxySettings', () => {
+  let onSettingsChange: (settings: AppSettings) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onSettingsChange = vi.fn();
+  });
+
+  it('keeps proxy toggle defaulted to false', () => {
+    const settingsWithoutProxyEnabled = {
+      ...defaultSettings,
+      proxyEnabled: undefined,
+    } as AppSettings;
+
+    render(
+      <ProxySettings settings={settingsWithoutProxyEnabled} onSettingsChange={onSettingsChange} />,
+    );
+
+    const proxyToggle = screen.getByRole('switch', { name: 'Enable Proxy' });
+    expect(proxyToggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('auto-prefills default proxy URLs when enabling proxy with empty values', () => {
+    render(
+      <ProxySettings
+        settings={{
+          ...defaultSettings,
+          proxyEnabled: false,
+          proxyHttpUrl: '',
+          proxyHttpsUrl: '',
+        }}
+        onSettingsChange={onSettingsChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Enable Proxy' }));
+
+    expect(onSettingsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxyEnabled: true,
+        proxyHttpUrl: 'http://127.0.0.1:7890',
+        proxyHttpsUrl: 'http://127.0.0.1:7890',
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/index.ts
+++ b/apps/desktop/src/renderer/components/settings/index.ts
@@ -8,6 +8,7 @@ export { ThemeSettings } from './ThemeSettings';
 export { ThemeSelector } from './ThemeSelector';
 export { GeneralSettings } from './GeneralSettings';
 export { AdvancedSettings } from './AdvancedSettings';
+export { ProxySettings } from './ProxySettings';
 export { SettingsSection } from './SettingsSection';
 export { useSettings } from './hooks/useSettings';
 export { MultiProviderModelSelect } from './MultiProviderModelSelect';

--- a/apps/desktop/src/renderer/stores/settings-store.ts
+++ b/apps/desktop/src/renderer/stores/settings-store.ts
@@ -506,15 +506,19 @@ export async function loadSettings(): Promise<void> {
  */
 export async function saveSettings(updates: Partial<AppSettings>): Promise<boolean> {
   const store = useSettingsStore.getState();
+  store.setError(null);
 
   try {
     const result = await window.electronAPI.saveSettings(updates);
     if (result.success) {
       store.updateSettings(updates);
+      store.setError(null);
       return true;
     }
+    store.setError(result.error || 'Failed to save settings');
     return false;
-  } catch {
+  } catch (error) {
+    store.setError(error instanceof Error ? error.message : 'Failed to save settings');
     return false;
   }
 }

--- a/apps/desktop/src/shared/constants/config.ts
+++ b/apps/desktop/src/shared/constants/config.ts
@@ -33,6 +33,7 @@ export const DEFAULT_APP_SETTINGS = {
   colorTheme: 'default' as const,
   defaultModel: 'opus',
   agentFramework: 'auto-claude',
+  proxyEnabled: false,
   pythonPath: undefined as string | undefined,
   gitPath: undefined as string | undefined,
   githubCLIPath: undefined as string | undefined,

--- a/apps/desktop/src/shared/i18n/locales/en/settings.json
+++ b/apps/desktop/src/shared/i18n/locales/en/settings.json
@@ -48,6 +48,10 @@
     "terminal-fonts": {
       "title": "Terminal Fonts",
       "description": "Customize terminal font appearance"
+    },
+    "proxy": {
+      "title": "Proxy",
+      "description": "Global network proxy settings"
     }
   },
   "apiProfiles": {
@@ -301,6 +305,28 @@
       "label": "YOLO Mode",
       "description": "Start Claude with --dangerously-skip-permissions flag, bypassing all safety prompts. Use with extreme caution.",
       "warning": "This mode bypasses Claude's permission system. Only enable if you fully trust the code being executed."
+    }
+  },
+  "proxy": {
+    "title": "Proxy Settings",
+    "description": "Configure global proxy settings for outbound network requests",
+    "enabled": {
+      "label": "Enable Proxy",
+      "description": "Route all outbound network requests through a proxy server"
+    },
+    "httpUrl": {
+      "label": "HTTP Proxy URL",
+      "description": "Proxy server URL for HTTP requests",
+      "placeholder": "http://127.0.0.1:7890"
+    },
+    "httpsUrl": {
+      "label": "HTTPS Proxy URL",
+      "description": "Proxy server URL for HTTPS requests",
+      "placeholder": "http://127.0.0.1:7890"
+    },
+    "validation": {
+      "invalidUrl": "Invalid URL format (must be http:// or https://)",
+      "requiredWhenEnabled": "URL is required when proxy is enabled"
     }
   },
   "updates": {

--- a/apps/desktop/src/shared/i18n/locales/fr/settings.json
+++ b/apps/desktop/src/shared/i18n/locales/fr/settings.json
@@ -48,6 +48,10 @@
     "terminal-fonts": {
       "title": "Polices de terminal",
       "description": "Personnaliser l'apparence des polices de terminal"
+    },
+    "proxy": {
+      "title": "Proxy",
+      "description": "Paramètres de proxy réseau globaux"
     }
   },
   "apiProfiles": {
@@ -301,6 +305,28 @@
       "label": "Mode YOLO",
       "description": "Démarrer Claude avec le flag --dangerously-skip-permissions, contournant toutes les invites de sécurité. À utiliser avec une extrême prudence.",
       "warning": "Ce mode contourne le système de permissions de Claude. N'activez que si vous faites entièrement confiance au code exécuté."
+    }
+  },
+  "proxy": {
+    "title": "Paramètres du proxy",
+    "description": "Configurer les paramètres de proxy globaux pour les requêtes réseau sortantes",
+    "enabled": {
+      "label": "Activer le proxy",
+      "description": "Acheminer toutes les requêtes réseau sortantes via un serveur proxy"
+    },
+    "httpUrl": {
+      "label": "URL du proxy HTTP",
+      "description": "URL du serveur proxy pour les requêtes HTTP",
+      "placeholder": "http://127.0.0.1:7890"
+    },
+    "httpsUrl": {
+      "label": "URL du proxy HTTPS",
+      "description": "URL du serveur proxy pour les requêtes HTTPS",
+      "placeholder": "http://127.0.0.1:7890"
+    },
+    "validation": {
+      "invalidUrl": "Format d'URL invalide (doit être http:// ou https://)",
+      "requiredWhenEnabled": "L'URL est requise lorsque le proxy est activé"
     }
   },
   "updates": {

--- a/apps/desktop/src/shared/types/settings.ts
+++ b/apps/desktop/src/shared/types/settings.ts
@@ -264,6 +264,9 @@ export interface AppSettings {
   colorTheme?: ColorTheme;
   defaultModel: string;
   agentFramework: string;
+  proxyEnabled?: boolean;
+  proxyHttpUrl?: string;
+  proxyHttpsUrl?: string;
   pythonPath?: string;
   gitPath?: string;
   githubCLIPath?: string;
@@ -362,5 +365,4 @@ export interface AppSettings {
 
 // GPU acceleration mode for terminal WebGL rendering
 export type GpuAcceleration = 'auto' | 'on' | 'off';
-
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "remark-gfm": "^4.0.1",
         "semver": "^7.7.4",
         "tailwind-merge": "^3.5.0",
+        "undici": "^8.0.2",
         "uuid": "^13.0.0",
         "web-tree-sitter": "^0.26.7",
         "xstate": "^5.28.0",
@@ -14872,6 +14873,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
+      "integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
## Summary
- add a top-level Proxy section in App Settings with icon parity, HTTP/HTTPS full URL fields, default-disabled behavior, and enable-time auto-fill to `http://127.0.0.1:7890`
- persist proxy settings, validate URLs on save, and apply/remove runtime proxy env state both on save and app startup via centralized runtime proxy utility
- integrate proxy-aware fetch/agent usage for main-process outbound flows and add regression/integration tests for UI behavior, save failure handling, and runtime proxy validation

## Test plan
- [x] `cd apps/desktop && npm run typecheck`
- [x] `cd apps/desktop && npm test -- src/renderer/components/settings/__tests__/AppSettings.proxy-nav.test.tsx src/renderer/components/settings/__tests__/ProxySettings.test.tsx`
- [x] `cd apps/desktop && npm test -- src/main/ipc-handlers/__tests__/settings-proxy-runtime.integration.test.ts`
- [x] `cd apps/desktop && npm run build`

## AI Disclosure
- [x] This PR includes AI-generated code (Claude Code / Codex)
- [x] Fully tested -- all tests pass, manually verified behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Proxy settings panel (toggle + separate HTTP/HTTPS URL fields, default off). App applies proxy settings at startup and when saved; enabling auto-populates sensible default URLs.

* **Bug Fixes**
  * Saving validates proxy inputs, rejects invalid values (preventing persistence), surfaces clear error messages, and disabling clears proxy environment settings.

* **Tests**
  * Added unit and integration tests covering UI, save/validation, runtime application, and network routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->