### PR TITLE
fix(roadmap): allow widening the feature detail panel and stop content clipping

### DIFF
--- a/apps/frontend/src/renderer/components/roadmap/FeatureDetailPanel.tsx
+++ b/apps/frontend/src/renderer/components/roadmap/FeatureDetailPanel.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
   Lightbulb,
   Users,
   CheckCircle2,
@@ -37,6 +39,7 @@ export function FeatureDetailPanel({
 }: FeatureDetailPanelProps) {
   const { t } = useTranslation('common');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const handleArchive = () => {
     onArchive?.(feature.id);
@@ -50,7 +53,11 @@ export function FeatureDetailPanel({
   };
 
   return (
-    <div className="fixed inset-y-0 right-0 w-96 bg-card border-l border-border shadow-lg flex flex-col z-50">
+    <div
+      className={`fixed inset-y-0 right-0 max-w-[90vw] bg-card border-l border-border shadow-lg flex flex-col z-50 transition-[width] duration-200 ${
+        isExpanded ? 'w-[42rem]' : 'w-96'
+      }`}
+    >
       {/* Header */}
       <div className="shrink-0 p-4 border-b border-border electron-no-drag">
         <div className="flex items-start justify-between gap-2">
@@ -73,6 +80,28 @@ export function FeatureDetailPanel({
               type="button"
               variant="ghost"
               size="icon"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsExpanded((prev) => !prev);
+              }}
+              aria-expanded={isExpanded}
+              aria-label={
+                isExpanded
+                  ? t('accessibility.collapseFeatureDetailsAriaLabel')
+                  : t('accessibility.expandFeatureDetailsAriaLabel')
+              }
+            >
+              {isExpanded ? (
+                <ChevronsRight className="h-4 w-4" />
+              ) : (
+                <ChevronsLeft className="h-4 w-4" />
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
               className="text-muted-foreground hover:text-destructive hover:bg-destructive/10"
               onClick={(e) => {
                 e.stopPropagation();
@@ -90,8 +119,10 @@ export function FeatureDetailPanel({
       </div>
 
       {/* Content */}
-      <ScrollArea className="flex-1">
-        <div className="p-4 space-y-6">
+      {/* Radix renders the viewport child as `display: table`, which lets a single long
+          token (e.g. a URL in a competitor insight) stretch every row past the panel edge. */}
+      <ScrollArea className="flex-1" viewportClassName="[&>div]:block!">
+        <div className="p-4 space-y-6 break-words">
           {/* Description */}
           <div>
             <h3 className="text-sm font-medium mb-2">Description</h3>

--- a/apps/frontend/src/shared/i18n/locales/en/common.json
+++ b/apps/frontend/src/shared/i18n/locales/en/common.json
@@ -31,6 +31,8 @@
     "deleteFeatureAriaLabel": "Delete feature",
     "archiveFeatureAriaLabel": "Archive feature",
     "closeFeatureDetailsAriaLabel": "Close feature details",
+    "expandFeatureDetailsAriaLabel": "Widen feature details panel",
+    "collapseFeatureDetailsAriaLabel": "Narrow feature details panel",
     "regenerateRoadmapAriaLabel": "Regenerate Roadmap",
     "repositoryOwnerAriaLabel": "Repository owner",
     "repositoryVisibilityAriaLabel": "Repository visibility",

--- a/apps/frontend/src/shared/i18n/locales/fr/common.json
+++ b/apps/frontend/src/shared/i18n/locales/fr/common.json
@@ -31,6 +31,8 @@
     "deleteFeatureAriaLabel": "Supprimer la fonctionnalité",
     "archiveFeatureAriaLabel": "Archiver la fonctionnalité",
     "closeFeatureDetailsAriaLabel": "Fermer les détails de la fonctionnalité",
+    "expandFeatureDetailsAriaLabel": "Élargir le panneau de détails de la fonctionnalité",
+    "collapseFeatureDetailsAriaLabel": "Réduire le panneau de détails de la fonctionnalité",
     "regenerateRoadmapAriaLabel": "Régénérer la feuille de route",
     "repositoryOwnerAriaLabel": "Propriétaire du dépôt",
     "repositoryVisibilityAriaLabel": "Visibilité du dépôt",


### PR DESCRIPTION
## Problem

Two issues with the roadmap feature detail panel (`FeatureDetailPanel.tsx`):

**1. No way to widen it.** The panel is hardcoded to `w-96`. The chevron in the header is the *close* button, so there is no expand affordance at all — on features with long acceptance criteria or competitor insights, there is no way to see more.

**2. Long content is clipped horizontally.** Radix renders the `ScrollArea` viewport child as `display: table`. A single long unbreakable token — in practice a URL inside a competitor insight — stretches that table past the panel edge, every row is then laid out at the wider width, and the overflow is cut off by the panel's `overflow-hidden`. Because only a vertical `ScrollBar` is rendered, there is no way to scroll to the hidden text. Short lines appear truncated even though they would have fit, which makes the panel look broken rather than just narrow.

Widening the panel alone does not fix (2) — the table still sizes to the longest token.

## Changes

- Add a width toggle in the panel header that switches between `w-96` and `w-[42rem]`, capped at `max-w-[90vw]` so the panel can never exceed the window, with a short `transition-[width]`.
- Force the `ScrollArea` viewport child to `block` and add `break-words` to the content wrapper, so long URLs wrap instead of pushing every row off-screen.
- Add `expandFeatureDetailsAriaLabel` / `collapseFeatureDetailsAriaLabel` to both `en` and `fr` locales; the toggle is labelled and exposes `aria-expanded`.

## Verification

- `npx tsc --noEmit` passes clean.
- `npx biome check` on the touched files reports only the three pre-existing `array-index-key` warnings already present in that file.

Not yet verified visually in a running app — worth a look at a feature whose competitor insights contain a long URL, which is the case that triggers the clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a control to expand or collapse the feature details panel for a more flexible viewing experience.

* **Accessibility**
  * Added localized accessibility labels in English and French for the panel controls.

* **Bug Fixes**
  * Improved content wrapping to prevent long text from overflowing the panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->