### PR TITLE
 fix(auth): validate token expiration and add pre-flight refresh before task start (#1603) 

### DIFF
--- a/apps/desktop/src/main/claude-profile/profile-utils.ts
+++ b/apps/desktop/src/main/claude-profile/profile-utils.ts
@@ -7,7 +7,8 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { existsSync, readFileSync, readdirSync, mkdirSync } from 'fs';
 import type { ClaudeProfile, APIProfile } from '../../shared/types';
-import { getCredentialsFromKeychain } from './credential-utils';
+import { getCredentialsFromKeychain, getFullCredentialsFromKeychain } from './credential-utils';
+import { isTokenExpiredOrNearExpiry } from './token-refresh';
 
 /**
  * Default Claude config directory
@@ -89,12 +90,19 @@ export function isProfileAuthenticated(profile: ClaudeProfile): boolean {
         const expandedConfigDir = configDir.startsWith('~')
           ? configDir.replace(/^~/, homedir())
           : configDir;
-        const platformCreds = getCredentialsFromKeychain(expandedConfigDir);
-        if (!platformCreds.token) {
+        const fullCreds = getFullCredentialsFromKeychain(expandedConfigDir);
+        if (!fullCreds.token) {
           // .claude.json exists but credential store is missing tokens - NOT authenticated
           console.warn(`[profile-utils] Profile has .claude.json but no platform credentials for: ${configDir}`);
           return false;
         }
+
+        // Check if the token is expired or near expiry (0ms threshold for strict validity)
+        if (isTokenExpiredOrNearExpiry(fullCreds.expiresAt, 0)) {
+          console.warn(`[profile-utils] Platform credential token is EXPIRED for: ${configDir}`);
+          return false;
+        }
+
         return true;
       }
     } catch (error) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -67,6 +67,7 @@ import { initSentryMain } from './sentry';
 import { preWarmToolCache } from './cli-tool-manager';
 import { initializeClaudeProfileManager, getClaudeProfileManager } from './claude-profile-manager';
 import { isProfileAuthenticated } from './claude-profile/profile-utils';
+import { ensureValidToken } from './claude-profile/token-refresh';
 import { isMacOS, isWindows } from './platform';
 import { ptyDaemonClient } from './terminal/pty-daemon-client';
 import type { AppSettings, AuthFailureInfo } from '../shared/types';
@@ -604,6 +605,22 @@ app.whenReady().then(() => {
                 console.warn('[main] Sending auth failure for migrated active profile:', activeProfile.name);
                 mainWindow?.webContents.send(IPC_CHANNELS.CLAUDE_AUTH_FAILURE, authFailureInfo);
               }, 1000);
+            });
+          }
+        }
+
+        // Proactively refresh tokens for all profiles on app startup
+        const allProfiles = profileManager.getSettings().profiles;
+        for (const profile of allProfiles) {
+          if (profile.configDir) {
+            ensureValidToken(profile.configDir).then((res) => {
+              if (res.wasRefreshed) {
+                console.warn(`[main] Startup proactive token refresh succeeded for profile: ${profile.name}`);
+              } else if (res.error) {
+                console.warn(`[main] Startup token check note for profile ${profile.name}: ${res.error}`);
+              }
+            }).catch((err) => {
+              console.warn(`[main] Startup token refresh error for profile ${profile.name}:`, err);
             });
           }
         }

--- a/apps/desktop/src/main/ipc-handlers/task/execution-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers/task/execution-handlers.ts
@@ -25,6 +25,7 @@ import { getIsolatedGitEnv, detectWorktreeBranch } from '../../utils/git-isolati
 import { cancelFallbackTimer } from '../agent-events-handlers';
 import { readSettingsFile } from '../../settings-utils';
 import type { ProviderAccount } from '../../../shared/types/provider-account';
+import { ensureValidToken } from '../../claude-profile/token-refresh';
 
 /**
  * Check if any provider account is configured (API key or OAuth).
@@ -191,7 +192,22 @@ export function registerTaskExecutionHandlers(
         return;
       }
 
-      // Check authentication - requires valid legacy profile OR provider account
+      // Attempt pre-flight token refresh if using Claude profile
+      const activeProfile = profileManager.getActiveProfile();
+      if (activeProfile?.configDir) {
+        const tokenResult = await ensureValidToken(activeProfile.configDir);
+        if (!tokenResult.token && !hasAnyProviderAccount()) {
+          console.warn('[TASK_START] Pre-flight token refresh failed or token missing:', tokenResult.error);
+          mainWindow.webContents.send(
+            IPC_CHANNELS.TASK_ERROR,
+            taskId,
+            `Authentication failed (${tokenResult.error || 'Token expired'}). Please re-authenticate in Settings > Accounts.`
+          );
+          return;
+        }
+      }
+
+      // Check authentication - requires valid profile OR provider account
       if (!profileManager.hasValidAuth() && !hasAnyProviderAccount()) {
         console.warn('[TASK_START] No valid authentication for active profile or provider accounts');
         mainWindow.webContents.send(


### PR DESCRIPTION
## Base Branch

- [x] This PR targets the `develop` branch (required for all feature/fix PRs)
- [ ] This PR targets `main` (hotfix only - maintainers)

## Description

Fixes an issue where scheduled tasks and terminal agents fail to authenticate after restarting the application following OAuth token expiration (#1603).

### Root Cause
1. `isProfileAuthenticated()` and `hasValidAuth()` previously only checked for the existence of platform credentials in the system Keychain, returning `true` even when stored OAuth tokens were expired.
2. Because background proactive token refresh stops when the desktop application closes, restarting the app after token expiration allowed scheduled tasks to execute using stale/expired tokens without prior validation or refresh.

### Key Changes
- **Token Expiration Check** (`apps/desktop/src/main/claude-profile/profile-utils.ts`): Updated `isProfileAuthenticated()` to check token expiration timestamp (`expiresAt`) using `isTokenExpiredOrNearExpiry()`. Returns `false` if credentials are present but expired.
- **Pre-Flight Refresh before Task Start** (`apps/desktop/src/main/claude-profile/execution-handlers.ts`): Added pre-flight token validation using `ensureValidToken()` inside the `TASK_START` handler before spawning agent processes. If expired, it triggers an automatic token refresh or prompts for re-authentication.
- **Proactive Startup Token Refresh** (`apps/desktop/src/main/index.ts`): Added a startup loop in `app.whenReady()` to check and proactively refresh tokens for all configured profile directories upon application boot.

## Related Issue

Closes #1603

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Test

## Area

- [ ] Frontend
- [x] Backend
- [ ] Fullstack

## Commit Message Format

`fix(auth): refresh expired tokens on startup and pre-flight task execution`

## AI Disclosure

- [ ] This PR includes AI-generated code (Claude, Codex, Copilot, etc.)

## Checklist

- [x] I've synced with `develop` branch
- [x] I've tested my changes locally
- [x] I've followed the code principles (SOLID, DRY, KISS)
- [x] My PR is small and focused (< 400 lines ideally)

## Platform Testing Checklist

- [x] **macOS tested** (either on macOS or via CI)

## Verification Steps

- [x] `npm run build` — compiled cleanly.
- [x] `npm run typecheck` — zero TypeScript errors.
- [x] `npx vitest run src/main/claude-profile/profile-utils.test.ts src/main/claude-profile/token-refresh.test.ts` — 33/33 unit tests passed.
- [x] `npm test` — 207 test files / 4,603 tests passed.
