### PR TITLE
fix: write orchestrator failure reasons to task_logs.json (#1978)

### DIFF
--- a/apps/desktop/src/main/ai/agent/worker.ts
+++ b/apps/desktop/src/main/ai/agent/worker.ts
@@ -678,6 +678,18 @@ async function runBuildOrchestrator(
   // state that doesn't map to a log phase. In that case, close whichever log phase
   // is still marked 'active' so the UI shows "Complete" instead of "Running".
   if (logWriter) {
+    // Write the failure reason to the log before closing the phase so the
+    // Logs tab shows a visible error entry. outcome.error originates from
+    // build-level validation failures that never flow through onEvent.
+    if (!outcome.success && outcome.error) {
+      const data = logWriter.getData();
+      const activePhase = (['validation', 'coding', 'planning'] as const).find(
+        (p) => data.phases[p]?.status === 'active'
+      );
+      const errorPhase: 'qa' | 'coding' | 'planning' =
+        activePhase === 'validation' ? 'qa' : (activePhase ?? 'planning');
+      logWriter.logText(outcome.error, errorPhase, 'error');
+    }
     const finalLogPhase = mapExecutionPhaseToPhase(outcome.finalPhase);
     if (finalLogPhase) {
       logWriter.endPhase(finalLogPhase, outcome.success);
@@ -946,6 +958,14 @@ async function runSpecOrchestrator(
 
   // Ensure any still-active log phase is closed and flushed
   if (logWriter) {
+    // Write the failure reason to the log before closing the phase so the
+    // Logs tab shows a visible error entry instead of just a red badge with
+    // no message. outcome.error comes from spec phase validation failures
+    // (e.g. "expected files not created: context.json") which never flow
+    // through the onEvent stream callback.
+    if (!outcome.success && outcome.error) {
+      logWriter.logText(outcome.error, 'spec', 'error');
+    }
     const data = logWriter.getData();
     // toLogPhase('spec') maps to 'planning' in the log writer
     if (data.phases.planning?.status === 'active') {


### PR DESCRIPTION
Fixes #1978

## Problem

After the Vercel AI SDK v6 migration, planning phase errors show as red "error" badges in the Logs tab with completely empty detail messages. When `SpecOrchestrator` or `BuildOrchestrator` fails (e.g., "Model completed session without making any tool calls — expected files not created: context.json"), the error string in `outcome.error` was emitted as a `PLANNING_FAILED` task event but never written to `task_logs.json`.

## Solution

Explicitly write `outcome.error` to the log writer as an `error` entry before closing the active phase, in both `runSpecOrchestrator` and `runBuildOrchestrator` in `worker.ts`. These orchestrator-level failures don't flow through the `onEvent` stream callback, so they need to be written at the point where `outcome.error` is first available.

## Testing

- Create a task where planning fails (e.g., using a model that doesn't call tools)
- Check the Logs tab — error entries should now show the actual failure message instead of blank text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging in the AI agent to ensure error messages from build and specification workflows are properly captured and recorded in task logs, providing better visibility into agent operation failures and supporting improved troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->