### PR TITLE
fix: prevent infinite PTY recreation loop on terminal natural exit

### DIFF
--- a/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
+++ b/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
@@ -113,8 +113,9 @@ describe('usePtyProcess — exited-terminal guard (#fix/terminal-exit-pty-recrea
     });
 
     expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
-    // The recreation path resets status from 'exited' → 'idle' before creating the PTY
-    expect(mockSetTerminalStatus).toHaveBeenCalledWith('term-1', 'idle');
+    // The recreation path must reset status from 'exited' → 'idle' BEFORE creating the PTY,
+    // otherwise the exited-guard above would short-circuit creation.
+    expect(mockSetTerminalStatus).toHaveBeenNthCalledWith(1, 'term-1', 'idle');
   });
 
   it('calls createTerminal when terminal status is idle', async () => {

--- a/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
+++ b/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
@@ -32,7 +32,10 @@ Object.defineProperty(window, 'electronAPI', {
 
 /** Mutable terminal state controlled per test */
 let mockTerminalStatus: TerminalStatus = 'idle';
-let mockIsRestored: boolean = false;
+let mockIsRestored = false;
+
+const mockSetTerminalStatus = vi.fn();
+const mockUpdateTerminal = vi.fn();
 
 vi.mock('../../../stores/terminal-store', () => ({
   useTerminalStore: Object.assign(vi.fn(), {
@@ -44,14 +47,17 @@ vi.mock('../../../stores/terminal-store', () => ({
           isRestored: mockIsRestored,
           isCLIMode: false,
           cwd: '/test',
+          title: 'Terminal 1',
+          claudeSessionId: undefined,
+          worktreeConfig: undefined,
+          createdAt: new Date('2024-01-01T00:00:00Z'),
         },
       ],
       setTerminalStatus: mockSetTerminalStatus,
+      updateTerminal: mockUpdateTerminal,
     }),
   }),
 }));
-
-const mockSetTerminalStatus = vi.fn();
 
 const DEFAULT_OPTIONS = {
   terminalId: 'term-1',
@@ -69,6 +75,7 @@ describe('usePtyProcess — exited-terminal guard (#fix/terminal-exit-pty-recrea
     mockIsRestored = false;
     mockCreateTerminal.mockResolvedValue({ success: true });
     mockDestroyTerminal.mockResolvedValue({ success: true });
+    mockRestoreTerminalSession.mockResolvedValue({ success: true, data: { success: true } });
   });
 
   it('does not call createTerminal when terminal status is exited (natural exit)', async () => {
@@ -123,7 +130,7 @@ describe('usePtyProcess — exited-terminal guard (#fix/terminal-exit-pty-recrea
     );
   });
 
-  it('calls createTerminal when terminal status is running (e.g. reconnect)', async () => {
+  it('calls createTerminal (new-terminal branch) when status is running and isRestored is false', async () => {
     mockTerminalStatus = 'running';
 
     await act(async () => {
@@ -131,6 +138,20 @@ describe('usePtyProcess — exited-terminal guard (#fix/terminal-exit-pty-recrea
     });
 
     expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    expect(mockRestoreTerminalSession).not.toHaveBeenCalled();
+  });
+
+  it('calls restoreTerminalSession (restore branch) when status is running and isRestored is true', async () => {
+    mockTerminalStatus = 'running';
+    mockIsRestored = true;
+
+    await act(async () => {
+      renderHook(() => usePtyProcess(DEFAULT_OPTIONS));
+    });
+
+    expect(mockRestoreTerminalSession).toHaveBeenCalledTimes(1);
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+    expect(mockUpdateTerminal).toHaveBeenCalledWith('term-1', { isRestored: false });
   });
 
   it('does not call createTerminal when skipCreation is true', async () => {

--- a/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
+++ b/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
@@ -34,9 +34,6 @@ Object.defineProperty(window, 'electronAPI', {
 let mockTerminalStatus: TerminalStatus = 'idle';
 let mockIsRestored: boolean = false;
 
-const mockSetTerminalStatus = vi.fn();
-const mockGetTerminal = vi.fn();
-
 vi.mock('../../../stores/terminal-store', () => ({
   useTerminalStore: Object.assign(vi.fn(), {
     getState: () => ({
@@ -50,10 +47,11 @@ vi.mock('../../../stores/terminal-store', () => ({
         },
       ],
       setTerminalStatus: mockSetTerminalStatus,
-      getTerminal: mockGetTerminal,
     }),
   }),
 }));
+
+const mockSetTerminalStatus = vi.fn();
 
 const DEFAULT_OPTIONS = {
   terminalId: 'term-1',

--- a/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
+++ b/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Unit tests for usePtyProcess
+ *
+ * Covers the guard that prevents PTY creation when a terminal has exited
+ * naturally (status === 'exited'), which was causing an infinite
+ * mount → create PTY → unmount → mount loop via the TerminalGrid
+ * pendingCleanup grace-period mechanism.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRef } from 'react';
+import { usePtyProcess } from '../usePtyProcess';
+
+const mockCreateTerminal = vi.fn();
+const mockDestroyTerminal = vi.fn();
+const mockRestoreTerminalSession = vi.fn();
+
+vi.stubGlobal('window', {
+  electronAPI: {
+    createTerminal: mockCreateTerminal,
+    destroyTerminal: mockDestroyTerminal,
+    restoreTerminalSession: mockRestoreTerminalSession,
+  },
+});
+
+/** Mutable terminal state controlled per test */
+let mockTerminalStatus: string = 'idle';
+let mockIsRestored: boolean = false;
+
+const mockSetTerminalStatus = vi.fn();
+const mockGetTerminal = vi.fn();
+
+vi.mock('../../../stores/terminal-store', () => ({
+  useTerminalStore: Object.assign(vi.fn(), {
+    getState: () => ({
+      terminals: [
+        {
+          id: 'term-1',
+          status: mockTerminalStatus,
+          isRestored: mockIsRestored,
+          isCLIMode: false,
+          cwd: '/test',
+        },
+      ],
+      setTerminalStatus: mockSetTerminalStatus,
+      getTerminal: mockGetTerminal,
+    }),
+  }),
+}));
+
+const DEFAULT_OPTIONS = {
+  terminalId: 'term-1',
+  cwd: '/test',
+  projectPath: '/test',
+  cols: 80,
+  rows: 24,
+  skipCreation: false,
+} as const;
+
+describe('usePtyProcess — exited-terminal guard (#fix/terminal-exit-pty-recreation-loop)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTerminalStatus = 'idle';
+    mockIsRestored = false;
+    mockCreateTerminal.mockResolvedValue({ success: true });
+    mockDestroyTerminal.mockResolvedValue({ success: true });
+  });
+
+  it('does not call createTerminal when terminal status is exited (natural exit)', async () => {
+    mockTerminalStatus = 'exited';
+
+    await act(async () => {
+      renderHook(() => usePtyProcess(DEFAULT_OPTIONS));
+    });
+
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+  });
+
+  it('does not call createTerminal on repeated mounts when status remains exited', async () => {
+    mockTerminalStatus = 'exited';
+
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        const { unmount } = renderHook(() => usePtyProcess(DEFAULT_OPTIONS));
+        unmount();
+      });
+    }
+
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+  });
+
+  it('allows PTY creation when status is exited but isRecreatingRef is true (worktree switch)', async () => {
+    mockTerminalStatus = 'exited';
+
+    await act(async () => {
+      renderHook(() => {
+        const isRecreatingRef = useRef(true);
+        return usePtyProcess({ ...DEFAULT_OPTIONS, isRecreatingRef });
+      });
+    });
+
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls createTerminal when terminal status is idle', async () => {
+    mockTerminalStatus = 'idle';
+
+    await act(async () => {
+      renderHook(() => usePtyProcess(DEFAULT_OPTIONS));
+    });
+
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    expect(mockCreateTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'term-1', cwd: '/test', cols: 80, rows: 24 }),
+    );
+  });
+
+  it('calls createTerminal when terminal status is running (e.g. reconnect)', async () => {
+    mockTerminalStatus = 'running';
+
+    await act(async () => {
+      renderHook(() => usePtyProcess(DEFAULT_OPTIONS));
+    });
+
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call createTerminal when skipCreation is true', async () => {
+    mockTerminalStatus = 'idle';
+
+    await act(async () => {
+      renderHook(() => usePtyProcess({ ...DEFAULT_OPTIONS, skipCreation: true }));
+    });
+
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
+++ b/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
@@ -92,6 +92,7 @@ describe('usePtyProcess — exited-terminal guard (#fix/terminal-exit-pty-recrea
     }
 
     expect(mockCreateTerminal).not.toHaveBeenCalled();
+    expect(mockDestroyTerminal).not.toHaveBeenCalled();
   });
 
   it('allows PTY creation when status is exited but isRecreatingRef is true (worktree switch)', async () => {

--- a/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
+++ b/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
@@ -20,8 +20,10 @@ const mockCreateTerminal = vi.fn();
 const mockDestroyTerminal = vi.fn();
 const mockRestoreTerminalSession = vi.fn();
 
-vi.stubGlobal('window', {
-  electronAPI: {
+Object.defineProperty(window, 'electronAPI', {
+  configurable: true,
+  writable: true,
+  value: {
     createTerminal: mockCreateTerminal,
     destroyTerminal: mockDestroyTerminal,
     restoreTerminalSession: mockRestoreTerminalSession,

--- a/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
+++ b/apps/desktop/src/renderer/components/terminal/__tests__/usePtyProcess.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useRef } from 'react';
 import { usePtyProcess } from '../usePtyProcess';
+import type { TerminalStatus } from '../../../stores/terminal-store';
 
 const mockCreateTerminal = vi.fn();
 const mockDestroyTerminal = vi.fn();
@@ -28,7 +29,7 @@ vi.stubGlobal('window', {
 });
 
 /** Mutable terminal state controlled per test */
-let mockTerminalStatus: string = 'idle';
+let mockTerminalStatus: TerminalStatus = 'idle';
 let mockIsRestored: boolean = false;
 
 const mockSetTerminalStatus = vi.fn();
@@ -104,6 +105,8 @@ describe('usePtyProcess — exited-terminal guard (#fix/terminal-exit-pty-recrea
     });
 
     expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    // The recreation path resets status from 'exited' → 'idle' before creating the PTY
+    expect(mockSetTerminalStatus).toHaveBeenCalledWith('term-1', 'idle');
   });
 
   it('calls createTerminal when terminal status is idle', async () => {

--- a/apps/desktop/src/renderer/components/terminal/usePtyProcess.ts
+++ b/apps/desktop/src/renderer/components/terminal/usePtyProcess.ts
@@ -152,15 +152,16 @@ export function usePtyProcess({
     const alreadyRunning = terminalState?.status === 'running' || terminalState?.status === 'claude-active';
     const isRestored = terminalState?.isRestored;
 
-    // Do not create a new PTY for a terminal that has exited naturally.
+    // Do not create a new PTY when the terminal has exited naturally or is no longer
+    // in the store (removed while the component was still mounted).
     // When the shell exits (e.g. user types "exit"), the terminal is kept in the DOM
     // for a short grace period (pendingCleanup). During that period the component can
     // mount/unmount rapidly — without this guard each mount would spin up a new PTY,
     // causing an infinite mount → create PTY → unmount → mount loop.
     // Deliberate recreation (worktree switch) sets isRecreatingRef before exiting, so
     // it is excluded from this guard.
-    if (terminalState?.status === 'exited' && !isRecreatingRef?.current) {
-      debugLog(`[usePtyProcess] Skipping PTY creation for terminal: ${terminalId} - terminal has exited naturally (status=exited)`);
+    if (!terminalState || (terminalState.status === 'exited' && !isRecreatingRef?.current)) {
+      debugLog(`[usePtyProcess] Skipping PTY creation for terminal: ${terminalId} - terminal has exited naturally or is not in store (status=${terminalState?.status})`);
       return;
     }
 

--- a/apps/desktop/src/renderer/components/terminal/usePtyProcess.ts
+++ b/apps/desktop/src/renderer/components/terminal/usePtyProcess.ts
@@ -23,6 +23,18 @@ interface UsePtyProcessOptions {
   onError?: (error: string) => void;
 }
 
+/**
+ * Manages the PTY process lifecycle for a terminal instance.
+ *
+ * Creates and tracks the underlying PTY process, handling:
+ * - Initial creation once xterm has measured valid dimensions (`skipCreation`)
+ * - Session restoration for terminals persisted across hot-reloads
+ * - Deliberate recreation after worktree switches (`isRecreatingRef`)
+ * - Retry logic when dimensions are not yet ready during recreation
+ *
+ * @returns `prepareForRecreate` / `resetForRecreate` callbacks used by
+ *   `Terminal.tsx` to coordinate controlled PTY destruction and recreation.
+ */
 export function usePtyProcess({
   terminalId,
   cwd,
@@ -139,6 +151,18 @@ export function usePtyProcess({
     const terminalState = store.terminals.find((t) => t.id === terminalId);
     const alreadyRunning = terminalState?.status === 'running' || terminalState?.status === 'claude-active';
     const isRestored = terminalState?.isRestored;
+
+    // Do not create a new PTY for a terminal that has exited naturally.
+    // When the shell exits (e.g. user types "exit"), the terminal is kept in the DOM
+    // for a short grace period (pendingCleanup). During that period the component can
+    // mount/unmount rapidly — without this guard each mount would spin up a new PTY,
+    // causing an infinite mount → create PTY → unmount → mount loop.
+    // Deliberate recreation (worktree switch) sets isRecreatingRef before exiting, so
+    // it is excluded from this guard.
+    if (terminalState?.status === 'exited' && !isRecreatingRef?.current) {
+      debugLog(`[usePtyProcess] Skipping PTY creation for terminal: ${terminalId} - terminal has exited naturally (status=exited)`);
+      return;
+    }
 
     debugLog(`[usePtyProcess] Starting PTY creation for terminal: ${terminalId}`);
     debugLog(`[usePtyProcess] Terminal ${terminalId} state: isRestored=${isRestored}, status=${terminalState?.status}`);


### PR DESCRIPTION
When the shell exited naturally (e.g. typing `exit`), the terminal would enter an infinite mount/unmount cycle. TerminalGrid's pendingCleanup grace period (150ms) kept remounting the Terminal component while its status was still 'exited', causing usePtyProcess to spin up a new PTY on each mount before the previous one could complete

Guard: skip PTY creation when status === 'exited' and isRecreatingRef is not set, which is the deliberate-recreation path (worktree switch)

Adds usePtyProcess.test.ts with 6 cases covering the guard, the recreation exception, and the normal creation path

## Base Branch

- [X] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

Fixes an infinite mount/unmount loop triggered when the user types `exit` in a terminal. TerminalGrid's `pendingCleanup` grace period (150ms) kept remounting the Terminal component while `status === 'exited'`, causing `usePtyProcess` to spawn a new PTY on each mount.

The fix adds a guard that skips PTY creation when the terminal has exited naturally, while preserving the deliberate-recreation path used by worktree switching.

## Related Issue

N/A

## Type of Change

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [X] 🧪 Test

## Area

- [X] Frontend
- [ ] Backend
- [ ] Fullstack

## Commit Message Format

Follow conventional commits: `<type>: <subject>`

**Types:** feat, fix, docs, style, refactor, test, chore

**Example:** `feat: add user authentication system`

## AI Disclosure

<!-- Check the box below if any part of this PR was written with AI assistance. -->

- [ ] This PR includes AI-generated code (Claude, Codex, Copilot, etc.)

<!-- If checked, please also fill in: -->
**Tool(s) used:** <!-- e.g., Claude Code, GitHub Copilot, ChatGPT -->
**Testing level:**
- [ ] Untested -- AI output not yet verified
- [ ] Lightly tested -- ran the app / spot-checked key paths
- [ ] Fully tested -- all tests pass, manually verified behavior

- [ ] I understand what this PR does and how the underlying code works

## Checklist

- [X] I've synced with `develop` branch
- [X] I've tested my changes locally
- [X] I've followed the code principles (SOLID, DRY, KISS)
- [X] My PR is small and focused (< 400 lines ideally)

## Platform Testing Checklist

**CRITICAL:** This project supports Windows, macOS, and Linux. Platform-specific bugs are a common source of breakage.

- [ ] **Windows tested** (either on Windows or via CI)
- [X] **macOS tested** (on macOS)
- [ ] **Linux tested** (CI covers this)
- [ ] Used centralized `platform/` module instead of direct `process.platform` checks
- [X] No hardcoded paths (used `findExecutable()` or platform abstractions)

**If you only have access to one OS:** CI now tests on all platforms. Ensure all checks pass before submitting.

## CI/Testing Requirements

- [ ] All CI checks pass on **Windows**
- [X] All CI checks pass on **macOS**
- [ ] All CI checks pass on **Linux**
- [X] All existing tests pass
- [X] New features include test coverage
- [X] Bug fixes include regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary PTY process restarts when terminals are remounted after natural exit, improving stability and responsiveness.

* **Tests**
  * Added unit tests covering PTY creation across terminal lifecycle states, recreation overrides, repeated mount/unmount behavior, restore vs create branching, and skip-creation conditions.

* **Documentation**
  * Expanded docs clarifying terminal PTY lifecycle, recreation semantics, and related signals for clearer maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->