### PR TITLE
fix: update model registry to Opus 4.8 and fix re-auth spinner

### DIFF
--- a/apps/desktop/src/main/ai/config/types.ts
+++ b/apps/desktop/src/main/ai/config/types.ts
@@ -13,7 +13,7 @@ import type { SupportedProvider } from '../providers/types';
 // ============================================
 
 /** Valid model shorthands used throughout the application */
-export type ModelShorthand = 'opus' | 'opus-1m' | 'opus-4.5' | 'sonnet' | 'haiku';
+export type ModelShorthand = 'opus' | 'opus-1m' | 'opus-4.6' | 'opus-4.5' | 'sonnet' | 'haiku';
 
 /** Valid thinking levels */
 export type ThinkingLevel = 'low' | 'medium' | 'high' | 'xhigh';
@@ -35,8 +35,9 @@ export type Phase = 'spec' | 'planning' | 'coding' | 'qa';
  * - apps/desktop/src/shared/constants/models.ts MODEL_ID_MAP
  */
 export const MODEL_ID_MAP: Record<ModelShorthand, string> = {
-  opus: 'claude-opus-4-6',
-  'opus-1m': 'claude-opus-4-6',
+  opus: 'claude-opus-4-8',
+  'opus-1m': 'claude-opus-4-8',
+  'opus-4.6': 'claude-opus-4-6',
   'opus-4.5': 'claude-opus-4-5-20251101',
   sonnet: 'claude-sonnet-4-6',
   haiku: 'claude-haiku-4-5-20251001',
@@ -84,6 +85,7 @@ export const EFFORT_LEVEL_MAP: Record<EffortLevel, string> = {
  */
 export const ADAPTIVE_THINKING_MODELS: ReadonlySet<string> = new Set([
   'claude-opus-4-6',
+  'claude-opus-4-8',
 ]);
 
 // ============================================

--- a/apps/desktop/src/main/ipc-handlers/claude-code-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers/claude-code-handlers.ts
@@ -1564,7 +1564,7 @@ export function registerClaudeCodeHandlers(): void {
                 profileManager.saveProfile(profile);
                 clearKeychainCache(expandedConfigDir);
                 const usageMonitor = getUsageMonitor();
-                usageMonitor.clearProfileUsageCache(profileId);
+                usageMonitor.clearAuthFailedProfile(profileId);
                 usageMonitor.checkNow();
                 console.warn('[Claude Code] Triggered immediate usage check after re-authentication:', profileId);
 

--- a/apps/desktop/src/shared/constants/models.ts
+++ b/apps/desktop/src/shared/constants/models.ts
@@ -11,8 +11,9 @@ import type { BuiltinProvider } from '../types/provider-account';
 // ============================================
 
 export const AVAILABLE_MODELS = [
-  { value: 'opus', label: 'Claude Opus 4.6' },
-  { value: 'opus-1m', label: 'Claude Opus 4.6 (1M)' },
+  { value: 'opus', label: 'Claude Opus 4.8' },
+  { value: 'opus-1m', label: 'Claude Opus 4.8 (1M)' },
+  { value: 'opus-4.6', label: 'Claude Opus 4.6' },
   { value: 'opus-4.5', label: 'Claude Opus 4.5' },
   { value: 'sonnet', label: 'Claude Sonnet 4.6' },
   { value: 'haiku', label: 'Claude Haiku 4.5' }
@@ -38,9 +39,10 @@ export interface ModelOption {
 
 export const ALL_AVAILABLE_MODELS: ModelOption[] = [
   // Anthropic
-  { value: 'opus', label: 'Claude Opus 4.6', provider: 'anthropic', description: 'Most capable', capabilities: { thinking: true, tools: true, vision: true, contextWindow: 200000 } },
-  { value: 'opus-1m', label: 'Claude Opus 4.6 (1M)', provider: 'anthropic', description: '1M context', capabilities: { thinking: true, tools: true, vision: true, contextWindow: 1000000 } },
+  { value: 'opus', label: 'Claude Opus 4.8', provider: 'anthropic', description: 'Most capable', capabilities: { thinking: true, tools: true, vision: true, contextWindow: 200000 } },
+  { value: 'opus-1m', label: 'Claude Opus 4.8 (1M)', provider: 'anthropic', description: '1M context', capabilities: { thinking: true, tools: true, vision: true, contextWindow: 1000000 } },
   { value: 'sonnet', label: 'Claude Sonnet 4.6', provider: 'anthropic', description: 'Balanced', capabilities: { thinking: true, tools: true, vision: true, contextWindow: 200000 } },
+  { value: 'opus-4.6', label: 'Claude Opus 4.6', provider: 'anthropic', description: 'Legacy', capabilities: { thinking: true, tools: true, vision: true, contextWindow: 200000 } },
   { value: 'opus-4.5', label: 'Claude Opus 4.5', provider: 'anthropic', description: 'Legacy', capabilities: { thinking: true, tools: true, vision: true, contextWindow: 200000 } },
   { value: 'haiku', label: 'Claude Haiku 4.5', provider: 'anthropic', description: 'Fast', capabilities: { thinking: false, tools: true, vision: true, contextWindow: 200000 } },
   // OpenAI
@@ -76,8 +78,9 @@ export const ALL_AVAILABLE_MODELS: ModelOption[] = [
 // Maps model shorthand to actual Claude model IDs
 // Values must match apps/desktop/src/main/ai/config/types.ts MODEL_ID_MAP
 export const MODEL_ID_MAP: Record<string, string> = {
-  opus: 'claude-opus-4-6',
-  'opus-1m': 'claude-opus-4-6',
+  opus: 'claude-opus-4-8',
+  'opus-1m': 'claude-opus-4-8',
+  'opus-4.6': 'claude-opus-4-6',
   'opus-4.5': 'claude-opus-4-5-20251101',
   sonnet: 'claude-sonnet-4-6',
   haiku: 'claude-haiku-4-5-20251001'
@@ -407,6 +410,15 @@ export interface ProviderModelSpec {
 export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinProvider, ProviderModelSpec>>> = {
   // ── Anthropic shorthands ──────────────────────────────────────────────────
   'opus': {
+    anthropic: { modelId: 'claude-opus-4-8', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    openai: { modelId: 'gpt-5.3-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
+    google: { modelId: 'gemini-2.5-pro', reasoning: { type: 'thinking_toggle', level: 'high' } },
+    xai: { modelId: 'grok-4-0709', reasoning: { type: 'reasoning_effort', level: 'high' } },
+    mistral: { modelId: 'mistral-large-latest', reasoning: { type: 'none' } },
+    groq: { modelId: 'meta-llama/llama-4-maverick', reasoning: { type: 'none' } },
+    zai: { modelId: 'glm-5', reasoning: { type: 'none' } },
+  },
+  'opus-4.6': {
     anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
     openai: { modelId: 'gpt-5.3-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
     google: { modelId: 'gemini-2.5-pro', reasoning: { type: 'thinking_toggle', level: 'high' } },
@@ -417,7 +429,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
   },
   'glm-5': {
     zai: { modelId: 'glm-5', reasoning: { type: 'none' } },
-    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    anthropic: { modelId: 'claude-opus-4-8', reasoning: { type: 'adaptive_effort', level: 'high' } },
     openai: { modelId: 'gpt-5.3-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
   },
   'glm-4.7': {
@@ -426,7 +438,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
     openai: { modelId: 'gpt-5.2', reasoning: { type: 'reasoning_effort', level: 'medium' } },
   },
   'opus-1m': {
-    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    anthropic: { modelId: 'claude-opus-4-8', reasoning: { type: 'adaptive_effort', level: 'high' } },
     openai: { modelId: 'gpt-5.2', reasoning: { type: 'reasoning_effort', level: 'high' } },
     google: { modelId: 'gemini-2.5-pro', reasoning: { type: 'thinking_toggle', level: 'high' } },
   },
@@ -455,7 +467,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
   // ── OpenAI models ─────────────────────────────────────────────────────────
   'gpt-5.3-codex': {
     openai: { modelId: 'gpt-5.3-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
-    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    anthropic: { modelId: 'claude-opus-4-8', reasoning: { type: 'adaptive_effort', level: 'high' } },
     google: { modelId: 'gemini-2.5-pro', reasoning: { type: 'thinking_toggle', level: 'high' } },
   },
   'gpt-5.2': {
@@ -465,7 +477,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
   },
   'gpt-5.2-codex': {
     openai: { modelId: 'gpt-5.2-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
-    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    anthropic: { modelId: 'claude-opus-4-8', reasoning: { type: 'adaptive_effort', level: 'high' } },
     google: { modelId: 'gemini-2.5-pro', reasoning: { type: 'thinking_toggle', level: 'high' } },
   },
   'gpt-5.1-codex-mini': {
@@ -480,7 +492,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
   },
   'o3': {
     openai: { modelId: 'o3', reasoning: { type: 'reasoning_effort', level: 'high' } },
-    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    anthropic: { modelId: 'claude-opus-4-8', reasoning: { type: 'adaptive_effort', level: 'high' } },
     google: { modelId: 'gemini-2.5-pro', reasoning: { type: 'thinking_toggle', level: 'high' } },
   },
   'o4-mini': {
@@ -491,7 +503,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
   // ── Google models ─────────────────────────────────────────────────────────
   'gemini-2.5-pro': {
     google: { modelId: 'gemini-2.5-pro', reasoning: { type: 'thinking_toggle', level: 'high' } },
-    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    anthropic: { modelId: 'claude-opus-4-8', reasoning: { type: 'adaptive_effort', level: 'high' } },
     openai: { modelId: 'gpt-5.3-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
   },
   'gemini-2.5-flash': {
@@ -502,7 +514,7 @@ export const DEFAULT_MODEL_EQUIVALENCES: Record<string, Partial<Record<BuiltinPr
   // ── xAI models ────────────────────────────────────────────────────────────
   'grok-4-0709': {
     xai: { modelId: 'grok-4-0709', reasoning: { type: 'reasoning_effort', level: 'high' } },
-    anthropic: { modelId: 'claude-opus-4-6', reasoning: { type: 'adaptive_effort', level: 'high' } },
+    anthropic: { modelId: 'claude-opus-4-8', reasoning: { type: 'adaptive_effort', level: 'high' } },
     openai: { modelId: 'gpt-5.3-codex', reasoning: { type: 'reasoning_effort', level: 'high' } },
   },
   'grok-3-mini': {


### PR DESCRIPTION
## Summary

- **Update model registry to Claude Opus 4.8** — The `opus`/`opus-1m` shorthands were still resolving to `claude-opus-4-6`. Updated across all registry locations (`AVAILABLE_MODELS`, `ALL_AVAILABLE_MODELS`, `MODEL_ID_MAP`, `DEFAULT_MODEL_EQUIVALENCES`, and the main-process mirror in `ai/config/types.ts`) to use `claude-opus-4-8`, the current flagship. Added `opus-4.6` as a selectable legacy entry so users who need the prior model can still access it. Added `claude-opus-4-8` to `ADAPTIVE_THINKING_MODELS`.
- **Fix re-auth spinner never clearing** — After completing browser re-authentication in Settings → Accounts, the spinner would persist indefinitely. Root cause: the success handler called `clearProfileUsageCache()` which doesn't clear `needsReauthProfiles`, the Set that drives the "Re-authentication required" UI badge. Fixed by calling `clearAuthFailedProfile()` instead, which correctly clears both `authFailedProfiles` and `needsReauthProfiles`.

## Files changed

- `apps/desktop/src/shared/constants/models.ts` — model registry (UI + equivalences)
- `apps/desktop/src/main/ai/config/types.ts` — main-process mirror + adaptive thinking set
- `apps/desktop/src/main/ipc-handlers/claude-code-handlers.ts` — re-auth success handler

## Test plan

- [ ] Open Settings → Agent Profile → model selector, confirm "Claude Opus 4.8" is the default and "Claude Opus 4.6" appears as a Legacy option
- [ ] Start a task with Opus selected, verify agent logs show `claude-opus-4-8`
- [ ] Go to Settings → Accounts → Re-authenticate on an Anthropic OAuth account, complete browser login, verify spinner clears and the "Re-authentication required" badge disappears
- [ ] Run `npm run typecheck` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Claude Opus 4.6 model variant
  * Updated available Claude Opus models with Opus 4.8 as the primary option

* **Improvements**
  * Enhanced authentication profile management for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->